### PR TITLE
Added example that benchmarks some integrators 

### DIFF
--- a/devtools/conda-recipe/build.sh
+++ b/devtools/conda-recipe/build.sh
@@ -3,3 +3,8 @@
 cp -r $RECIPE_DIR/../.. $SRC_DIR
 $PYTHON setup.py clean
 $PYTHON setup.py install
+
+# Copy examples
+# TODO: Have setup.py install examples instead?
+mkdir $PREFIX/share/openmmtools
+cp -r $RECIPE_DIR/../../examples $PREFIX/share/openmmtools/

--- a/examples/integrator-benchmarks/integrator-benchmarks.py
+++ b/examples/integrator-benchmarks/integrator-benchmarks.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python
+
+"""
+Benchmark various integrators provided in openmmtools on some test systems.
+
+"""
+
+from simtk import openmm
+from simtk import unit
+from simtk.openmm import app
+from openmmtools import testsystems
+from openmmtools import integrators
+import numpy as np
+import time
+
+# Test systems to benchmark
+testsystems_to_benchmark = ['LennardJonesFluid']
+
+# Integrators to benchmark
+integrators_to_benchmark = ['VerletIntegrator', 'VelocityVerletIntegrator', 'GHMCIntegrator']
+
+# Parameters
+timestep = 1.0 * unit.femtoseconds
+collision_rate = 90.0 / unit.picoseconds
+temperature = 300.0 * unit.kelvin
+ntrials = 10 # number of timing trials
+nsteps = 100 # number of steps per timing trial
+
+# Cycle through test systems.
+for testsystem_name in testsystems_to_benchmark:
+    print testsystem_name
+
+    # Create test system.
+    testsystem = getattr(testsystems, testsystem_name)()
+
+    # Minimize testsystem.
+    integrator = openmm.VerletIntegrator(timestep)
+    context = openmm.Context(testsystem.system, integrator)
+    context.setPositions(testsystem.positions)
+    openmm.LocalEnergyMinimizer.minimize(context)
+    testsystem.positions = context.getState(getPositions=True).getPositions()
+    del context, integrator
+
+    # Benchmark integrators.
+    for integrator_name in integrators_to_benchmark:
+        if integrator_name == 'VerletIntegrator':
+            integrator = openmm.VerletIntegrator(timestep)
+        elif integrator_name == 'VelocityVerletIntegrator':
+            integrator = integrators.VelocityVerletIntegrator(timestep)
+        elif integrator_name == 'GHMCIntegrator':
+            integrator = integrators.GHMCIntegrator(temperature=temperature, collision_rate=collision_rate, timestep=timestep)
+
+        # Create system.
+        context = openmm.Context(testsystem.system, integrator)
+        context.setPositions(testsystem.positions)
+
+        # Run one step.
+        integrator.step(1)
+
+        # Perform timing trials.
+        elapsed_time = np.zeros([ntrials], np.float64)
+        for trial in range(ntrials):
+            initial_time = time.time()
+            integrator.step(nsteps)
+            final_time = time.time()
+            elapsed_time[trial] = final_time - initial_time
+        print "%32s : mean %8.3f ms / std %8.3f ms" % (integrator_name, elapsed_time.mean(), elapsed_time.std())
+
+        # Clean up.
+        del context, integrator
+
+    print ""

--- a/examples/integrator-benchmarks/integrator-benchmarks.py
+++ b/examples/integrator-benchmarks/integrator-benchmarks.py
@@ -17,14 +17,14 @@ import time
 testsystems_to_benchmark = ['LennardJonesFluid']
 
 # Integrators to benchmark
-integrators_to_benchmark = ['VerletIntegrator', 'VelocityVerletIntegrator', 'GHMCIntegrator']
+integrators_to_benchmark = ['VerletIntegrator', 'VelocityVerletIntegrator', 'VVVRIntegrator', 'GHMCIntegrator']
 
 # Parameters
 timestep = 1.0 * unit.femtoseconds
-collision_rate = 90.0 / unit.picoseconds
+collision_rate = 91.0 / unit.picoseconds
 temperature = 300.0 * unit.kelvin
 ntrials = 10 # number of timing trials
-nsteps = 100 # number of steps per timing trial
+nsteps = 200 # number of steps per timing trial
 
 # Cycle through test systems.
 for testsystem_name in testsystems_to_benchmark:
@@ -47,6 +47,8 @@ for testsystem_name in testsystems_to_benchmark:
             integrator = openmm.VerletIntegrator(timestep)
         elif integrator_name == 'VelocityVerletIntegrator':
             integrator = integrators.VelocityVerletIntegrator(timestep)
+        elif integrator_name == 'VVVRIntegrator':
+            integrator = integrators.VVVRIntegrator(temperature=temperature, collision_rate=collision_rate, timestep=timestep)
         elif integrator_name == 'GHMCIntegrator':
             integrator = integrators.GHMCIntegrator(temperature=temperature, collision_rate=collision_rate, timestep=timestep)
 


### PR DESCRIPTION
Output on my `osx` laptop with `CPU` platform:
```
LennardJonesFluid
                VerletIntegrator : mean    0.033 ms / std    0.004 ms
        VelocityVerletIntegrator : mean    0.800 ms / std    0.029 ms
                  VVVRIntegrator : mean    1.807 ms / std    0.376 ms
                  GHMCIntegrator : mean    4.457 ms / std    0.723 ms
```
Thought it might be both useful and an illustrative exercise of how to use the `testsystems` and `integrators`.
