### PR TITLE
Implement `.getTemperature` and `setTemperature` for `VVVR` integrator

### DIFF
--- a/openmmtools/integrators.py
+++ b/openmmtools/integrators.py
@@ -805,3 +805,48 @@ class VVVRIntegrator(mm.CustomIntegrator):
         if monitor_heat:
             self.addComputeSum("kinetic_energy_3", "0.5 * m * v * v")
             self.addComputeGlobal("heat", "heat + (kinetic_energy_1 - kinetic_energy_0) + (kinetic_energy_3 - kinetic_energy_2)")
+
+    def setTemperature(self, temperature=298.0 * simtk.unit.kelvin):
+        """
+        Set the current temperature of the VVVR integrator.
+
+        Parameters
+        ----------
+        temperature : numpy.unit.Quantity compatible with kelvin, default: 298.0*simtk.unit.kelvin
+           The temperature.
+
+        Examples
+        --------
+
+        Set the temperature.
+
+        >>> temperature = 298.0 * simtk.unit.kelvin
+        >>> integrator.setTemperature(temperature)
+
+        """
+
+        kT = kB * temperature
+
+        self.setGlobalVariableByName('kT', kT)
+
+    def getTemperature(self):
+        """
+        Get the current temperature of the VVVR integrator in Kelvin.
+
+        Examples
+        --------
+
+        Retrieve the temperature.
+
+        >>> print integrator.getTemperature()
+
+        """
+
+        kT = self.getGlobalVariableByName('kT')
+
+        if not isinstance(kT, units.Quantity):
+            # if we get a plain number assume that it given
+            # in kJ / mol which is one of the standard units in openmm
+            kT = float(kT) * units.kilojoule_per_mole
+
+        return kT / kB

--- a/openmmtools/tests/test_integrators.py
+++ b/openmmtools/tests/test_integrators.py
@@ -141,3 +141,16 @@ def test_vvvr_shadow_work_accumulation():
    names_of_globals = [integrator.getGlobalVariableName(i) for i in range(n_globals)]
    assert('shadow_work' not in names_of_globals)
    
+def test_vvvr_getset_temperature():
+   temperature = 298.0 * unit.kelvin
+   integrator = integrators.VVVRIntegrator(temperature, monitor_work=True)
+
+   assert(integrator.getTemperature() == temperature)
+
+   new_temperature = 500.0 * unit.kelvin
+   integrator.setTemperature(new_temperature)
+
+   assert(integrator.getTemperature() == new_temperature)
+
+   new_kT = new_temperature * kB / unit.kilojoule_per_mole
+   assert(integrator.getGlobalVariableByName('kT') == new_kT)


### PR DESCRIPTION
This implements #82 for VVVR and the corresponding getter. This is more a convenience to get the temperature that is used.
