### PR TITLE
Implement temperature setter and getter for integrators coupled to a heat bath

### DIFF
--- a/openmmtools/integrators.py
+++ b/openmmtools/integrators.py
@@ -93,7 +93,7 @@ class MetropolizedIntegrator(object):
         except Exception:
             pass
 
-    def addTemperatureDependentComputePerDofs(self, compute_per_dof):
+    def addComputeTemperatureDependentConstants(self, compute_per_dof):
         """Wrap the ComputePerDof into an if-block executed only when kT changes.
 
         Parameters
@@ -109,10 +109,10 @@ class MetropolizedIntegrator(object):
             self.addGlobalVariable('has_kT_changed', 1)
 
         # Create if-block that conditionally update the per-DOF variables.
-        self.beginIfBlock("has_kT_changed = 1")
+        self.beginIfBlock('has_kT_changed = 1')
         for variable, expression in compute_per_dof.items():
             self.addComputePerDof(variable, expression)
-        self.setGlobalVariableByName('has_kT_changed', 0)
+        self.addComputeGlobal('has_kT_changed', '0')
         self.endBlock()
 
 
@@ -355,7 +355,7 @@ class AndersenVelocityVerletIntegrator(mm.CustomIntegrator, MetropolizedIntegrat
         #
         # Update velocities from Maxwell-Boltzmann distribution for particles that collide.
         #
-        self.addTemperatureDependentComputePerDofs({"sigma_v": "sqrt(kT/m)"})
+        self.addComputeTemperatureDependentConstants({"sigma_v": "sqrt(kT/m)"})
         self.addComputePerDof("collision", "step(p_collision-uniform)")  # if collision has occured this timestep, 0 otherwise
         self.addComputePerDof("v", "(1-collision)*v + collision*sigma_v*gaussian")  # randomize velocities of particles that have collided
 
@@ -441,7 +441,7 @@ class MetropolisMonteCarloIntegrator(mm.CustomIntegrator, MetropolizedIntegrator
         #
         # Update velocities from Maxwell-Boltzmann distribution.
         #
-        self.addTemperatureDependentComputePerDofs({"sigma_v": "sqrt(kT/m)"})
+        self.addComputeTemperatureDependentConstants({"sigma_v": "sqrt(kT/m)"})
         self.addComputePerDof("v", "sigma_v*gaussian")
         self.addConstrainVelocities()
 
@@ -534,7 +534,7 @@ class HMCIntegrator(mm.CustomIntegrator, MetropolizedIntegrator):
         # This only needs to be done once, but it needs to be done for each degree of freedom.
         # Could move this to initialization?
         #
-        self.addTemperatureDependentComputePerDofs({"sigma": "sqrt(kT/m)"})
+        self.addComputeTemperatureDependentConstants({"sigma": "sqrt(kT/m)"})
 
         #
         # Allow Context updating here, outside of inner loop only.
@@ -852,7 +852,7 @@ class VVVRIntegrator(mm.CustomIntegrator, MetropolizedIntegrator):
         # This only needs to be done once, but it needs to be done for each degree of freedom.
         # Could move this to initialization?
         #
-        self.addTemperatureDependentComputePerDofs({"sigma": "sqrt(kT/m)"})
+        self.addComputeTemperatureDependentConstants({"sigma": "sqrt(kT/m)"})
 
         #
         # Velocity perturbation.

--- a/openmmtools/integrators.py
+++ b/openmmtools/integrators.py
@@ -35,38 +35,45 @@ this program.  If not, see <http://www.gnu.org/licenses/>.
 # GLOBAL IMPORTS
 # ============================================================================================
 
-import types
-
 import numpy
 
 import simtk.unit
 
 import simtk.unit as units
 import simtk.openmm as mm
-from .constants import kB
 
+from openmmtools.constants import kB
 from openmmtools import respa
 
 
 # ============================================================================================
-# MIXINS
+# BASE CLASSES
 # ============================================================================================
 
-class MetropolizedIntegrator(object):
+class MetropolizedIntegrator(mm.CustomIntegrator):
     """Add temperature functions to a CustomIntegrator.
 
     This class is intended to be inherited by integrators that maintain the
-    velocities stationary distribution at a given temperature. The setter
-    and getter assume the presence of a single global variable "kT" in
-    the CustomIntegrator definition.
+    stationary distribution at a given temperature. The constructor adds a
+    global variable named "kT" defining the thermal energy at the given
+    temperature. This global variable is updated through the temperature
+    setter and getter.
 
     It also provide a utility function to handle per-DOF constants that
     must be computed only when the temperature changes.
 
-    Notes
-    -----
     Notice that the CustomIntegrator internally stored by a Context object
-    will loose setter and getter. You can re-add them with add_interface().
+    will loose setter and getter and any extra function you define. The same
+    happens when you copy your integrator. You can restore the methods with
+    the static method MetropolizedIntegrator.restore_interface().
+
+    Parameters
+    ----------
+    temperature : simtk.unit.Quantity
+        The temperature of the integrator heat bath (temperature units).
+    timestep : simtk.unit.Quantity
+        The timestep to pass to the CustomIntegrator constructor (time
+        units).
 
     Examples
     --------
@@ -75,11 +82,9 @@ class MetropolizedIntegrator(object):
     "sigma" that we need to update only when the temperature is changed.
 
     >>> from simtk import openmm, unit
-    >>> class TestIntegrator(openmm.CustomIntegrator, MetropolizedIntegrator):
+    >>> class TestIntegrator(MetropolizedIntegrator):
     ...     def __init__(self, temperature=298.0*unit.kelvin, timestep=1.0*unit.femtoseconds):
-    ...         kT = kB * temperature
-    ...         super(TestIntegrator, self).__init__(timestep)
-    ...         self.addGlobalVariable("kT", kT)  # thermal energy
+    ...         super(TestIntegrator, self).__init__(temperature, timestep)
     ...         self.addPerDofVariable("sigma", 0)  # velocity standard deviation
     ...         self.addComputeTemperatureDependentConstants({"sigma": "sqrt(kT/m)"})
     ...
@@ -92,6 +97,8 @@ class MetropolizedIntegrator(object):
     >>> integrator.setTemperature(380.0*unit.kelvin)
     >>> integrator.getTemperature()
     Quantity(value=380.0, unit=kelvin)
+    >>> integrator.getGlobalVariableByName('kT')
+    3.1594995390636815
 
     Notice that a CustomIntegrator bound to a context loses any extra method.
 
@@ -104,15 +111,23 @@ class MetropolizedIntegrator(object):
     ...
     AttributeError: type object 'object' has no attribute '__getattr__'
 
-    We can restore the MetropolizedIntegrator interface with a class method
+    We can restore the original interface with a class method
 
-    >>> MetropolizedIntegrator.add_interface(integrator)
+    >>> MetropolizedIntegrator.restore_interface(integrator)
     True
     >>> integrator.getTemperature()
     Quantity(value=380.0, unit=kelvin)
     >>> integrator.setTemperature(400.0*unit.kelvin)
+    >>> isinstance(integrator, TestIntegrator)
+    True
 
     """
+    def __init__(self, temperature, *args, **kwargs):
+        super(MetropolizedIntegrator, self).__init__(*args, **kwargs)
+        self.addGlobalVariable('kT', kB * temperature)  # thermal energy
+        self.addGlobalVariable('metropolized_class_hash',
+                               self._compute_class_hash(self.__class__))
+
     def getTemperature(self):
         """Return the temperature of the heat bath.
 
@@ -149,7 +164,7 @@ class MetropolizedIntegrator(object):
 
         Parameters
         ----------
-        computer_per_dof : dict of str: str
+        compute_per_dof : dict of str: str
             A dictionary of variable_name: expression.
 
         """
@@ -166,13 +181,37 @@ class MetropolizedIntegrator(object):
         self.addComputeGlobal('has_kT_changed', '0')
         self.endBlock()
 
-    @classmethod
-    def add_interface(cls, integrator):
-        """Add the MetropolizedIntegrator interface to a CustomIntegrator.
+    @staticmethod
+    def is_metropolized(integrator):
+        """Return true if the integrator is a MetropolizedIntegrator.
 
-        The function adds the interface only to CustomIntegrators that
-        have a global variable named "kT". If this is not the case, it
-        returns False.
+        This can be useful when you only have access to the Context
+        CustomIntegrator, which loses all extra function during serialization.
+
+        Parameters
+        ----------
+        integrator : simtk.openmm.Integrator
+            The integrator to check.
+
+        Returns
+        -------
+        True if the original CustomIntegrator class inherited from
+        MetropolizedIntegrator, False otherwise.
+
+        """
+        try:
+            integrator.getGlobalVariableByName('metropolized_class_hash')
+            return True
+        except Exception:
+            return False
+
+    @classmethod
+    def restore_interface(cls, integrator):
+        """Restore the original interface to a CustomIntegrator.
+
+        The function restore the interface of the original class that
+        inherited from MetropolizedIntegrator. Return False if the interface
+        could not be restored.
 
         Parameters
         ----------
@@ -181,20 +220,33 @@ class MetropolizedIntegrator(object):
 
         Returns
         -------
-        True if the given integrator is a CustomIntegrator that defines
-        a "kT" global variables. False otherwise.
+        True if the original class interface could be restored, False otherwise.
 
         """
-        if not isinstance(integrator, mm.CustomIntegrator):
-            return False
         try:
-            integrator.getGlobalVariableByName('kT')
+            integrator_hash = integrator.getGlobalVariableByName('metropolized_class_hash')
         except Exception:
             return False
-        integrator.setTemperature = types.MethodType(cls.setTemperature, integrator)
-        integrator.getTemperature = types.MethodType(cls.getTemperature, integrator)
+
+        # Compute the hash table for all subclasses.
+        if not hasattr(cls, '_cached_hash_subclasses'):
+            cls._cached_hash_subclasses = {cls._compute_class_hash(sc): sc
+                                           for sc in cls.__subclasses__()}
+        # Retrieve integrator class.
+        try:
+            integrator_class = cls._cached_hash_subclasses[integrator_hash]
+        except KeyError:
+            return False
+
+        # Restore class interface.
+        integrator.__class__ = integrator_class
         return True
 
+    @staticmethod
+    def _compute_class_hash(integrator_class):
+        """Return a numeric hash for the integrator class."""
+        # We need to convert to float because some digits may be lost in the conversion
+        return float(hash(integrator_class.__name__))
 
 # ============================================================================================
 # INTEGRATORS
@@ -381,7 +433,7 @@ class VelocityVerletIntegrator(mm.CustomIntegrator):
         self.addConstrainVelocities()
 
 
-class AndersenVelocityVerletIntegrator(mm.CustomIntegrator, MetropolizedIntegrator):
+class AndersenVelocityVerletIntegrator(MetropolizedIntegrator):
 
     """Velocity Verlet integrator with Andersen thermostat using per-particle collisions (rather than massive collisions).
 
@@ -420,13 +472,11 @@ class AndersenVelocityVerletIntegrator(mm.CustomIntegrator, MetropolizedIntegrat
            The integration timestep.
 
         """
-        super(AndersenVelocityVerletIntegrator, self).__init__(timestep)
+        super(AndersenVelocityVerletIntegrator, self).__init__(temperature, timestep)
 
         #
         # Integrator initialization.
         #
-        kT = kB * temperature
-        self.addGlobalVariable("kT", kT)  # thermal energy
         self.addGlobalVariable("p_collision", timestep * collision_rate)  # per-particle collision probability per timestep
         self.addPerDofVariable("sigma_v", 0)  # velocity distribution stddev for Maxwell-Boltzmann (computed later)
         self.addPerDofVariable("collision", 0)  # 1 if collision has occured this timestep, 0 otherwise
@@ -451,7 +501,7 @@ class AndersenVelocityVerletIntegrator(mm.CustomIntegrator, MetropolizedIntegrat
         self.addConstrainVelocities()
 
 
-class MetropolisMonteCarloIntegrator(mm.CustomIntegrator, MetropolizedIntegrator):
+class MetropolisMonteCarloIntegrator(MetropolizedIntegrator):
 
     """
     Metropolis Monte Carlo with Gaussian displacement trials.
@@ -494,10 +544,7 @@ class MetropolisMonteCarloIntegrator(mm.CustomIntegrator, MetropolizedIntegrator
         """
 
         # Create a new Custom integrator.
-        super(MetropolisMonteCarloIntegrator, self).__init__(timestep)
-
-        # Compute the thermal energy.
-        kT = kB * temperature
+        super(MetropolisMonteCarloIntegrator, self).__init__(temperature, timestep)
 
         #
         # Integrator initialization.
@@ -505,7 +552,6 @@ class MetropolisMonteCarloIntegrator(mm.CustomIntegrator, MetropolizedIntegrator
         self.addGlobalVariable("naccept", 0)  # number accepted
         self.addGlobalVariable("ntrials", 0)  # number of Metropolization trials
 
-        self.addGlobalVariable("kT", kT)  # thermal energy
         self.addPerDofVariable("sigma_x", sigma)  # perturbation size
         self.addPerDofVariable("sigma_v", 0)  # velocity distribution stddev for Maxwell-Boltzmann (set later)
         self.addPerDofVariable("xold", 0)  # old positions
@@ -541,7 +587,7 @@ class MetropolisMonteCarloIntegrator(mm.CustomIntegrator, MetropolizedIntegrator
         self.addComputeGlobal("ntrials", "ntrials + 1")
 
 
-class HMCIntegrator(mm.CustomIntegrator, MetropolizedIntegrator):
+class HMCIntegrator(MetropolizedIntegrator):
 
     """
     Hybrid Monte Carlo (HMC) integrator.
@@ -589,10 +635,7 @@ class HMCIntegrator(mm.CustomIntegrator, MetropolizedIntegrator):
 
         """
 
-        super(HMCIntegrator, self).__init__(timestep)
-
-        # Compute the thermal energy.
-        kT = kB * temperature
+        super(HMCIntegrator, self).__init__(temperature, timestep)
 
         #
         # Integrator initialization.
@@ -600,7 +643,6 @@ class HMCIntegrator(mm.CustomIntegrator, MetropolizedIntegrator):
         self.addGlobalVariable("naccept", 0)  # number accepted
         self.addGlobalVariable("ntrials", 0)  # number of Metropolization trials
 
-        self.addGlobalVariable("kT", kT)  # thermal energy
         self.addPerDofVariable("sigma", 0)
         self.addGlobalVariable("ke", 0)  # kinetic energy
         self.addPerDofVariable("xold", 0)  # old positions
@@ -675,7 +717,7 @@ class HMCIntegrator(mm.CustomIntegrator, MetropolizedIntegrator):
         return self.n_accept / float(self.n_trials)
 
 
-class GHMCIntegrator(mm.CustomIntegrator, MetropolizedIntegrator):
+class GHMCIntegrator(MetropolizedIntegrator):
 
     """
     Generalized hybrid Monte Carlo (GHMC) integrator.
@@ -726,16 +768,14 @@ class GHMCIntegrator(mm.CustomIntegrator, MetropolizedIntegrator):
         """
 
         # Initialize constants.
-        kT = kB * temperature
         gamma = collision_rate
 
         # Create a new custom integrator.
-        super(GHMCIntegrator, self).__init__(timestep)
+        super(GHMCIntegrator, self).__init__(temperature, timestep)
 
         #
         # Integrator initialization.
         #
-        self.addGlobalVariable("kT", kT)  # thermal energy
         self.addGlobalVariable("b", numpy.exp(-gamma * timestep))  # velocity mixing parameter
         self.addPerDofVariable("sigma", 0) # velocity standard deviation
         self.addGlobalVariable("ke", 0)  # kinetic energy
@@ -830,7 +870,7 @@ class GHMCIntegrator(mm.CustomIntegrator, MetropolizedIntegrator):
         # Reset statistics to ensure 'sigma' is updated on step 0
         self.resetStatistics()
 
-class VVVRIntegrator(mm.CustomIntegrator, MetropolizedIntegrator):
+class VVVRIntegrator(MetropolizedIntegrator):
 
     """
     Create a velocity Verlet with velocity randomization (VVVR) integrator.
@@ -885,16 +925,14 @@ class VVVRIntegrator(mm.CustomIntegrator, MetropolizedIntegrator):
 
         """
         # Compute constants.
-        kT = kB * temperature
         gamma = collision_rate
 
         # Create a new custom integrator.
-        super(VVVRIntegrator, self).__init__(timestep)
+        super(VVVRIntegrator, self).__init__(temperature, timestep)
 
         #
         # Integrator initialization.
         #
-        self.addGlobalVariable("kT", kT)  # thermal energy
         self.addGlobalVariable("b", numpy.exp(-gamma * timestep))  # velocity mixing parameter
         self.addPerDofVariable("sigma", 0)
         self.addPerDofVariable("x1", 0)  # position before application of constraints

--- a/openmmtools/integrators.py
+++ b/openmmtools/integrators.py
@@ -35,6 +35,8 @@ this program.  If not, see <http://www.gnu.org/licenses/>.
 # GLOBAL IMPORTS
 # ============================================================================================
 
+import types
+
 import numpy
 
 import simtk.unit
@@ -114,6 +116,35 @@ class MetropolizedIntegrator(object):
             self.addComputePerDof(variable, expression)
         self.addComputeGlobal('has_kT_changed', '0')
         self.endBlock()
+
+    @classmethod
+    def add_interface(cls, integrator):
+        """Add the MetropolizedIntegrator interface to a CustomIntegrator.
+
+        The function adds the interface only to CustomIntegrators that
+        have a global variable named "kT". If this is not the case, it
+        returns False.
+
+        Parameters
+        ----------
+        integrator : simtk.openmm.CustomIntegrator
+            The integrator to which add setters and getters.
+
+        Returns
+        -------
+        True if the given integrator is a CustomIntegrator that defines
+        a "kT" global variables. False otherwise.
+
+        """
+        if not isinstance(integrator, mm.CustomIntegrator):
+            return False
+        try:
+            integrator.getGlobalVariableByName('kT')
+        except Exception:
+            return False
+        integrator.setTemperature = types.MethodType(cls.setTemperature, integrator)
+        integrator.getTemperature = types.MethodType(cls.getTemperature, integrator)
+        return True
 
 
 # ============================================================================================

--- a/openmmtools/tests/test_integrators.py
+++ b/openmmtools/tests/test_integrators.py
@@ -59,41 +59,41 @@ def get_all_custom_integrators(only_thermostated=False):
 
 
 def check_stability(integrator, test, platform=None, nsteps=100, temperature=300.0*unit.kelvin):
-   """
-   Check that the simulation does not explode over a number integration steps.
+    """
+    Check that the simulation does not explode over a number integration steps.
 
-   Parameters
-   ----------
-   integrator : simtk.openmm.Integrator
-      The integrator to test.
-   test : testsystem
-      The testsystem to test.
+    Parameters
+    ----------
+    integrator : simtk.openmm.Integrator
+       The integrator to test.
+    test : testsystem
+       The testsystem to test.
 
-   """
-   kT = kB * temperature
+    """
+    kT = kB * temperature
 
-   # Create Context and initialize positions.
-   if platform:
-      context = openmm.Context(test.system, integrator, platform)
-   else:
-      context = openmm.Context(test.system, integrator)
-   context.setPositions(test.positions)
-   context.setVelocitiesToTemperature(temperature) # TODO: Make deterministic.
- 
-   # Set integrator temperature
-   if hasattr(integrator, 'setTemperature'):
-      integrator.setTemperature(temperature)
+    # Create Context and initialize positions.
+    if platform:
+        context = openmm.Context(test.system, integrator, platform)
+    else:
+        context = openmm.Context(test.system, integrator)
+    context.setPositions(test.positions)
+    context.setVelocitiesToTemperature(temperature) # TODO: Make deterministic.
 
-   # Take a number of steps.
-   integrator.step(nsteps)
+    # Set integrator temperature
+    if hasattr(integrator, 'setTemperature'):
+        integrator.setTemperature(temperature)
 
-   # Check that simulation has not exploded.
-   state = context.getState(getEnergy=True)
-   potential = state.getPotentialEnergy() / kT
-   if numpy.isnan(potential):
-      raise Exception("Potential energy for integrator %s became NaN." % integrator.__doc__)
+    # Take a number of steps.
+    integrator.step(nsteps)
 
-   del context
+    # Check that simulation has not exploded.
+    state = context.getState(getEnergy=True)
+    potential = state.getPotentialEnergy() / kT
+    if numpy.isnan(potential):
+        raise Exception("Potential energy for integrator %s became NaN." % integrator.__doc__)
+
+    del context
 
 
 def check_integrator_temperature(integrator, temperature, has_changed):
@@ -142,28 +142,29 @@ def check_integrator_temperature_getter_setter(integrator):
 #=============================================================================================
 
 def test_stabilities():
-   """
-   Test integrators for stability over a short number of steps.
+    """
+    Test integrators for stability over a short number of steps.
 
-   """
-   ts = testsystems  # shortcut
-   test_cases = {'harmonic oscillator': ts.HarmonicOscillator(),
-                 'alanine dipeptide in implicit solvent': ts.AlanineDipeptideImplicit()}
-   custom_integrators = get_all_custom_integrators()
+    """
+    ts = testsystems  # shortcut
+    test_cases = {'harmonic oscillator': ts.HarmonicOscillator(),
+                  'alanine dipeptide in implicit solvent': ts.AlanineDipeptideImplicit()}
+    custom_integrators = get_all_custom_integrators()
 
-   for test_name, test in test_cases.items():
-      for integrator_name, integrator_class in custom_integrators:
-         integrator = integrator_class()
-         integrator.__doc__ = integrator_name
-         check_stability.description = ("Testing {} for stability over a short number of "
-                                        "integration steps of a {}.").format(integrator_name, test_name)
-         yield check_stability, integrator, test
+    for test_name, test in test_cases.items():
+        for integrator_name, integrator_class in custom_integrators:
+            integrator = integrator_class()
+            integrator.__doc__ = integrator_name
+            check_stability.description = ("Testing {} for stability over a short number of "
+                                           "integration steps of a {}.").format(integrator_name, test_name)
+            yield check_stability, integrator, test
+
 
 def test_integrator_decorators():
     integrator = integrators.HMCIntegrator(timestep=0.05 * unit.femtoseconds)
     testsystem = testsystems.IdealGas()
     nsteps = 25
-    
+
     context = openmm.Context(testsystem.system, integrator)
     context.setPositions(testsystem.positions)
     context.setVelocitiesToTemperature(300 * unit.kelvin)
@@ -174,34 +175,35 @@ def test_integrator_decorators():
     assert integrator.n_trials == nsteps
     assert integrator.acceptance_rate == 1.0
 
+
 def test_vvvr_shadow_work_accumulation():
-   ''' When `monitor_work==True`, assert that global `shadow_work` is initialized to zero and
-   reaches a nonzero value after integrating a few dozen steps.
-   
-   By default (`monitor_work=False`), assert that there is no global name for `shadow_work`. '''
-   
-   # test `monitor_work=True` --> accumulation of a nonzero value in global `shadow_work`
-   testsystem = testsystems.HarmonicOscillator()
-   system, topology = testsystem.system, testsystem.topology
-   temperature = 298.0 * unit.kelvin
-   integrator = integrators.VVVRIntegrator(temperature, monitor_work=True)
-   context = openmm.Context(system, integrator)
-   context.setPositions(testsystem.positions)
-   context.setVelocitiesToTemperature(temperature)
-   assert(integrator.getGlobalVariableByName('shadow_work') == 0)
-   integrator.step(25)
-   assert(integrator.getGlobalVariableByName('shadow_work') != 0)
-   
-   # test default (`monitor_work=False`, `monitor_heat=False`) --> absence of a global `shadow_work`
-   integrator = integrators.VVVRIntegrator(temperature)
-   context = openmm.Context(system, integrator)
-   context.setPositions(testsystem.positions)
-   context.setVelocitiesToTemperature(temperature)
-   integrator.step(25)
-   # get the names of all global variables
-   n_globals = integrator.getNumGlobalVariables()
-   names_of_globals = [integrator.getGlobalVariableName(i) for i in range(n_globals)]
-   assert('shadow_work' not in names_of_globals)
+    """When `monitor_work==True`, assert that global `shadow_work` is initialized to zero and
+    reaches a nonzero value after integrating a few dozen steps.
+
+    By default (`monitor_work=False`), assert that there is no global name for `shadow_work`."""
+
+    # test `monitor_work=True` --> accumulation of a nonzero value in global `shadow_work`
+    testsystem = testsystems.HarmonicOscillator()
+    system, topology = testsystem.system, testsystem.topology
+    temperature = 298.0 * unit.kelvin
+    integrator = integrators.VVVRIntegrator(temperature, monitor_work=True)
+    context = openmm.Context(system, integrator)
+    context.setPositions(testsystem.positions)
+    context.setVelocitiesToTemperature(temperature)
+    assert(integrator.getGlobalVariableByName('shadow_work') == 0)
+    integrator.step(25)
+    assert(integrator.getGlobalVariableByName('shadow_work') != 0)
+
+    # test default (`monitor_work=False`, `monitor_heat=False`) --> absence of a global `shadow_work`
+    integrator = integrators.VVVRIntegrator(temperature)
+    context = openmm.Context(system, integrator)
+    context.setPositions(testsystem.positions)
+    context.setVelocitiesToTemperature(temperature)
+    integrator.step(25)
+    # get the names of all global variables
+    n_globals = integrator.getNumGlobalVariables()
+    names_of_globals = [integrator.getGlobalVariableName(i) for i in range(n_globals)]
+    assert('shadow_work' not in names_of_globals)
 
 
 def test_temperature_getter_setter():

--- a/openmmtools/tests/test_integrators_and_testsystems.py
+++ b/openmmtools/tests/test_integrators_and_testsystems.py
@@ -14,7 +14,7 @@ Test combinations of custom integrators and testsystems to make sure there are n
 #=============================================================================================
 
 import re
-import numpy
+import inspect
 from functools import partial
 
 from simtk import unit
@@ -65,8 +65,9 @@ def test_integrators_and_testsystems():
    """
    from openmmtools import integrators, testsystems
 
-   # Create lists of integrator and testsystem names.
-   integrator_names = [ methodname for methodname in dir(integrators) if re.match('.*Integrator$', methodname) ]
+   # Get all the CustomIntegrators in the integrators module.
+   is_integrator = lambda x: inspect.isclass(x) and issubclass(x, openmm.CustomIntegrator)
+   custom_integrators = inspect.getmembers(integrators, predicate=is_integrator)
 
    def all_subclasses(cls):
        """Return list of all subclasses and subsubclasses for a given class."""
@@ -86,9 +87,9 @@ def test_integrators_and_testsystems():
           print("Skipping %s due to missing dependency" % testsystem_name)
           continue
 
-      for integrator_name in integrator_names:
+      for integrator_name, integrator_class in custom_integrators:
          # Create integrator.
-         integrator = getattr(integrators, integrator_name)()
+         integrator = integrator_class()
 
          # Create test.
          f = partial(check_combination, integrator, testsystem, platform)

--- a/openmmtools/tests/test_integrators_and_testsystems.py
+++ b/openmmtools/tests/test_integrators_and_testsystems.py
@@ -68,7 +68,7 @@ def test_integrators_and_testsystems():
    # Get all the CustomIntegrators in the integrators module.
    is_integrator = lambda x: (inspect.isclass(x) and
                               issubclass(x, openmm.CustomIntegrator) and
-                              x != integrators.MetropolizedIntegrator)
+                              x != integrators.ThermostatedIntegrator)
    custom_integrators = inspect.getmembers(integrators, predicate=is_integrator)
 
    def all_subclasses(cls):

--- a/openmmtools/tests/test_integrators_and_testsystems.py
+++ b/openmmtools/tests/test_integrators_and_testsystems.py
@@ -31,70 +31,70 @@ kB = unit.BOLTZMANN_CONSTANT_kB * unit.AVOGADRO_CONSTANT_NA
 #=============================================================================================
 
 def check_combination(integrator, test, platform=None):
-   """
-   Check combination of integrator and testsystem.
+    """
+    Check combination of integrator and testsystem.
 
-   Parameters
-   ----------
-   integrator : simtk.openmm.Integrator
-      The integrator to test.
-   test : testsystem
-      The testsystem to test.
+    Parameters
+    ----------
+    integrator : simtk.openmm.Integrator
+       The integrator to test.
+    test : testsystem
+       The testsystem to test.
 
-   """
+    """
 
-   # Create Context and initialize positions.
-   if platform:
-      context = openmm.Context(test.system, integrator, platform)
-   else:
-      context = openmm.Context(test.system, integrator)
+    # Create Context and initialize positions.
+    if platform:
+        context = openmm.Context(test.system, integrator, platform)
+    else:
+        context = openmm.Context(test.system, integrator)
 
-   # Clean up.
-   del context
+    # Clean up.
+    del context
 
-   return
+    return
+
 
 #=============================================================================================
 # TESTS
 #=============================================================================================
 
 def test_integrators_and_testsystems():
-   """
-   Test combinations of integrators and testsystems to ensure there are no global context parameters.
+    """
+    Test combinations of integrators and testsystems to ensure there are no global context parameters.
 
-   """
-   from openmmtools import integrators, testsystems
+    """
+    from openmmtools import integrators, testsystems
 
-   # Get all the CustomIntegrators in the integrators module.
-   is_integrator = lambda x: (inspect.isclass(x) and
-                              issubclass(x, openmm.CustomIntegrator) and
-                              x != integrators.ThermostatedIntegrator)
-   custom_integrators = inspect.getmembers(integrators, predicate=is_integrator)
+    # Get all the CustomIntegrators in the integrators module.
+    is_integrator = lambda x: (inspect.isclass(x) and
+                               issubclass(x, openmm.CustomIntegrator) and
+                               x != integrators.ThermostatedIntegrator)
+    custom_integrators = inspect.getmembers(integrators, predicate=is_integrator)
 
-   def all_subclasses(cls):
-       """Return list of all subclasses and subsubclasses for a given class."""
-       return cls.__subclasses__() + [s for s in cls.__subclasses__()]
-   testsystem_classes = all_subclasses(testsystems.TestSystem)
-   testsystem_names = [ cls.__name__ for cls in testsystem_classes ]
+    def all_subclasses(cls):
+        """Return list of all subclasses and subsubclasses for a given class."""
+        return cls.__subclasses__() + [s for s in cls.__subclasses__()]
+    testsystem_classes = all_subclasses(testsystems.TestSystem)
+    testsystem_names = [ cls.__name__ for cls in testsystem_classes ]
 
-   # Use Reference platform.
-   platform = openmm.Platform.getPlatformByName('Reference')
+    # Use Reference platform.
+    platform = openmm.Platform.getPlatformByName('Reference')
 
-   for testsystem_name in testsystem_names:
-      # Create testsystem.
-      try:
-          testsystem = getattr(testsystems, testsystem_name)()
-      except ImportError as e:
-          print(e)
-          print("Skipping %s due to missing dependency" % testsystem_name)
-          continue
+    for testsystem_name in testsystem_names:
+        # Create testsystem.
+        try:
+            testsystem = getattr(testsystems, testsystem_name)()
+        except ImportError as e:
+            print(e)
+            print("Skipping %s due to missing dependency" % testsystem_name)
+            continue
 
-      for integrator_name, integrator_class in custom_integrators:
-         # Create integrator.
-         integrator = integrator_class()
+        for integrator_name, integrator_class in custom_integrators:
+            # Create integrator.
+            integrator = integrator_class()
 
-         # Create test.
-         f = partial(check_combination, integrator, testsystem, platform)
-         f.description = "Checking combination of %s and %s" % (integrator_name, testsystem_name)
-         yield f
-
+            # Create test.
+            f = partial(check_combination, integrator, testsystem, platform)
+            f.description = "Checking combination of %s and %s" % (integrator_name, testsystem_name)
+            yield f

--- a/openmmtools/tests/test_integrators_and_testsystems.py
+++ b/openmmtools/tests/test_integrators_and_testsystems.py
@@ -66,7 +66,9 @@ def test_integrators_and_testsystems():
    from openmmtools import integrators, testsystems
 
    # Get all the CustomIntegrators in the integrators module.
-   is_integrator = lambda x: inspect.isclass(x) and issubclass(x, openmm.CustomIntegrator)
+   is_integrator = lambda x: (inspect.isclass(x) and
+                              issubclass(x, openmm.CustomIntegrator) and
+                              x != integrators.MetropolizedIntegrator)
    custom_integrators = inspect.getmembers(integrators, predicate=is_integrator)
 
    def all_subclasses(cls):

--- a/openmmtools/testsystems.py
+++ b/openmmtools/testsystems.py
@@ -180,7 +180,8 @@ def halton_sequence(p, n):
 
     """
     eps = np.finfo(np.double).eps
-    b = np.zeros(np.ceil(np.log(n) / np.log(p)) + 1)   # largest number of digits (adding one for halton_sequence(2,64) corner case)
+    # largest number of digits (adding one for halton_sequence(2,64) corner case)
+    b = np.zeros(int(np.ceil(np.log(n) / np.log(p))) + 1)
     u = np.empty(n)
     for j in range(n):
         i = 0


### PR DESCRIPTION
Fix #129 .

I realize now this is a more general version of the old PR #120 . @jhprinz is it ok if I close your PR?

I'll merge this first into the `mcmoves` branch because I need it there.

I still need to add a test and some examples. Here I've added a new mixin class `MetropolizedIntegrator` that
- adds setter and getter for temperature to its children.
- implements a utility function `addTemperatureDependentComputePerDofs` which wraps the kT-dependent per-DOF constants into an if-block executed only when the temperature is set.

I thought the second would be useful to automate the computation of the per-DOF velocity stddev (i.e. sigma_v) only once, but I can revert those changes if you don't like it.