### PR TITLE
Fix for which precision models are tested when comparing platforms

### DIFF
--- a/openmmtools/scripts/test_openmm_platforms.py
+++ b/openmmtools/scripts/test_openmm_platforms.py
@@ -386,6 +386,14 @@ def main():
                         platform = openmm.Platform.getPlatform(platform_index)
                         platform_name = platform.getName()
                         
+                        # Define precision models to test.
+                        if platform_name == 'Reference':
+                            precision_models = ['double']
+                        else:
+                            precision_models = ['single']
+                            if platform.supportsDoublePrecision():
+                                precision_models.append('double')
+
                         for precision_model in precision_models:
                             # Set precision.
                             if platform_name == 'CUDA':


### PR DESCRIPTION
This fixes the list of precision models tested when comparing platforms when trying to break down by force components.