### PR TITLE
Charged LJ Fluid, Ewald tolerance, FCC grid

### DIFF
--- a/openmmtools/testsystems.py
+++ b/openmmtools/testsystems.py
@@ -212,7 +212,14 @@ def subrandom_particle_positions(nparticles, box_vectors, method='sobol'):
 
 
 def build_lattice_cell():
-    """Build a single (4 atom) unit cell of a FCC lattice."""
+    """Build a single (4 atom) unit cell of a FCC lattice, assuming a cell length
+    of 1.0.
+
+    Returns
+    -------
+    xyz : np.ndarray, shape=(4, 3), dtype=float
+        Coordinates of each particle in cell
+    """
     xyz = [[0, 0, 0], [0, 0.5, 0.5], [0.5, 0.5, 0], [0.5, 0, 0.5]]
     xyz = np.array(xyz)
 
@@ -221,6 +228,20 @@ def build_lattice_cell():
 
 def build_lattice(n_particles):
     """Build a FCC lattice with n_particles, where (n_particles / 4) must be a cubed integer.
+
+    Parameters
+    ----------
+    n_particles : int
+        How many particles.
+
+    Returns
+    -------
+    xyz : np.ndarray, shape=(n_particles, 3), dtype=float
+        Coordinates of each particle in box.  Each subcell is based on a unit-sized
+        cell output by build_lattice_cell()
+    n : int
+        The number of cells along each direction.  Because each cell has unit
+        length, `n` is also the total box length of the `n_particles` system.
 
     Notes
     -----

--- a/openmmtools/testsystems.py
+++ b/openmmtools/testsystems.py
@@ -220,7 +220,7 @@ def build_lattice_cell():
 
 
 def build_lattice(n_particles):
-    """Build a FCC lattice with n_particles, where (n / 4) must be a cubed integer.
+    """Build a FCC lattice with n_particles, where (n_particles / 4) must be a cubed integer.
 
     Notes
     -----
@@ -229,7 +229,7 @@ def build_lattice(n_particles):
     n = ((n_particles / 4.) ** (1 / 3.))
 
     if np.abs(n - np.round(n)) > 1E-10:
-        raise(ValueError("Must input 14 n^3 particles for some integer n!"))
+        raise(ValueError("Must input 4 m^3 particles for some integer m!"))
     else:
         n = int(np.round(n))
 


### PR DESCRIPTION
1.  Allow alternating plus and minus charges in LJ fluid for testing PME in a simple liquid system
2.  Allow setting of Ewald tolerance in LJ Fluid and WaterBox
3.  Allow LJ Fluid to use a FCC grid for starting coordinates, which can be useful when trying to get a liquid testsystem that doesn't require pressure equilibration.  