### PR TITLE
Add multiple GB model options to some systems

### DIFF
--- a/openmmtools/tests/test_testsystems.py
+++ b/openmmtools/tests/test_testsystems.py
@@ -70,7 +70,7 @@ def check_properties(testsystem):
 def test_properties_all_testsystems():
     """Testing computation of analytic properties for all systems.
     """
-    testsystem_classes = testsystems.TestSystem.__subclasses__()
+    testsystem_classes = get_all_subclasses(testsystems.TestSystem)
     logging.info("Testing analytical property computation:")
     for testsystem_class in testsystem_classes:
         class_name = testsystem_class.__name__
@@ -105,6 +105,8 @@ fast_testsystems = [
     "CustomGBForceSystem",
     "AlchemicalLennardJonesCluster",
     "LennardJonesPair",
+    "TolueneVacuum", "TolueneImplicit", "TolueneImplicitHCT", "TolueneImplicitOBC1", "TolueneImplicitOBC2", "TolueneImplicitGBn", "TolueneImplicitGBn2",
+    "HostGuestVacuum", "HostGuestImplicit", "HostGuestImplicitHCT", 'HostGuestImplicitOBC1',
     ]
 
 def check_potential_energy(system, positions):
@@ -190,4 +192,3 @@ def test_topology_all_testsystems():
         f = partial(check_topology, testsystem.system, testsystem.topology)
         f.description = "Testing topology for testsystem %s" % class_name
         yield f
-

--- a/openmmtools/testsystems.py
+++ b/openmmtools/testsystems.py
@@ -3241,23 +3241,23 @@ class HostGuestImplicit(TestSystem):
 
         self.system, self.positions = system, positions
 
-class HostGuestImplicitHCT(TolueneImplicit):
+class HostGuestImplicitHCT(HostGuestImplicit):
     def __init__(self, **kwargs):
         HostGuestImplicit.__init__(self, implicitSolvent=app.HCT, **kwargs)
 
-class HostGuestImplicitOBC1(TolueneImplicit):
+class HostGuestImplicitOBC1(HostGuestImplicit):
     def __init__(self, **kwargs):
         HostGuestImplicit.__init__(self, implicitSolvent=app.OBC1, **kwargs)
 
-class HostGuestImplicitOBC2(TolueneImplicit):
+class HostGuestImplicitOBC2(HostGuestImplicit):
     def __init__(self, **kwargs):
         HostGuestImplicit.__init__(self, implicitSolvent=app.OBC2, **kwargs)
 
-class HostGuestImplicitGBn(TolueneImplicit):
+class HostGuestImplicitGBn(HostGuestImplicit):
     def __init__(self, **kwargs):
         HostGuestImplicit.__init__(self, implicitSolvent=app.GBn, **kwargs)
 
-class HostGuestImplicitGBn2(TolueneImplicit):
+class HostGuestImplicitGBn2(HostGuestImplicit):
     def __init__(self, **kwargs):
         HostGuestImplicit.__init__(self, implicitSolvent=app.GBn2, **kwargs)
 

--- a/openmmtools/testsystems.py
+++ b/openmmtools/testsystems.py
@@ -3415,11 +3415,16 @@ class LysozymeImplicit(TestSystem):
     Examples
     --------
 
+    Create T4 lysozyme L99A with p-xylene ligand using OBC1 GBSA.
     >>> lysozyme = LysozymeImplicit()
     >>> (system, positions) = lysozyme.system, lysozyme.positions
+
+    Create T4 lysozyme L99A with p-xylene ligand using OBC2 GBSA.
+    >>> lysozyme = LysozymeImplicit(implicitSolvent=app.OBC2)
+
     """
 
-    def __init__(self, constraints=app.HBonds, implicitSolvent=app.OBC1, **kwargs):
+    def __init__(self, **kwargs):
 
         TestSystem.__init__(self, **kwargs)
 
@@ -3428,7 +3433,13 @@ class LysozymeImplicit(TestSystem):
 
         # Initialize system.
         prmtop = app.AmberPrmtopFile(prmtop_filename)
-        system = prmtop.createSystem(implicitSolvent=app.OBC1, constraints=app.HBonds, nonbondedCutoff=None)
+
+        defaults = { 'implicitSolvent' : app.OBC1,
+                     'constraints' : app.HBonds,
+                     'nonbondedMethod' : app.NoCutoff,
+                    }
+        create_system_kwargs = handle_kwargs(prmtop.createSystem, defaults, kwargs)
+        system = prmtop.createSystem(**create_system_kwargs)
 
         # Extract topology
         self.topology = prmtop.topology
@@ -3438,7 +3449,6 @@ class LysozymeImplicit(TestSystem):
         positions = inpcrd.getPositions(asNumpy=True)
 
         self.system, self.positions = system, positions
-
 
 class SrcImplicit(TestSystem):
 


### PR DESCRIPTION
This PR extends some of the test systems to allow multiple `CustomGBForce`-based GB models supported by OpenMM's [`customgbforces.py`](https://github.com/pandegroup/openmm/blob/master/wrappers/python/simtk/openmm/app/internal/customgbforces.py) functionality to be used. This is a first step toward implementing general `CustomGBForce` support in [`alchemy`](http://github.com/choderalab/alchemy).

* `TolueneImplicit` and `HostGuestImplicit` now accept the `implicitSolvent` option
* Both classes also have variants like `TolueneImplicitHCT`, `TolueneImplicitOBC1`, etc. for all OpenMM-supported implicit solvent models.
* I've implemented the beginnings of a more flexible way of allowing parameters to be fed (as `kwargs`) to the class constructor. Only options that are present in the function signature for `AmberPrmtopFile.createSystem()` are passed on. This scheme (and some code) comes from @andrrizzi, who added this functionality to yank. Eventually, we can expand this scheme to all test systems once we refine it further, but for now, this is probably a good start.