### PR TITLE
Added file logging output option to test-openmm-platforms

### DIFF
--- a/openmmtools/scripts/test_openmm_platforms.py
+++ b/openmmtools/scripts/test_openmm_platforms.py
@@ -132,8 +132,6 @@ def config_root_logger(verbose, log_file_path=None, mpicomm=None):
     else:
         logging.root.setLevel(terminal_handler.level)
 
-config_root_logger(True, log_file_path='test-openmm-platforms.log')
-
 #=============================================================================================
 # GLOBAL IMPORTS
 #=============================================================================================
@@ -338,15 +336,26 @@ def get_all_subclasses(cls):
 
 def main():
     import doctest
+    import argparse
 
-    debug = False # Don't display extra debug information.
+    parser = argparse.ArgumentParser(description="Check OpenMM computed energies and forces across all platforms for a suite of test systems.")
+    parser.add_argument('-o', '--outfile', dest='logfile', action='store', type=str, default=None)
+    parser.add_argument('-v', dest='verbose', action='store_true')
+    args = parser.parse_args()
+
+    verbose = args.verbose # Don't display extra debug information.
+    config_root_logger(verbose, log_file_path=args.logfile)
+
+    # Print version.
+    logger.info("OpenMM version: %s" % openmm.version.version)
+    logger.info("")
 
     # List all available platforms
-    print("Available platforms:")
+    logger.info("Available platforms:")
     for platform_index in range(openmm.Platform.getNumPlatforms()):
         platform = openmm.Platform.getPlatform(platform_index)
-        print("%5d %s" % (platform_index, platform.getName()))
-    print("")
+        logger.info("%5d %s" % (platform_index, platform.getName()))
+    logger.info("")
 
     # Test all systems on Reference platform.
     platform = openmm.Platform.getPlatformByName("Reference")
@@ -422,7 +431,7 @@ def main():
                     if abs(force_rmse) > FORCE_RMSE_TOLERANCE:
                         test_success = False
                         logger.info("%32s WARNING: Force RMS error (%.6f kcal/mol/nm) exceeds tolerance (%.6f kcal/mol/nm).  Test failed." % ("", force_rmse/force_unit, FORCE_RMSE_TOLERANCE/force_unit))
-                        if debug:
+                        if verbose:
                             for atom_index in range(natoms):
                                 for k in range(3):
                                     logger.info("%12.6f" % (reference_force[atom_index,k]/force_unit), end="")

--- a/openmmtools/scripts/test_openmm_platforms.py
+++ b/openmmtools/scripts/test_openmm_platforms.py
@@ -39,6 +39,102 @@ TODO
 from __future__ import print_function
 
 #=============================================================================================
+# ENABLE LOGGING
+#=============================================================================================
+
+import logging
+logger = logging.getLogger(__name__)
+
+def config_root_logger(verbose, log_file_path=None, mpicomm=None):
+    """Setup the the root logger's configuration.
+     The log messages are printed in the terminal and saved in the file specified
+     by log_file_path (if not None) and printed. Note that logging use sys.stdout
+     to print logging.INFO messages, and stderr for the others. The root logger's
+     configuration is inherited by the loggers created by logging.getLogger(name).
+     Different formats are used to display messages on the terminal and on the log
+     file. For example, in the log file every entry has a timestamp which does not
+     appear in the terminal. Moreover, the log file always shows the module that
+     generate the message, while in the terminal this happens only for messages
+     of level WARNING and higher.
+    Parameters
+    ----------
+    verbose : bool
+        Control the verbosity of the messages printed in the terminal. The logger
+        displays messages of level logging.INFO and higher when verbose=False.
+        Otherwise those of level logging.DEBUG and higher are printed.
+    log_file_path : str, optional, default = None
+        If not None, this is the path where all the logger's messages of level
+        logging.DEBUG or higher are saved.
+    mpicomm : mpi4py.MPI.COMM communicator, optional, default=None
+        If specified, this communicator will be used to determine node rank.
+
+    """
+
+    class TerminalFormatter(logging.Formatter):
+        """
+        Simplified format for INFO and DEBUG level log messages.
+        This allows to keep the logging.info() and debug() format separated from
+        the other levels where more information may be needed. For example, for
+        warning and error messages it is convenient to know also the module that
+        generates them.
+        """
+
+        # This is the cleanest way I found to make the code compatible with both
+        # Python 2 and Python 3
+        simple_fmt = logging.Formatter('%(message)s')
+        default_fmt = logging.Formatter('%(levelname)s - %(name)s - %(message)s')
+
+        def format(self, record):
+            if record.levelno <= logging.INFO:
+                return self.simple_fmt.format(record)
+            else:
+                return self.default_fmt.format(record)
+
+    # Check if root logger is already configured
+    n_handlers = len(logging.root.handlers)
+    if n_handlers > 0:
+        root_logger = logging.root
+        for i in xrange(n_handlers):
+            root_logger.removeHandler(root_logger.handlers[0])
+
+    # If this is a worker node, don't save any log file
+    if mpicomm:
+        rank = mpicomm.rank
+    else:
+        rank = 0
+
+    if rank != 0:
+        log_file_path = None
+
+    # Add handler for stdout and stderr messages
+    terminal_handler = logging.StreamHandler()
+    terminal_handler.setFormatter(TerminalFormatter())
+    if rank != 0:
+        terminal_handler.setLevel(logging.WARNING)
+    elif verbose:
+        terminal_handler.setLevel(logging.DEBUG)
+    else:
+        terminal_handler.setLevel(logging.INFO)
+    logging.root.addHandler(terminal_handler)
+
+    # Add file handler to root logger
+    if log_file_path is not None:
+        #file_format = '%(asctime)s - %(levelname)s - %(name)s - %(message)s'
+        file_format = '%(asctime)s: %(message)s'
+        file_handler = logging.FileHandler(log_file_path)
+        file_handler.setLevel(logging.DEBUG)
+        file_handler.setFormatter(logging.Formatter(file_format))
+        logging.root.addHandler(file_handler)
+
+    # Do not handle logging.DEBUG at all if unnecessary
+    if log_file_path is not None:
+        logging.root.setLevel(logging.DEBUG)
+    else:
+        logging.root.setLevel(terminal_handler.level)
+
+config_root_logger(True, log_file_path='test-openmm-platforms.log')
+
+#=============================================================================================
 # GLOBAL IMPORTS
 #=============================================================================================
 
@@ -261,7 +357,7 @@ def main():
     # Make a count of how often set tolerance is exceeded.
     tests_failed = 0 # number of times tolerance is exceeded
     tests_passed = 0 # number of times tolerance is not exceeded
-    print("%16s%16s %16s          %16s          %16s          %16s" % ("platform", "precision", "potential", "error", "force mag", "rms error"))
+    logger.info("%16s%16s %16s          %16s          %16s          %16s" % ("platform", "precision", "potential", "error", "force mag", "rms error"))
     reference_platform = openmm.Platform.getPlatformByName("Reference")
     testsystem_classes = get_all_subclasses(testsystems.TestSystem)
     for testsystem_class in testsystem_classes:
@@ -270,11 +366,11 @@ def main():
         try:
             testsystem = testsystem_class()
         except ImportError as e:
-            print(e)
-            print("Skipping %s due to missing dependency" % class_name)
+            logger.info(e)
+            logger.info("Skipping %s due to missing dependency" % class_name)
             continue
 
-        print("%s" % class_name)
+        logger.info("%s" % class_name)
 
         testsystem = testsystem_class()
         [system, positions] = [testsystem.system, testsystem.positions]
@@ -317,24 +413,24 @@ def main():
                     force_ms = ((platform_force / force_unit)**2).sum() / natoms * force_unit**2
                     force_rms = units.sqrt(force_ms)
 
-                    print("%16s%16s %16.6f kcal/mol %16.6f kcal/mol %16.6f kcal/mol/nm %16.6f kcal/mol/nm" % (platform_name, precision_model, platform_potential / units.kilocalories_per_mole, potential_error / units.kilocalories_per_mole, force_rms / force_unit, force_rmse / force_unit))
+                    logger.info("%16s%16s %16.6f kcal/mol %16.6f kcal/mol %16.6f kcal/mol/nm %16.6f kcal/mol/nm" % (platform_name, precision_model, platform_potential / units.kilocalories_per_mole, potential_error / units.kilocalories_per_mole, force_rms / force_unit, force_rmse / force_unit))
 
                     # Mark whether tolerance is exceeded or not.
                     if abs(potential_error) > ENERGY_TOLERANCE:
                         test_success = False
-                        print("%32s WARNING: Potential energy error (%.6f kcal/mol) exceeds tolerance (%.6f kcal/mol).  Test failed." % ("", potential_error/units.kilocalories_per_mole, ENERGY_TOLERANCE/units.kilocalories_per_mole))
+                        logger.info("%32s WARNING: Potential energy error (%.6f kcal/mol) exceeds tolerance (%.6f kcal/mol).  Test failed." % ("", potential_error/units.kilocalories_per_mole, ENERGY_TOLERANCE/units.kilocalories_per_mole))
                     if abs(force_rmse) > FORCE_RMSE_TOLERANCE:
                         test_success = False
-                        print("%32s WARNING: Force RMS error (%.6f kcal/mol/nm) exceeds tolerance (%.6f kcal/mol/nm).  Test failed." % ("", force_rmse/force_unit, FORCE_RMSE_TOLERANCE/force_unit))
+                        logger.info("%32s WARNING: Force RMS error (%.6f kcal/mol/nm) exceeds tolerance (%.6f kcal/mol/nm).  Test failed." % ("", force_rmse/force_unit, FORCE_RMSE_TOLERANCE/force_unit))
                         if debug:
                             for atom_index in range(natoms):
                                 for k in range(3):
-                                    print("%12.6f" % (reference_force[atom_index,k]/force_unit), end="")
-                                print(" : ", end="")
+                                    logger.info("%12.6f" % (reference_force[atom_index,k]/force_unit), end="")
+                                logger.info(" : ", end="")
                                 for k in range(3):
-                                    print("%12.6f" % (platform_force[atom_index,k]/force_unit), end="")
+                                    logger.info("%12.6f" % (platform_force[atom_index,k]/force_unit), end="")
             except Exception as e:
-                print(e)
+                logger.info(e)
 
         if test_success:
             tests_passed += 1
@@ -343,7 +439,7 @@ def main():
 
         if (test_success is False):
             # Write XML files of failed tests to aid in debugging.
-            print("Writing failed test system to '%s'.{system,state}.xml ..." % testsystem.name)
+            logger.info("Writing failed test system to '%s'.{system,state}.xml ..." % testsystem.name)
             [system_xml, state_xml] = testsystem.serialize()
             xml_file = open(testsystem.name + '.system.xml', 'w')
             xml_file.write(system_xml)
@@ -373,13 +469,13 @@ def main():
             ngroups = len(force_group_names)
 
             # Test by force group.
-            print("Breakdown of discrepancies by Force component:")
+            logger.info("Breakdown of discrepancies by Force component:")
             nforces = system.getNumForces()
             for force_group in range(ngroups):
                 force_name = force_group_names[force_group]
-                print(force_name)
+                logger.info(force_name)
                 [reference_potential, reference_force] = compute_potential_and_force_by_force_group(system, positions, reference_platform, force_group)
-                print("%16s%16s %16s          %16s          %16s          %16s" % ("platform", "precision", "potential", "error", "force mag", "rms error"))
+                logger.info("%16s%16s %16s          %16s          %16s          %16s" % ("platform", "precision", "potential", "error", "force mag", "rms error"))
 
                 for platform_index in range(openmm.Platform.getNumPlatforms()):
                     try:
@@ -416,15 +512,15 @@ def main():
                             force_ms = ((platform_force / force_unit)**2).sum() / natoms * force_unit**2
                             force_rms = units.sqrt(force_ms)
 
-                            print("%16s%16s %16.6f kcal/mol %16.6f kcal/mol %16.6f kcal/mol/nm %16.6f kcal/mol/nm" % (platform_name, precision_model, platform_potential / units.kilocalories_per_mole, potential_error / units.kilocalories_per_mole, force_rms / force_unit, force_rmse / force_unit))
+                            logger.info("%16s%16s %16.6f kcal/mol %16.6f kcal/mol %16.6f kcal/mol/nm %16.6f kcal/mol/nm" % (platform_name, precision_model, platform_potential / units.kilocalories_per_mole, potential_error / units.kilocalories_per_mole, force_rms / force_unit, force_rmse / force_unit))
 
                     except Exception as e:
-                        print(e)
+                        logger.info(e)
                         pass
-        print("")
+        logger.info("")
 
-    print("%d tests failed" % tests_failed)
-    print("%d tests passed" % tests_passed)
+    logger.info("%d tests failed" % tests_failed)
+    logger.info("%d tests passed" % tests_passed)
 
     if (tests_failed > 0):
         # Signal failure of test.


### PR DESCRIPTION
You can now use `test-openmm-platforms -o logfile` to output to `logfile`, along with timestamps.

The OpenMM version in use is also output at the beginning of the log.