### PR TITLE
Disabled OpenMM platform comparison tests

### DIFF
--- a/openmmtools/tests/test_platforms.py
+++ b/openmmtools/tests/test_platforms.py
@@ -7,4 +7,4 @@ def test_openmm_platforms():
     """Testing comparison of platforms.
     """
     from openmmtools.scripts import test_openmm_platforms
-    test_openmm_platforms.main()
+    #test_openmm_platforms.main()


### PR DESCRIPTION
These are just slowing down travis and not helping us debug `openmmtools` issues, so I've disabled the nosetests (while leaving the command-line tool we can use to test OpenMM).