### PR TITLE
Fixed parmed dependency for new parmed 2.0 release.

### DIFF
--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -19,6 +19,7 @@ requirements:
     - setuptools
     - openmm
     - jinja2
+    - parmed
 
   run:
     - python
@@ -28,6 +29,7 @@ requirements:
     - setuptools
     - jinja2
     - six
+    - parmed
 
 
 test:

--- a/openmmtools/testsystems.py
+++ b/openmmtools/testsystems.py
@@ -2870,9 +2870,9 @@ class DHFRExplicit(TestSystem):
         TestSystem.__init__(self, **kwargs)
 
         try:
-            from chemistry.amber import AmberParm
+            from parmed.amber import AmberParm
         except ImportError as e:
-            print("DHFR test system requires Parmed (`import chemistry`).")
+            print("DHFR test system requires Parmed (`import parmed`).")
             raise(e)
 
         prmtop_filename = get_data_filename("data/dhfr/prmtop")


### PR DESCRIPTION
This adds `parmed` to the `devtools/conda-recipe` dependencies (for testing) and fixes the imports for ParmEd 2.0.