### PR TITLE
Explicitly implement __ne__ operator for Python 2

### DIFF
--- a/openmmtools/alchemy.py
+++ b/openmmtools/alchemy.py
@@ -342,6 +342,10 @@ class AlchemicalState(object):
             is_equal = is_equal and self_value == other_value
         return is_equal
 
+    def __ne__(self, other):
+        # TODO: we can safely remove this when dropping support for Python 2
+        return not self == other
+
     def __str__(self):
         return str(self._parameters)
 

--- a/openmmtools/tests/test_alchemy.py
+++ b/openmmtools/tests/test_alchemy.py
@@ -1258,8 +1258,11 @@ class TestAlchemicalState(object):
 
     def test_check_system_consistency(self):
         """Test method AlchemicalState.check_system_consistency()."""
-        # Raise error if system has MORE lambda parameters.
+        # A system is consistent with itself.
         alchemical_state = AlchemicalState.from_system(self.alanine_state.system)
+        alchemical_state.check_system_consistency(self.alanine_state.system)
+
+        # Raise error if system has MORE lambda parameters.
         with nose.tools.assert_raises(AlchemicalStateError):
             alchemical_state.check_system_consistency(self.full_alanine_state.system)
 


### PR DESCRIPTION
It turns out that when you implement a `__eq__` operator, Python 3 implicitly defines `__ne__` as not equal, but Python 2 doesn't.

I'll merge this as soon as tests pass since this PR is very small and it's blocking.