### PR TITLE
Several small improvements to existing framework

### DIFF
--- a/devtools/travis-ci/install.sh
+++ b/devtools/travis-ci/install.sh
@@ -17,7 +17,7 @@ bash $MINICONDA -b -p $MINICONDA_HOME
 export PIP_ARGS="-U"
 export PATH=$MINICONDA_HOME/bin:$PATH
 conda update --yes conda
-conda install --yes conda-build jinja2 anaconda-client pip
+conda install --yes conda-build=2.1.5 jinja2 anaconda-client pip
 
 # Restore original directory
 popd

--- a/openmmtools/__init__.py
+++ b/openmmtools/__init__.py
@@ -10,4 +10,4 @@ from openmmtools import version
 __version__ = version.version
 
 # Import modules.
-from openmmtools import testsystems, integrators
+from openmmtools import testsystems, integrators, alchemy, mcmc, states, cache, utils, constants

--- a/openmmtools/cache.py
+++ b/openmmtools/cache.py
@@ -389,6 +389,21 @@ class ContextCache(object):
         thermodynamic_state.apply_to_context(context)
         return context, context_integrator
 
+    def __getstate__(self):
+        if self.platform is not None:
+            platform_serialization = self.platform.getName()
+        else:
+            platform_serialization = None
+        return dict(platform=platform_serialization, capacity=self.capacity,
+                    time_to_live=self.time_to_live)
+
+    def __setstate__(self, serialization):
+        if serialization['platform'] is None:
+            self._platform = None
+        else:
+            self._platform = openmm.Platform.getPlatformByName(serialization['platform'])
+        self._lru = LRUCache(serialization['capacity'], serialization['time_to_live'])
+
     # -------------------------------------------------------------------------
     # Internal usage
     # -------------------------------------------------------------------------
@@ -489,6 +504,19 @@ class DummyContextCache(object):
         """Create a new context in the given thermodynamic state."""
         context = thermodynamic_state.create_context(integrator, self.platform)
         return context, integrator
+
+    def __getstate__(self):
+        if self.platform is not None:
+            platform_serialization = self.platform.getName()
+        else:
+            platform_serialization = None
+        return dict(platform=platform_serialization)
+
+    def __setstate__(self, serialization):
+        if serialization['platform'] is None:
+            self.platform = None
+        else:
+            self.platform = openmm.Platform.getPlatformByName(serialization['platform'])
 
 
 # =============================================================================

--- a/openmmtools/cache.py
+++ b/openmmtools/cache.py
@@ -167,6 +167,9 @@ class LRUCache(object):
     def __contains__(self, item):
         return item in self._data
 
+    def __iter__(self):
+        return self._data.__iter__()
+
     def _remove_expired(self):
         """Remove all expired cache entries.
 
@@ -322,11 +325,15 @@ class ContextCache(object):
         """Clear up cache and remove all Contexts."""
         self._lru.empty()
 
-    def get_context(self, thermodynamic_state, integrator):
+    def get_context(self, thermodynamic_state, integrator=None):
         """Return a context in the given thermodynamic state.
 
         In general, the Context must be considered newly initialized. This
         means that positions and velocities must be set afterwards.
+
+        If the integrator is not provided, this will search the cache for
+        any Context in the given ThermodynamicState, regardless of its
+        integrator.
 
         This creates a new Context if no compatible one has been cached.
         If a compatible Context exists, the ThermodynamicState is applied
@@ -340,8 +347,8 @@ class ContextCache(object):
         ----------
         thermodynamic_state : states.ThermodynamicState
             The thermodynamic state of the system.
-        integrator : simtk.openmm.Integrator
-            The integrator for the context.
+        integrator : simtk.openmm.Integrator, optional
+            The integrator for the context (default is None).
 
         Returns
         -------
@@ -352,11 +359,28 @@ class ContextCache(object):
             a difference instance from the one passed as an argument.
 
         """
-        context_id = self._generate_context_id(thermodynamic_state, integrator)
-        try:
-            context = self._lru[context_id]
-        except KeyError:
-            context = thermodynamic_state.create_context(integrator, self._platform)
+        context = None
+
+        # If the user requires a specific integrator, look for one that matches.
+        if integrator is None:
+            thermodynamic_state_id = self._generate_state_id(thermodynamic_state)
+            matching_context_ids = [context_id for context_id in self._lru
+                                    if context_id[0] == thermodynamic_state_id]
+            if len(matching_context_ids) > 0:
+                context = self._lru[matching_context_ids[0]]  # Return first found.
+            else:
+                # We have to create a new Context. Use a likely-to-be-used Integrator.
+                integrator = integrators.GHMCIntegrator(temperature=thermodynamic_state.temperature)
+
+        if context is None:
+            # Determine the Context id matching the pair state-integrator.
+            context_id = self._generate_context_id(thermodynamic_state, integrator)
+
+            # Search for previously cached compatible Contexts or create new one.
+            try:
+                context = self._lru[context_id]
+            except KeyError:
+                context = thermodynamic_state.create_context(integrator, self._platform)
             self._lru[context_id] = context
         context_integrator = context.getIntegrator()
 
@@ -415,15 +439,27 @@ class ContextCache(object):
                 pass
         return standard_integrator
 
-    @classmethod
-    def _generate_context_id(cls, thermodynamic_state, integrator):
-        """Return the unique string key of the context for this state."""
+    @staticmethod
+    def _generate_state_id(thermodynamic_state):
+        """Return a unique key for the ThermodynamicState."""
         # We take advantage of the cached _standard_system_hash property
         # to generate a compatible hash for the thermodynamic state.
-        state_id = str(thermodynamic_state._standard_system_hash)
+        return str(thermodynamic_state._standard_system_hash)
+
+    @classmethod
+    def _generate_context_id(cls, thermodynamic_state, integrator):
+        """Return a unique key for a context in the given state.
+
+        We return a tuple containing the ThermodynamicState hash and the
+        the serialization of the Integrator. Keeping the two separated
+        makes it possible to search for Contexts in a given state regardless
+        of the integrator.
+
+        """
+        state_id = cls._generate_state_id(thermodynamic_state)
         standard_integrator = cls._standardize_integrator(integrator)
         integrator_id = openmm.XmlSerializer.serialize(standard_integrator)
-        return state_id + integrator_id
+        return state_id, integrator_id
 
 
 # =============================================================================

--- a/openmmtools/cache.py
+++ b/openmmtools/cache.py
@@ -473,7 +473,7 @@ class ContextCache(object):
         """
         state_id = cls._generate_state_id(thermodynamic_state)
         standard_integrator = cls._standardize_integrator(integrator)
-        integrator_id = openmm.XmlSerializer.serialize(standard_integrator)
+        integrator_id = openmm.XmlSerializer.serialize(standard_integrator).__hash__()
         return state_id, integrator_id
 
 

--- a/openmmtools/states.py
+++ b/openmmtools/states.py
@@ -737,32 +737,19 @@ class ThermodynamicState(object):
 
         Examples
         --------
-        Creating a context with a thermostated integrator means that
-        the context system will not have a thermostat.
+        When passing an integrator that does not expose getter and setter
+        for the temperature, the context will be created with a thermostat.
 
         >>> from simtk import openmm, unit
         >>> from openmmtools import testsystems
         >>> toluene = testsystems.TolueneVacuum()
         >>> state = ThermodynamicState(toluene.system, 300*unit.kelvin)
-        >>> platform = openmm.Platform.getPlatformByName('Reference')
         >>> integrator = openmm.VerletIntegrator(1.0*unit.femtosecond)
-        >>> context = state.create_context(integrator, platform)
+        >>> context = state.create_context(integrator)
         >>> system = context.getSystem()
         >>> [force.__class__.__name__ for force in system.getForces()
         ...  if 'Thermostat' in force.__class__.__name__]
         ['AndersenThermostat']
-
-        The thermostat is removed if we choose an integrator coupled
-        to a heat bath.
-
-        >>> del context  # Delete previous context.
-        >>> integrator = openmm.LangevinIntegrator(300*unit.kelvin, 5.0/unit.picosecond,
-        ...                                        2.0*unit.femtosecond)
-        >>> context = state.create_context(integrator, platform)
-        >>> system = context.getSystem()
-        >>> [force.__class__.__name__ for force in system.getForces()
-        ...  if 'Thermostat' in force.__class__.__name__]
-        []
 
         """
         # Check that integrator is consistent and if it is thermostated.

--- a/openmmtools/states.py
+++ b/openmmtools/states.py
@@ -744,8 +744,9 @@ class ThermodynamicState(object):
         >>> from openmmtools import testsystems
         >>> toluene = testsystems.TolueneVacuum()
         >>> state = ThermodynamicState(toluene.system, 300*unit.kelvin)
+        >>> platform = openmm.Platform.getPlatformByName('Reference')
         >>> integrator = openmm.VerletIntegrator(1.0*unit.femtosecond)
-        >>> context = state.create_context(integrator)
+        >>> context = state.create_context(integrator, platform)
         >>> system = context.getSystem()
         >>> [force.__class__.__name__ for force in system.getForces()
         ...  if 'Thermostat' in force.__class__.__name__]
@@ -754,9 +755,10 @@ class ThermodynamicState(object):
         The thermostat is removed if we choose an integrator coupled
         to a heat bath.
 
+        >>> del context  # Delete previous context.
         >>> integrator = openmm.LangevinIntegrator(300*unit.kelvin, 5.0/unit.picosecond,
         ...                                        2.0*unit.femtosecond)
-        >>> context = state.create_context(integrator)
+        >>> context = state.create_context(integrator, platform)
         >>> system = context.getSystem()
         >>> [force.__class__.__name__ for force in system.getForces()
         ...  if 'Thermostat' in force.__class__.__name__]

--- a/openmmtools/tests/test_alchemy.py
+++ b/openmmtools/tests/test_alchemy.py
@@ -1470,7 +1470,12 @@ class TestAlchemicalState(object):
         alanine_state = copy.deepcopy(self.alanine_state)
         compound_state = states.CompoundThermodynamicState(alanine_state, [alchemical_state])
 
+        # The serialized system is standard.
         serialization = utils.serialize(compound_state)
+        serialized_standard_system = serialization['thermodynamic_state']['standard_system']
+        assert serialized_standard_system.__hash__() == compound_state._standard_system_hash
+
+        # The object is deserialized correctly.
         deserialized_state = utils.deserialize(serialization)
         original_system_pickle = pickle.dumps(compound_state.system)
         original_alchemical_state_pickle = pickle.dumps(compound_state._composable_states[0])

--- a/openmmtools/tests/test_cache.py
+++ b/openmmtools/tests/test_cache.py
@@ -221,6 +221,25 @@ class TestContextCache(object):
         assert len(cache) == 4
         assert n_contexts == 4
 
+    def test_get_context_any_integrator(self):
+        """ContextCache.get_context first search the cache when integrator is unspecified."""
+        cache = ContextCache()
+        state1, state2 = self.incompatible_states[:2]
+
+        # First we create a Context in state1.
+        cache.get_context(state1, copy.deepcopy(self.verlet_2fs))
+        assert len(cache) == 1
+
+        # When we don't specify the integrator, it first looks for cached Contexts.
+        context, integrator = cache.get_context(state1)
+        assert len(cache) == 1
+        assert state1.is_context_compatible(context)
+        assert isinstance(integrator, openmm.VerletIntegrator)
+
+        # With an incompatible state, a new Context is created.
+        cache.get_context(state2)
+        assert len(cache) == 2
+
     def test_cache_capacity_ttl(self):
         """Check that the cache capacity and time_to_live work as expected."""
         cache = ContextCache(capacity=3)

--- a/openmmtools/tests/test_integrators.py
+++ b/openmmtools/tests/test_integrators.py
@@ -20,7 +20,7 @@ from simtk import unit
 from simtk import openmm
 
 from openmmtools import integrators, testsystems
-from openmmtools.integrators import ThermostatedIntegrator
+from openmmtools.integrators import RestorableIntegrator, ThermostatedIntegrator
 
 #=============================================================================================
 # CONSTANTS
@@ -50,7 +50,8 @@ def get_all_custom_integrators(only_thermostated=False):
     """
     predicate = lambda x: (inspect.isclass(x) and
                            issubclass(x, openmm.CustomIntegrator) and
-                           x != integrators.ThermostatedIntegrator)
+                           x != integrators.ThermostatedIntegrator and
+                           x != integrators.RestorableIntegrator)
     if only_thermostated:
         old_predicate = predicate  # Avoid infinite recursion.
         predicate = lambda x: old_predicate(x) and issubclass(x, integrators.ThermostatedIntegrator)
@@ -256,8 +257,8 @@ def test_thermostated_integrator_hash():
     thermostated_integrators = get_all_custom_integrators(only_thermostated=True)
     all_hashes = set()
     for integrator_name, integrator_class in thermostated_integrators:
-        hash_float = ThermostatedIntegrator._compute_class_hash(integrator_class)
+        hash_float = RestorableIntegrator._compute_class_hash(integrator_class)
         all_hashes.add(hash_float)
         integrator = integrator_class()
-        assert integrator.getGlobalVariableByName('thermostated_class_hash') == hash_float
+        assert integrator.getGlobalVariableByName('_restorable__class_hash') == hash_float
     assert len(all_hashes) == len(thermostated_integrators)

--- a/openmmtools/tests/test_integrators_and_testsystems.py
+++ b/openmmtools/tests/test_integrators_and_testsystems.py
@@ -69,7 +69,8 @@ def test_integrators_and_testsystems():
     # Get all the CustomIntegrators in the integrators module.
     is_integrator = lambda x: (inspect.isclass(x) and
                                issubclass(x, openmm.CustomIntegrator) and
-                               x != integrators.ThermostatedIntegrator)
+                               x != integrators.ThermostatedIntegrator and
+                               x != integrators.RestorableIntegrator)
     custom_integrators = inspect.getmembers(integrators, predicate=is_integrator)
 
     def all_subclasses(cls):

--- a/openmmtools/tests/test_mcmc.py
+++ b/openmmtools/tests/test_mcmc.py
@@ -33,8 +33,8 @@ analytical_testsystems = [
     ("HarmonicOscillator", testsystems.HarmonicOscillator(),
         GHMCMove(timestep=10.0*unit.femtoseconds, n_steps=100)),
     ("HarmonicOscillator", testsystems.HarmonicOscillator(),
-        WeightedMove({GHMCMove(timestep=10.0*unit.femtoseconds, n_steps=100): 0.5,
-                      HMCMove(timestep=10*unit.femtosecond, n_steps=10): 0.5})),
+        WeightedMove([(GHMCMove(timestep=10.0*unit.femtoseconds, n_steps=100), 0.5),
+                      (HMCMove(timestep=10*unit.femtosecond, n_steps=10), 0.5)])),
     ("HarmonicOscillatorArray", testsystems.HarmonicOscillatorArray(N=4),
         LangevinDynamicsMove(timestep=10.0*unit.femtoseconds, n_steps=100)),
     ("IdealGas", testsystems.IdealGas(nparticles=216),
@@ -267,7 +267,7 @@ def test_moves_serialization():
         HMCMove(context_cache=context_cache),
         MonteCarloBarostatMove(context_cache=dummy_cache),
         SequenceMove(move_list=[LangevinDynamicsMove(), GHMCMove()]),
-        WeightedMove(move_set={HMCMove(): 0.5, MonteCarloBarostatMove(): 0.5})
+        WeightedMove(move_set=[(HMCMove(), 0.5), (MonteCarloBarostatMove(), 0.5)])
     ]
     for move in test_cases:
         original_pickle = pickle.dumps(move)

--- a/openmmtools/tests/test_mcmc.py
+++ b/openmmtools/tests/test_mcmc.py
@@ -283,8 +283,8 @@ def test_move_restart():
 
     # We define a Move that counts the times it is attempted.
     class MyMove(BaseIntegratorMove):
-        def __init__(self):
-            super(MyMove, self).__init__(n_steps=1, n_restart_attempts=n_restart_attempts)
+        def __init__(self, **kwargs):
+            super(MyMove, self).__init__(n_steps=1, n_restart_attempts=n_restart_attempts, **kwargs)
             self.attempted_count = 0
 
         def _get_integrator(self, thermodynamic_state):
@@ -310,7 +310,11 @@ def test_move_restart():
     # Create and run move. An IntegratoMoveError is raised.
     sampler_state = SamplerState(positions)
     thermodynamic_state = ThermodynamicState(system, 300*unit.kelvin)
-    move = MyMove()
+
+    # We use a local context cache with Reference platform since on the
+    # CPU platform CustomIntegrators raises an error with NaN particles.
+    reference_platform = openmm.Platform.getPlatformByName('Reference')
+    move = MyMove(context_cache=cache.ContextCache(platform=reference_platform))
     with nose.tools.assert_raises(IntegratorMoveError) as cm:
         move.apply(thermodynamic_state, sampler_state)
 

--- a/openmmtools/tests/test_states.py
+++ b/openmmtools/tests/test_states.py
@@ -852,6 +852,10 @@ class TestSamplerState(object):
         assert np.allclose(sliced_sampler_state.positions[0],
                            self.alanine_explicit_positions[0])
 
+        # Modifying the sliced sampler state doesn't modify original.
+        sliced_sampler_state.positions[0][0] += 1 * unit.angstrom
+        assert sliced_sampler_state.positions[0][0] == sampler_state.positions[0][0] + 1 * unit.angstrom
+
         sliced_sampler_state = sampler_state[2:10]
         assert sliced_sampler_state.n_particles == 8
         assert len(sliced_sampler_state.velocities) == 8
@@ -864,9 +868,17 @@ class TestSamplerState(object):
         assert np.allclose(sliced_sampler_state.positions,
                            self.alanine_explicit_positions[2:10:2])
 
+        # Modifying the sliced sampler state doesn't modify original. We check
+        # this here too since the algorithm for slice objects is different.
+        sliced_sampler_state.positions[0][0] += 1 * unit.angstrom
+        assert sliced_sampler_state.positions[0][0] == sampler_state.positions[2][0] + 1 * unit.angstrom
+
         # The other attributes are copied correctly.
         assert sliced_sampler_state.volume == sampler_state.volume
-        assert sliced_sampler_state.total_energy == sampler_state.total_energy
+
+        # Energies are undefined for as subset of atoms.
+        assert sliced_sampler_state.kinetic_energy is None
+        assert sliced_sampler_state.potential_energy is None
 
     def test_cache_positions_velocities_md_units(self):
         """Test caching positions and velocities in md units."""

--- a/openmmtools/tests/test_states.py
+++ b/openmmtools/tests/test_states.py
@@ -880,41 +880,6 @@ class TestSamplerState(object):
         assert sliced_sampler_state.kinetic_energy is None
         assert sliced_sampler_state.potential_energy is None
 
-    def test_cache_positions_velocities_md_units(self):
-        """Test caching positions and velocities in md units."""
-        test_pos = self.alanine_explicit_positions.value_in_unit_system(
-            unit.md_unit_system)
-
-        # Types are correct and cached value is initialized on-demand.
-        sampler_state = SamplerState(self.alanine_explicit_positions)
-        assert sampler_state._cached_positions_in_md_units is None
-        assert np.allclose(sampler_state._positions_in_md_units, test_pos)
-        assert sampler_state._cached_positions_in_md_units is not None
-        assert sampler_state._cached_velocities_in_md_units is None
-
-        # apply_to_context() forces the unitless positions to be cached.
-        sampler_state = SamplerState(self.alanine_explicit_positions)
-        assert sampler_state._cached_positions_in_md_units is None
-        context = self.create_context(self.alanine_explicit_state)
-        sampler_state.apply_to_context(context)
-        assert sampler_state._cached_positions_in_md_units is not None
-
-        # Caches are invalidated on update_from_context()
-        assert sampler_state._cached_positions_in_md_units is not None
-        sampler_state.update_from_context(context)
-        for state in [SamplerState.from_context(context), sampler_state]:
-            assert state._cached_positions_in_md_units is None
-
-        # Cache is correctly invalidated on assignment/update.
-        sampler_state._positions_in_md_units  # Force caching
-        sampler_state._velocities_in_md_units  # Force caching
-        assert sampler_state._cached_positions_in_md_units is not None
-        sampler_state.positions = self.alanine_explicit_positions
-        assert sampler_state._cached_positions_in_md_units is None
-        assert sampler_state._cached_velocities_in_md_units is not None
-        sampler_state.velocities = sampler_state.velocities
-        assert sampler_state._cached_velocities_in_md_units is None
-
 
 # =============================================================================
 # TEST COMPOUND STATE

--- a/openmmtools/utils.py
+++ b/openmmtools/utils.py
@@ -96,12 +96,12 @@ class Timer(object):
     >>> timer.start('my benchmark')
     >>> for i in range(10):
     ...     pass
-    >>> timer.stop('my benchmark')
+    >>> elapsed_time = timer.stop('my benchmark')
     >>> timer.start('second benchmark')
     >>> for i in range(10):
     ...     for j in range(10):
     ...         pass
-    >>> timer.start('second benchmark')
+    >>> elsapsed_time = timer.stop('second benchmark')
     >>> timer.report_timing()
 
     """


### PR DESCRIPTION
Ready for review. Several bug fixes and improvements. Here is a list of the main changes:
- `ContextCache` can now be used to retrieve a context in a thermodynamic state with any integrator, which is useful when we only have to compute energies.
- Added an `IntegratorMove` class to easily instantiate an `MCMCMove` object from an OpenMM `Integrator`.
- Implemented `__getstate__` and `__setstate__` methods for all states and MCMC moves for future-compatible serialization.
- Split the restorable interface features for `CustomIntegrator`s from `ThermostatedIntegrator` to a new base class `RestorableIntegrator`
- Any MCMCMove inheriting from `BaseIntegratorMove` now checks for NaNs energy after `apply()`, and optionally restart the move for a configurable number of times. An `IntegratorMoveError` that can serialize the `Context` is raised if it cannot recover.
- Added new MCMCMoves `MetropolizedMove` (partially abstract), `MCRotationMove` and `MCDisplacementMove` which were previously implemented as part of `ModifiedHamiltonianExchange` in `yank/sampling.py`.