### PR TITLE
Added bitwise-reversible velocity Verlet integrator

### DIFF
--- a/openmmtools/tests/test_integrators.py
+++ b/openmmtools/tests/test_integrators.py
@@ -69,6 +69,71 @@ def check_stability(integrator, test, platform=None, nsteps=100, temperature=300
 # TESTS
 #=============================================================================================
 
+def test_bitwise_reversible_velocity_verlet():
+   """
+   Test bitwise-reversible velocity Verlet integrator.
+
+   """
+   from openmmtools import testsystems
+   from simtk.openmm import app
+
+   # Select test system.
+   testsystem_list = [
+      testsystems.LennardJonesCluster(),
+      testsystems.LennardJonesFluid(),
+      testsystems.UnconstrainedDiatomicFluid(),
+      testsystems.FlexibleWaterBox(nonbondedMethod=app.CutoffPeriodic),
+      testsystems.AlanineDipeptideImplicit(constraints=None),
+      testsystems.AlanineDipeptideExplicit(constraints=None)
+      ]
+   for testsystem in testsystem_list:
+      check_bitwise_reversible_velocity_verlet.description = "Testing bitwise reversible velocity Verlet integration with %s" % testsystem.__class__.__name__
+      yield check_bitwise_reversible_velocity_verlet, testsystem
+
+   return
+
+def check_bitwise_reversible_velocity_verlet(testsystem):
+   from simtk import openmm, unit
+   from simtk.openmm import app
+   from openmmtools import integrators, testsystems
+   import numpy as np
+
+   # Create a bitwise-reversible velocity Verlet integrator.
+   timestep = 1.0 * unit.femtoseconds
+   integrator = integrators.BitwiseReversibleVelocityVerletIntegrator(timestep)
+   nsteps = 10
+   # Demonstrate bitwise reversibility for a simple harmonic oscillator.
+   platform = openmm.Platform.getPlatformByName('Reference')
+   context = openmm.Context(testsystem.system, integrator, platform)
+   context.setPositions(testsystem.positions)
+   # Select velocity.
+   context.setVelocitiesToTemperature(300*unit.kelvin)
+   # Truncate accuracy and store initial positions.
+   integrator.truncatePrecision(context)
+   initial_positions = context.getState(getPositions=True).getPositions(asNumpy=True)
+   # Integrate forward in time.
+   integrator.step(nsteps)
+   # Negate velocity and integrate backwards
+   context.setVelocities(-context.getState(getVelocities=True).getVelocities(asNumpy=True))
+   integrator.step(nsteps)
+   # Compare positions.
+   final_positions = context.getState(getPositions=True).getPositions(asNumpy=True)
+   # Make sure differences are identically zero.
+   delta = final_positions - initial_positions
+   delta = delta / delta.unit
+   if not np.all(delta==0.0):
+      # TODO: Use bitstring representations for positions.
+      string  = "Final positions do not match initial positions after %d steps of forward/backward integration.\n\n" % nsteps
+      string += "Initial positions:\n"
+      string += str(initial_positions) + '\n'
+      string += "Final positions:\n"
+      string += str(final_positions) + '\n'
+      string += "Delta:\n"
+      string += str(final_positions - initial_positions) + '\n'
+      raise Exception(string)
+
+   return
+
 def test_stabilities_harmonic_oscillator():
    """
    Test integrators for stability over a short number of steps of a harmonic oscillator.
@@ -101,7 +166,7 @@ def test_integrator_decorators():
     integrator = integrators.HMCIntegrator(timestep=0.05 * unit.femtoseconds)
     testsystem = testsystems.IdealGas()
     nsteps = 25
-    
+
     context = openmm.Context(testsystem.system, integrator)
     context.setPositions(testsystem.positions)
     context.setVelocitiesToTemperature(300 * unit.kelvin)

--- a/openmmtools/testsystems.py
+++ b/openmmtools/testsystems.py
@@ -2508,20 +2508,24 @@ class DischargedWaterBoxHsites(WaterBox):
 
 class AlanineDipeptideVacuum(TestSystem):
     """Alanine dipeptide ff96 in vacuum.
-    
+
     Parameters
     ----------
     constraints : optional, default=simtk.openmm.app.HBonds
-    
+        Type of constraints to use.
+    removeCMMotion : bool, optional, default=False
+        If True, will remove center of mass motion periodically.
+
     Examples
     --------
-    
+
     Create alanine dipeptide with constraints on bonds to hydrogen
     >>> alanine = AlanineDipeptideVacuum()
     >>> (system, positions) = alanine.system, alanine.positions
+
     """
 
-    def __init__(self, constraints=app.HBonds, **kwargs):
+    def __init__(self, constraints=app.HBonds, removeCMMotion=False, **kwargs):
 
         TestSystem.__init__(self, **kwargs)
 
@@ -2529,7 +2533,7 @@ class AlanineDipeptideVacuum(TestSystem):
         crd_filename = get_data_filename("data/alanine-dipeptide-gbsa/alanine-dipeptide.crd")
 
         prmtop = app.AmberPrmtopFile(prmtop_filename)
-        system = prmtop.createSystem(implicitSolvent=None, constraints=constraints, nonbondedCutoff=None)
+        system = prmtop.createSystem(implicitSolvent=None, constraints=constraints, nonbondedCutoff=None, removeCMMotion=removeCMMotion)
 
         # Extract topology
         self.topology = prmtop.topology
@@ -2546,20 +2550,24 @@ class AlanineDipeptideVacuum(TestSystem):
 
 class AlanineDipeptideImplicit(TestSystem):
     """Alanine dipeptide ff96 in OBC GBSA implicit solvent.
-    
+
     Parameters
     ----------
     constraints : optional, default=simtk.openmm.app.HBonds
-    
+        Type of constraints to use.
+    removeCMMotion : bool, optional, default=False
+        If True, will remove center of mass motion periodically.
+
     Examples
     --------
-    
+
     Create alanine dipeptide with constraints on bonds to hydrogen
     >>> alanine = AlanineDipeptideImplicit()
     >>> (system, positions) = alanine.system, alanine.positions
+
     """
 
-    def __init__(self, constraints=app.HBonds, **kwargs):
+    def __init__(self, constraints=app.HBonds, removeCMMotion=False, **kwargs):
 
         TestSystem.__init__(self, **kwargs)
 
@@ -2568,7 +2576,7 @@ class AlanineDipeptideImplicit(TestSystem):
 
         # Initialize system.
         prmtop = app.AmberPrmtopFile(prmtop_filename)
-        system = prmtop.createSystem(implicitSolvent=app.OBC1, constraints=constraints, nonbondedCutoff=None)
+        system = prmtop.createSystem(implicitSolvent=app.OBC1, constraints=constraints, nonbondedCutoff=None, removeCMMotion=removeCMMotion)
 
         # Extract topology
         self.topology = prmtop.topology
@@ -2596,17 +2604,20 @@ class AlanineDipeptideExplicit(TestSystem):
     nonbondedMethod : simtk.openmm.app nonbonded method, optional, default=app.PME
        Sets the nonbonded method to use for the water box (one of app.CutoffPeriodic, app.Ewald, app.PME).
     hydrogenMass : unit, optional, default=None
-        If set, will pass along a modified hydrogen mass for OpenMM to 
+        If set, will pass along a modified hydrogen mass for OpenMM to
         use mass repartitioning.
+    removeCMMotion : bool, optional, default=False
+        If True, will remove center of mass motion periodically.
 
     Examples
     --------
 
     >>> alanine = AlanineDipeptideExplicit()
     >>> (system, positions) = alanine.system, alanine.positions
+
     """
 
-    def __init__(self, constraints=app.HBonds, rigid_water=True, nonbondedCutoff=9.0 * unit.angstroms, use_dispersion_correction=True, nonbondedMethod=app.PME, hydrogenMass=None, **kwargs):
+    def __init__(self, constraints=app.HBonds, rigid_water=True, nonbondedCutoff=9.0 * unit.angstroms, use_dispersion_correction=True, nonbondedMethod=app.PME, hydrogenMass=None, removeCMMotion=False, **kwargs):
 
         TestSystem.__init__(self, **kwargs)
 
@@ -2615,7 +2626,7 @@ class AlanineDipeptideExplicit(TestSystem):
 
         # Initialize system.
         prmtop = app.AmberPrmtopFile(prmtop_filename)
-        system = prmtop.createSystem(constraints=constraints, nonbondedMethod=nonbondedMethod, rigidWater=rigid_water, nonbondedCutoff=nonbondedCutoff, hydrogenMass=hydrogenMass)
+        system = prmtop.createSystem(constraints=constraints, nonbondedMethod=nonbondedMethod, rigidWater=rigid_water, nonbondedCutoff=nonbondedCutoff, hydrogenMass=hydrogenMass, removeCMMotion=removeCMMotion)
 
         # Extract topology
         self.topology = prmtop.topology


### PR DESCRIPTION
I've added a draft of a bitwise-reversible velocity Verlet integrator along with a battery of tests to make sure that the positions end up back where they started after 10 steps of integration, velocity reversal, and 10 steps of integration.

Using the integrator looks like this:
```
# Create a bitwise-reversible velocity Verlet integrator.
integrator = integrators.BitwiseReversibleVelocityVerletIntegrator(timestep)
# Create a context.
 context = openmm.Context(testsystem.system, integrator, platform)
# Set positions and velocities.
context.setPositions(positions) 
context.setVelocities(velocities) 
# Truncate accuracy of positions and velocities.
# This is required for bitwise-reversibility!                                                                                                                                            
integrator.truncatePrecision(context)
# Integrate dynamics in a bitwise-reversible manner.
integrator.step(nsteps)                                                                                                                                      
```

There is control over two kinds of precision:
```
# Create a bitwise-reversible velocity Verlet integrator.
integrator = integrators.BitwiseReversibleVelocityVerletIntegrator(timestep, precision_nbits=20, timestep_precision_nbits=5)
```
The quantity `precision_nbits` is the number of bits of precision retained in the quantity `0.5*dt*f/m` accumulated in the velocity of velocity Verlet.  This is done crudely via the truncation
```
floor(0.5*dt*f/m*scale + 0.5)/scale
```
where `scale = 2**precision_nbits`, which means that quantities smaller than `2**-precision_nbits` in natural OpenMM velocity units (`9.5e-7 nm/ps` in this example) are lost.  Note that this transformation does not really retain `precision_nbits` bits in the mantissa, and is more appropriate to fixed-point or integer arithmetic.

The quantity `timestep_precision_nbits` is used to round the specified timestep to retain only this number of bits in the floating-point mantissa.  If you want a timestep of 1 fs, for example, the best representation with 5 bits of mantissa precision (~0.000977 ps) will be retained.  This is done so that the position update step of velocity Verlet
```
x+dt*v
```
will not accumulate too many bits of precision during integration.

Note that this scheme is not ideal, as I fear it is possible to accumulate `timestep_precision_nbits` bits of precision in the positions and velocities each timestep.  Even with double precision accumulation, this could quickly overwhelm the number of available bits of precision.  I'm working on finding a way to rework the velocity-explicit velocity Verlet scheme to avoid this issue.

There are some limitations on what kinds of systems and platforms are supported:
* Only platforms with deterministic forces (Reference, OpenCL) are supported
* Only precision models in which positions and velocities are accumulated in double precision (`mixed` and `double`) are supported
* Constraints are not supported; handling constraints in a bitwise-reversible manner seems to be an open problem for the field