### PR TITLE
Track external protocol work in LangevinSplittingIntegrator

### DIFF
--- a/openmmtools/integrators.py
+++ b/openmmtools/integrators.py
@@ -1128,7 +1128,8 @@ class VVVRIntegrator(LangevinSplittingIntegrator):
                  timestep=1.0 * simtk.unit.femtoseconds,
                  constraint_tolerance=1e-8,
                  measure_shadow_work=False,
-                 measure_heat=True
+                 measure_heat=True,
+                 measure_protocol_work=False,
                  ):
         """Create a velocity verlet with velocity randomization (VVVR) integrator.
         -----
@@ -1157,7 +1158,8 @@ class VVVRIntegrator(LangevinSplittingIntegrator):
                                              timestep=timestep,
                                              constraint_tolerance=constraint_tolerance,
                                              measure_shadow_work=measure_shadow_work,
-                                             measure_heat=measure_heat
+                                             measure_heat=measure_heat,
+                                             measure_protocol_work=measure_protocol_work
                                              )
 
 class BAOABIntegrator(LangevinSplittingIntegrator):

--- a/openmmtools/integrators.py
+++ b/openmmtools/integrators.py
@@ -1098,8 +1098,11 @@ class LangevinSplittingIntegrator(ThermostatedIntegrator):
 
         if measure_shadow_work:
             self.addGlobalVariable("old_pe", 0)
-            self.addGlobalVariable("new_pe", 0)
+
             self.addGlobalVariable("shadow_work", 0)
+
+        if measure_protocol_work or measure_shadow_work:
+            self.addGlobalVariable("new_pe", 0)
 
         if measure_protocol_work:
             self.addGlobalVariable("protocol_work", 0)
@@ -1117,6 +1120,9 @@ class LangevinSplittingIntegrator(ThermostatedIntegrator):
             self.addComputeGlobal("protocol_work", "protocol_work + (perturbed_pe - new_pe)")
         for i, step in enumerate(splitting):
             substep_function(step)
+        if measure_protocol_work:
+            self.addComputeGlobal("new_pe", "energy")
+
 
 
 class VVVRIntegrator(LangevinSplittingIntegrator):

--- a/openmmtools/integrators.py
+++ b/openmmtools/integrators.py
@@ -1098,11 +1098,8 @@ class LangevinSplittingIntegrator(ThermostatedIntegrator):
 
         if measure_shadow_work:
             self.addGlobalVariable("old_pe", 0)
-
-            self.addGlobalVariable("shadow_work", 0)
-
-        if measure_protocol_work or measure_shadow_work:
             self.addGlobalVariable("new_pe", 0)
+            self.addGlobalVariable("shadow_work", 0)
 
         if measure_protocol_work:
             self.addGlobalVariable("protocol_work", 0)
@@ -1120,9 +1117,6 @@ class LangevinSplittingIntegrator(ThermostatedIntegrator):
             self.addComputeGlobal("protocol_work", "protocol_work + (perturbed_pe - new_pe)")
         for i, step in enumerate(splitting):
             substep_function(step)
-        if measure_protocol_work:
-            self.addComputeGlobal("new_pe", "energy")
-
 
 
 class VVVRIntegrator(LangevinSplittingIntegrator):

--- a/openmmtools/tests/test_integrators.py
+++ b/openmmtools/tests/test_integrators.py
@@ -222,10 +222,15 @@ def test_vvvr_protocol_work_accumulation():
     assert(integrator.getGlobalVariableByName('protocol_work') == 0), "Protocol work should be 0 initially"
     integrator.step(25)
     assert(integrator.getGlobalVariableByName('protocol_work') == 0), "There should be no protocol work."
+
+    pe_1 = context.getState(getEnergy=True).getPotentialEnergy()
     perturbed_K=99.0 * unit.kilocalories_per_mole / unit.angstroms**2
     context.setParameter('testsystems_HarmonicOscillator_K', perturbed_K)
+    pe_2 = context.getState(getEnergy=True).getPotentialEnergy()
     integrator.step(1)
     assert (integrator.getGlobalVariableByName('protocol_work') != 0), "There should be protocol work after perturbing."
+    assert (integrator.getGlobalVariableByName('protocol_work') == pe_2 - pe_1), \
+        "The potential energy difference should be equal to protocol work."
 
     # test default (`measure_protocol_work=False`, `measure_heat=True`) --> absence of a global `protocol_work`
     integrator = integrators.VVVRIntegrator(temperature)

--- a/openmmtools/tests/test_integrators.py
+++ b/openmmtools/tests/test_integrators.py
@@ -206,6 +206,39 @@ def test_vvvr_shadow_work_accumulation():
     assert('shadow_work' not in names_of_globals)
 
 
+def test_vvvr_protocol_work_accumulation():
+    """When `measure_protocol_work==True`, assert that global `protocol_work` is initialized to zero and
+    reaches a zero value after integrating a few dozen steps without perturbation.
+
+    By default (`measure_protocol_work=False`), assert that there is no global name for `protocol_work`."""
+
+    testsystem = testsystems.HarmonicOscillator()
+    system, topology = testsystem.system, testsystem.topology
+    temperature = 298.0 * unit.kelvin
+    integrator = integrators.VVVRIntegrator(temperature, measure_protocol_work=True)
+    context = openmm.Context(system, integrator)
+    context.setPositions(testsystem.positions)
+    context.setVelocitiesToTemperature(temperature)
+    assert(integrator.getGlobalVariableByName('protocol_work') == 0), "Protocol work should be 0 initially"
+    integrator.step(25)
+    assert(integrator.getGlobalVariableByName('protocol_work') == 0), "There should be no protocol work."
+    perturbed_K=99.0 * unit.kilocalories_per_mole / unit.angstroms**2
+    context.setParameter('testsystems_HarmonicOscillator_K', perturbed_K)
+    integrator.step(1)
+    assert (integrator.getGlobalVariableByName('protocol_work') != 0), "There should be protocol work after perturbing."
+
+    # test default (`measure_protocol_work=False`, `measure_heat=True`) --> absence of a global `protocol_work`
+    integrator = integrators.VVVRIntegrator(temperature)
+    context = openmm.Context(system, integrator)
+    context.setPositions(testsystem.positions)
+    context.setVelocitiesToTemperature(temperature)
+    integrator.step(25)
+    # get the names of all global variables
+    n_globals = integrator.getNumGlobalVariables()
+    names_of_globals = [integrator.getGlobalVariableName(i) for i in range(n_globals)]
+    assert('protocol_work' not in names_of_globals), "Protocol work should not be defined."
+
+
 def test_temperature_getter_setter():
     """Test that temperature setter and getter modify integrator variables."""
     temperature = 350*unit.kelvin

--- a/openmmtools/tests/test_integrators.py
+++ b/openmmtools/tests/test_integrators.py
@@ -229,7 +229,7 @@ def test_vvvr_protocol_work_accumulation():
     pe_2 = context.getState(getEnergy=True).getPotentialEnergy()
     integrator.step(1)
     assert (integrator.getGlobalVariableByName('protocol_work') != 0), "There should be protocol work after perturbing."
-    assert (integrator.getGlobalVariableByName('protocol_work') == pe_2 - pe_1), \
+    assert (integrator.getGlobalVariableByName('protocol_work') * unit.kilojoule_per_mole == (pe_2 - pe_1)), \
         "The potential energy difference should be equal to protocol work."
 
     # test default (`measure_protocol_work=False`, `measure_heat=True`) --> absence of a global `protocol_work`


### PR DESCRIPTION
Why:

Some codebases, for instance protons and saltswap, modify context
parameters externally. To save expensive energy computations,
we want to accumulate the protocol work inside the integrator.
This commit adds a `protocol_work` variable to keep track of it.

It also adds a unit test to make sure the new feature works adequately.

This change addresses the need by:

* Adding the `measure_protocol_work` parameter, default false, and
including the machinery that calculates it.
* Adding a unit test to ensure it works as expected.

Please double-check that the tests passes before merging. I haven't been able to run it locally yet.