### PR TITLE
Remove lambda_restraints from parameters controlled by AlchemicalState

### DIFF
--- a/openmmtools/alchemy.py
+++ b/openmmtools/alchemy.py
@@ -108,9 +108,6 @@ class AlchemicalState(object):
         Scaling factor for alchemically-softened angles (default is 1.0).
     lambda_torsions : float, optional
         Scaling factor for alchemically-softened torsions (default is 1.0).
-    lambda_restraints : float, optional
-        Scaling factor for remaining receptor-ligand relative restraint
-        terms to help keep ligand near protein (default is 1.0).
 
     Attributes
     ----------
@@ -119,7 +116,6 @@ class AlchemicalState(object):
     lambda_bonds
     lambda_angles
     lambda_torsions
-    lambda_restraints
 
     Examples
     --------
@@ -277,7 +273,6 @@ class AlchemicalState(object):
     lambda_bonds = _LambdaProperty('lambda_bonds')
     lambda_angles = _LambdaProperty('lambda_angles')
     lambda_torsions = _LambdaProperty('lambda_torsions')
-    lambda_restraints = _LambdaProperty('lambda_restraints')
 
     def set_alchemical_parameters(self, new_value):
         """Set all defined parameters to the given value.

--- a/openmmtools/states.py
+++ b/openmmtools/states.py
@@ -1481,8 +1481,8 @@ class SamplerState(object):
     def __init__(self, positions, velocities=None, box_vectors=None):
         self._initialize(positions, velocities, box_vectors)
 
-    @staticmethod
-    def from_context(context_state):
+    @classmethod
+    def from_context(cls, context_state):
         """Alternative constructor.
 
         Read all the configurational properties from a Context object or
@@ -1502,7 +1502,7 @@ class SamplerState(object):
             A new SamplerState object.
 
         """
-        sampler_state = SamplerState([])
+        sampler_state = cls([])
         sampler_state._read_context_state(context_state, check_consistency=False)
         return sampler_state
 
@@ -1673,7 +1673,7 @@ class SamplerState(object):
         return False
 
     def __getitem__(self, item):
-        sampler_state = SamplerState([])
+        sampler_state = self.__class__([])
         if isinstance(item, slice):
             # Copy original values to avoid side effects.
             sampler_state._positions = copy.deepcopy(self._positions[item])

--- a/openmmtools/tests/test_alchemy.py
+++ b/openmmtools/tests/test_alchemy.py
@@ -1155,7 +1155,7 @@ class TestAlchemicalState(object):
         cls.alanine_state = states.ThermodynamicState(alchemical_alanine_system,
                                                       temperature=300*unit.kelvin)
 
-        # System with all lambdas except for lambda_restraints.
+        # System with all lambdas.
         alchemical_region = AlchemicalRegion(alchemical_atoms=range(22), alchemical_torsions=True,
                                              alchemical_angles=True, alchemical_bonds=True)
         fully_alchemical_alanine_system = factory.create_alchemical_system(alanine_vacuum.system, alchemical_region)
@@ -1247,8 +1247,10 @@ class TestAlchemicalState(object):
 
         # Raise an error if an extra parameter is defined in the state.
         for state, defined_lambdas in test_cases:
+            if 'lambda_bonds' in defined_lambdas:
+                continue
             defined_lambdas = set(defined_lambdas)  # Copy
-            defined_lambdas.add('lambda_restraints')  # Add extra parameter.
+            defined_lambdas.add('lambda_bonds')  # Add extra parameter.
             kwargs = dict.fromkeys(defined_lambdas, 1.0)
             alchemical_state = AlchemicalState(**kwargs)
             with nose.tools.assert_raises(AlchemicalStateError):


### PR DESCRIPTION
I have removed `lambda_restraints` from parameters controlled by `AlchemicalState` since the `alchemy` module does not offer features related to restraints. The parameter is now controlled in YANK by a dedicated composable `RestraintState`.

I've also added some context cleanup in the tests that hopefully will fix the last memory-related problem with Travis tests.

@bas-rustenburg this is the last API-breaking change I plan to make before YANK 1.0, so `openmmtools` should be ready for release on my side.