### PR TITLE
Simplifying NCMC with ExternalPerturbationLangevinIntegrator

### DIFF
--- a/openmmtools/integrators.py
+++ b/openmmtools/integrators.py
@@ -1520,7 +1520,13 @@ class NonequilibriumLangevinIntegrator(LangevinIntegrator):
 
 
 class ExternalPerturbationLangevinIntegrator(LangevinIntegrator):
-    """LangevinSplittingIntegrator that accounts for external perturbations and tracks protocol work."""
+    """
+    LangevinSplittingIntegrator that accounts for external perturbations and tracks protocol work.
+
+    If used before an NCMC attempt, initialize the protocol work with
+    >>> integrator.setGlobalVariableByName("first_step", 0)
+    where integrator is an instance of ExternalPerturbationLangevinIntegrator.
+    """
 
     def __init__(self,
                  splitting="V R O R V",
@@ -1551,6 +1557,7 @@ class ExternalPerturbationLangevinIntegrator(LangevinIntegrator):
         self.beginIfBlock("first_step < 1")
         self.addComputeGlobal("first_step", "1")
         self.addComputeGlobal("unperturbed_pe", "energy")
+        self.addComputeGlobal("protocol_work", "0.0")
         self.endBlock()
         self.addComputeGlobal("protocol_work", "protocol_work + (perturbed_pe - unperturbed_pe)")
         super(ExternalPerturbationLangevinIntegrator, self).add_integrator_steps(splitting, measure_shadow_work, measure_heat, ORV_counts, force_group_nV, mts)

--- a/openmmtools/integrators.py
+++ b/openmmtools/integrators.py
@@ -1524,13 +1524,13 @@ class ExternalPerturbationLangevinIntegrator(LangevinIntegrator):
     LangevinSplittingIntegrator that accounts for external perturbations and tracks protocol work. An example of an
     external perturbation could be changing the forcefield parameters via
 
-     >>> force.setParticleParameters(...)
-     >>> force.updateParametersInContext(context)
+    > force.setParticleParameters(...)
+    > force.updateParametersInContext(context)
 
     where force is an instance of openmm's force class. The externally performed protocol work is accumulated in the
     "protocol_work" global variable. This variable can be re-initialized with
 
-    >>> integrator.setGlobalVariableByName("first_step", 0)
+    > integrator.setGlobalVariableByName("first_step", 0)
 
     where integrator is an instance of ExternalPerturbationLangevinIntegrator.
     """

--- a/openmmtools/integrators.py
+++ b/openmmtools/integrators.py
@@ -1521,10 +1521,17 @@ class NonequilibriumLangevinIntegrator(LangevinIntegrator):
 
 class ExternalPerturbationLangevinIntegrator(LangevinIntegrator):
     """
-    LangevinSplittingIntegrator that accounts for external perturbations and tracks protocol work.
+    LangevinSplittingIntegrator that accounts for external perturbations and tracks protocol work. An example of an
+    external perturbation could be changing the forcefield parameters via
 
-    If used before an NCMC attempt, initialize the protocol work with
+     >>> force.setParticleParameters(...)
+     >>> force.updateParametersInContext(context)
+
+    where force is an instance of openmm's force class. The externally performed protocol work is accumulated in the
+    "protocol_work" global variable. This variable can be re-initialized with
+
     >>> integrator.setGlobalVariableByName("first_step", 0)
+
     where integrator is an instance of ExternalPerturbationLangevinIntegrator.
     """
 


### PR DESCRIPTION
This PR addresses Issue #164. With this commit, the protocol work variable in `ExternalPerturbationLangevinIntegrator` is set to zero when first_step = 0. This simplifies the implementation of `ExternalPerturbationLangevinIntegrator` for NCMC, which requires multiple sequential protocol work calculations. 

@bas-rustenburg, could you make sure that I've used `self.addComputeGlobal("protocol_work", "0.0")` correctly? I get confused with this versus  `self.setGlobalVariableByName("protocol_work", "0.0")` . Thanks!