### PR TITLE
Pin conda-build to 2.1.5 until they fix it

### DIFF
--- a/devtools/travis-ci/install.sh
+++ b/devtools/travis-ci/install.sh
@@ -17,7 +17,7 @@ bash $MINICONDA -b -p $MINICONDA_HOME
 export PIP_ARGS="-U"
 export PATH=$MINICONDA_HOME/bin:$PATH
 conda update --yes conda
-conda install --yes conda-build jinja2 anaconda-client pip
+conda install --yes conda-build=2.1.5 jinja2 anaconda-client pip
 
 # Restore original directory
 popd


### PR DESCRIPTION
`--yes` and `--use-local` conflict in conda-build 2.1.6, no idea when it will be fixed, so pinning version to keep production moving