### PR TITLE
Fix travis segfault

### DIFF
--- a/openmmtools/states.py
+++ b/openmmtools/states.py
@@ -20,7 +20,7 @@ import copy
 import numpy as np
 from simtk import openmm, unit
 
-from openmmtools import utils, integrators
+from openmmtools import utils, integrators, constants
 
 
 # =============================================================================
@@ -441,6 +441,14 @@ class ThermodynamicState(object):
             self._set_barostat_temperature(barostat, value)
 
     @property
+    def kT(self):
+        return constants.kB * self.temperature
+
+    @property
+    def beta(self):
+        return 1.0 / self.kT
+
+    @property
     def pressure(self):
         """Constant pressure of the thermodynamic state.
 
@@ -750,6 +758,18 @@ class ThermodynamicState(object):
         >>> [force.__class__.__name__ for force in system.getForces()
         ...  if 'Thermostat' in force.__class__.__name__]
         ['AndersenThermostat']
+
+        The thermostat is removed if we choose an integrator coupled
+        to a heat bath.
+
+        >>> del context  # Delete previous context to free memory.
+        >>> integrator = openmm.LangevinIntegrator(300*unit.kelvin, 5.0/unit.picosecond,
+        ...                                        2.0*unit.femtosecond)
+        >>> context = state.create_context(integrator)
+        >>> system = context.getSystem()
+        >>> [force.__class__.__name__ for force in system.getForces()
+        ...  if 'Thermostat' in force.__class__.__name__]
+        []
 
         """
         # Check that integrator is consistent and if it is thermostated.

--- a/openmmtools/tests/test_states.py
+++ b/openmmtools/tests/test_states.py
@@ -577,7 +577,7 @@ class TestThermodynamicState(object):
                 assert state._find_thermostat(context.getSystem()) is not None
 
             # Get rid of old context. This test can create a lot of them.
-            del context
+            del context, integrator
 
     def test_method_is_compatible(self):
         """ThermodynamicState context and state compatibility methods."""

--- a/openmmtools/tests/test_states.py
+++ b/openmmtools/tests/test_states.py
@@ -576,6 +576,9 @@ class TestThermodynamicState(object):
                 assert toluene_str == context.getSystem().__getstate__()
                 assert state._find_thermostat(context.getSystem()) is not None
 
+            # Get rid of old context. This test can create a lot of them.
+            del context
+
     def test_method_is_compatible(self):
         """ThermodynamicState context and state compatibility methods."""
         def check_compatibility(state1, state2, is_compatible):


### PR DESCRIPTION
Fix #138 .

This seems to have worked. In the test, I was creating a bunch of `Context`s on different platforms and probably the garbage collector was not quick enough to delete them without an explicit `del` statement.

I'll rerun the tests 2-3 times before merging just to be sure.

Thanks to @Lnaden for directing my attention to the faulty test.