### PR TITLE
LRU Context cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,19 @@ This repository contains a number of additional integrators for OpenMM in `openm
 
 The `openmmtools.testsystems` module contains a large suite of test systems---including many with simple exactly-computable properties---that can be used to test molecular simulation algorithms
 
+## States
+
+The module `openmmtools.states` contains classes to maintain a consistent state of the simulation.
+- `ThermodynamicState`: Represent and manipulate the thermodynamic state of OpenMM `System`s and `Context`s.
+- `SamplerState`: Represent and cache the state of the simulation that changes when the `System` is integrated.
+- `CompoundThermodynamicState`: Extend the `ThermodynamicState` to handle parameters other than temperature and pressure through the implementations of the `IComposableState` abstract class.
+
+## Cache
+
+The module `openmmtools.cache` implements a shared LRU cache for `Context` objects that tries to minimize the number of `Context` in memory at the same time.
+- `LRUCache`: A simple LRU cache with a dictionary-like interface. It supports a maximum capacity and expiration.
+- `ContextCache`: A LRU cache for OpenMM `Context` objects.
+
 ## OpenMM testing scripts
 
 `scripts/` contains a script that may be useful in testing your OpenMM installation is installed:

--- a/openmmtools/cache.py
+++ b/openmmtools/cache.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python
+
+# =============================================================================
+# MODULE DOCSTRING
+# =============================================================================
+
+"""
+Provide cache classes to handle creation of OpenMM Context objects.
+
+"""
+
+
+# =============================================================================
+# GLOBAL IMPORTS
+# =============================================================================
+
+import collections
+
+
+# =============================================================================
+# GENERAL LRU CACHE
+# =============================================================================
+
+class LRUCache(object):
+    """A simple LRU cache."""
+
+    def __init__(self, capacity, time_to_live=None):
+        self._data = collections.OrderedDict()
+        self._capacity = capacity
+        self._ttl = time_to_live
+        self._n_access = 0
+
+    def __getitem__(self, key):
+        self._n_access += 1
+
+        # When we access data, push element at the
+        # end to make it the most recently used.
+        entry = self._data.pop(key)
+        self._data[key] = entry
+
+        # Update expiration and cleanup expired values.
+        if self._ttl is not None:
+            entry.expiration = self._n_access + self._ttl
+            self._remove_expired()
+        return entry.value
+
+    def __setitem__(self, key, value):
+        self._n_access += 1
+
+        # When we access data, push element at the
+        # end to make it the most recently used.
+        try:
+            self._data.pop(key)
+        except KeyError:
+            # Remove first item if we hit maximum capacity.
+            if len(self._data) >= self._capacity:
+                self._data.popitem(last=False)
+
+        # Determine expiration and clean up expired.
+        if self._ttl is None:
+            ttl = None
+        else:
+            ttl = self._ttl + self._n_access
+            self._remove_expired()
+        self._data[key] = _CacheEntry(value, ttl)
+
+    def __len__(self):
+        return len(self._data)
+
+    def __contains__(self, item):
+        return item in self._data
+
+    def _remove_expired(self):
+        """Remove all expired cache entries.
+
+        Assumes that entries were created with an expiration attribute.
+
+        """
+        keys_to_remove = set()
+        for key, entry in self._data.items():
+            if entry.expiration <= self._n_access:
+                keys_to_remove.add(key)
+            else:
+                # Later entries have been accessed later
+                # and they surely haven't expired yet.
+                break
+        for key in keys_to_remove:
+            del self._data[key]
+
+
+# =============================================================================
+# CACHE ENTRY (MODULE INTERNAL USAGE)
+# =============================================================================
+
+class _CacheEntry(object):
+    """A cache entry holding an optional expiration attribute."""
+    def __init__(self, value, expiration=None):
+        self.value = value
+
+        # We create the self.expiration attribute only if requested
+        # to save memory in case the cache stores a lot of entries.
+        if expiration is not None:
+            self.expiration = expiration

--- a/openmmtools/cache.py
+++ b/openmmtools/cache.py
@@ -16,6 +16,8 @@ Provide cache classes to handle creation of OpenMM Context objects.
 
 import collections
 
+from openmmtools import utils
+
 
 # =============================================================================
 # GENERAL LRU CACHE
@@ -86,6 +88,38 @@ class LRUCache(object):
                 break
         for key in keys_to_remove:
             del self._data[key]
+
+
+# =============================================================================
+# GENERAL CONTEXT CACHE
+# =============================================================================
+
+class ContextCache(object):
+    """Cache the minimum amount of incompatible Contexts."""
+
+    def __init__(self, **kwargs):
+        self._lru = LRUCache(**kwargs)
+
+    def __len__(self):
+        return len(self._lru)
+
+    # -------------------------------------------------------------------------
+    # Internal usage
+    # -------------------------------------------------------------------------
+
+    @staticmethod
+    def _generate_context_id(thermodynamic_state, integrator, platform):
+        """Return the unique string key of the context for this state."""
+        if platform is None:
+            platform = utils.get_fastest_platform()
+
+        # We take advantage of the cached _standard_system_hash property
+        # to generate a compatible hash for the thermodynamic state.
+        state_id = str(thermodynamic_state._standard_system_hash)
+        integrator_id = integrator.__class__.__name__
+        platform_id = platform.getName()
+
+        return state_id + integrator_id + platform_id
 
 
 # =============================================================================

--- a/openmmtools/cache.py
+++ b/openmmtools/cache.py
@@ -24,7 +24,7 @@ import collections
 class LRUCache(object):
     """A simple LRU cache."""
 
-    def __init__(self, capacity, time_to_live=None):
+    def __init__(self, capacity=None, time_to_live=None):
         self._data = collections.OrderedDict()
         self._capacity = capacity
         self._ttl = time_to_live
@@ -53,7 +53,7 @@ class LRUCache(object):
             self._data.pop(key)
         except KeyError:
             # Remove first item if we hit maximum capacity.
-            if len(self._data) >= self._capacity:
+            if self._capacity is not None and len(self._data) >= self._capacity:
                 self._data.popitem(last=False)
 
         # Determine expiration and clean up expired.

--- a/openmmtools/states.py
+++ b/openmmtools/states.py
@@ -962,7 +962,17 @@ class ThermodynamicState(object):
 
     @property
     def _standard_system_hash(self):
-        """Shortcut for _get_standard_system_hash(self._system)."""
+        """Shortcut for _get_standard_system_hash(self._system).
+
+        This property is marked for internal usage since we may change
+        this system in the future, but ContextCache makes use of this
+        property too.
+
+        See Also
+        --------
+        cache.ContextCache._generate_context_id
+
+        """
         if self._cached_standard_system_hash is None:
             self._cached_standard_system_hash = self._get_standard_system_hash(self._system)
         return self._cached_standard_system_hash

--- a/openmmtools/tests/test_cache.py
+++ b/openmmtools/tests/test_cache.py
@@ -41,6 +41,12 @@ def test_lru_cache_maximum_capacity():
     assert len(cache) == 2
     assert 'first' not in cache
 
+    # Test infinite capacity
+    cache = LRUCache()
+    for i in range(100):
+        cache[str(i)] = i
+    assert len(cache) == 100
+
 
 def test_lru_cache_eliminate_least_recently_used():
     """LRUCache deletes LRU element when size exceeds capacity."""

--- a/openmmtools/tests/test_cache.py
+++ b/openmmtools/tests/test_cache.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python
+
+# =============================================================================
+# MODULE DOCSTRING
+# =============================================================================
+
+"""
+Test Context cache classes in cache.py.
+
+"""
+
+# =============================================================================
+# GLOBAL IMPORTS
+# =============================================================================
+
+from openmmtools.cache import *
+
+
+# =============================================================================
+# TEST LRU CACHE
+# =============================================================================
+
+def test_lru_cache_cache_entry_unpacking():
+    """Values in LRUCache are unpacked from CacheEntry."""
+    cache = LRUCache(capacity=5)
+    cache['first'] = 1
+    assert cache['first'] == 1
+
+    # When we don't require a time-to-leave, there's
+    # no expiration attribute in the cache entry.
+    assert not hasattr(cache._data['first'], 'expiration')
+
+
+def test_lru_cache_maximum_capacity():
+    """Maximum size of LRUCache is handled correctly."""
+    cache = LRUCache(capacity=2)
+    cache['first'] = 1
+    cache['second'] = 2
+    assert len(cache) == 2
+    cache['third'] = 3
+    assert len(cache) == 2
+    assert 'first' not in cache
+
+
+def test_lru_cache_eliminate_least_recently_used():
+    """LRUCache deletes LRU element when size exceeds capacity."""
+    cache = LRUCache(capacity=3)
+    cache['first'] = 1
+    cache['second'] = 2
+
+    # We access 'first' through setting, so that it becomes the LRU.
+    cache['first'] = 1
+    cache['third'] = 3
+    cache['fourth'] = 4  # Here size exceed capacity.
+    assert len(cache) == 3
+    assert 'second' not in cache
+
+    # We access 'first' through getting now.
+    cache['first']
+    cache['fifth'] = 5  # Size exceed capacity.
+    assert len(cache) == 3
+    assert 'third' not in cache
+
+
+def test_lru_cache_access_to_live():
+    """LRUCache deletes element after specified number of accesses."""
+    def almost_expire_first():
+        cache['first'] = 1  # Update expiration.
+        for _ in range(ttl - 1):
+            cache['second']
+            assert 'first' in cache
+
+    ttl = 3
+    cache = LRUCache(capacity=2, time_to_live=ttl)
+    cache['first'] = 1
+    cache['second'] = 2  # First access.
+    assert cache._data['first'].expiration == ttl + 1
+    cache['first']  # Expiration gets updated.
+    assert cache._data['first'].expiration == ttl + 3
+
+    # At the ttl-th read access, 'first' gets deleted.
+    almost_expire_first()
+    cache['second']
+    assert 'second' in cache
+    assert 'first' not in cache
+
+    # The same happen at the ttl-th write access.
+    almost_expire_first()
+    cache['second'] = 2
+    assert 'second' in cache
+    assert 'first' not in cache
+
+    # If we touch at the last minute 'first', it remains in memory.
+    almost_expire_first()
+    cache['first']
+    assert 'second' in cache
+    assert 'first' in cache

--- a/openmmtools/tests/test_cache.py
+++ b/openmmtools/tests/test_cache.py
@@ -210,7 +210,7 @@ class TestContextCache(object):
         assert len(cache) == 6
         assert n_contexts == 8
 
-        cache = ContextCache(time_to_live=8)
+        cache = ContextCache(time_to_live=4)
         n_contexts = self.cache_incompatible_contexts(cache)
         assert len(cache) == 4
         assert n_contexts == 8

--- a/openmmtools/tests/test_cache.py
+++ b/openmmtools/tests/test_cache.py
@@ -205,12 +205,12 @@ class TestContextCache(object):
 
     def test_cache_capacity_ttl(self):
         """Check that the cache capacity and time_to_live work as expected."""
-        cache = ContextCache(capacity=6)
+        cache = ContextCache(capacity=7)
         n_contexts = self.cache_incompatible_contexts(cache)
-        assert len(cache) == 6
+        assert len(cache) == 7
         assert n_contexts == 8
 
-        cache = ContextCache(time_to_live=4)
+        cache = ContextCache(time_to_live=7)
         n_contexts = self.cache_incompatible_contexts(cache)
-        assert len(cache) == 4
+        assert len(cache) == 7
         assert n_contexts == 8

--- a/openmmtools/utils.py
+++ b/openmmtools/utils.py
@@ -16,6 +16,29 @@ General utility functions for the repo.
 
 import abc
 
+from simtk import openmm
+
+
+# =============================================================================
+# OPENMM PLATFORM UTILITIES
+# =============================================================================
+
+def get_fastest_platform():
+    """Return the fastest available platform.
+
+    This relies on the hardcoded speed values in Platform.getSpeed().
+
+    Returns
+    -------
+    platform : simtk.openmm.Platform
+       The fastest available platform.
+
+    """
+    platforms = [openmm.Platform.getPlatform(i)
+                 for i in range(openmm.Platform.getNumPlatforms())]
+    fastest_platform = max(platforms, key=lambda x: x.getSpeed())
+    return fastest_platform
+
 
 # =============================================================================
 # METACLASS UTILITIES


### PR DESCRIPTION
This PR adds a module `cache.py` implementing a LRU cache for `Context`s that will be used by the new `MCMCMove` classes. It should be ready for review if all tests pass.