### PR TITLE
Release 0.8.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ DOCLINES = __doc__.split("\n")
 
 ########################
 VERSION = "0.8.3"
-ISRELEASED = False
+ISRELEASED = True
 __version__ = VERSION
 ########################
 CLASSIFIERS = """\


### PR DESCRIPTION
Set `ISRELEASED=True` to release 0.8.3 for GB model support.