### PR TITLE
Add more tests for ExternalPerturbationLangevinIntegrator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,7 @@ env:
   global:
     - ORGNAME="omnia" # the name of the organization
     - PACKAGENAME="openmmtools" # the name of your package
+    - OPENMM_CPU_THREADS="1" # only use one CPU thread for determinism
     # encrypted BINSTAR_TOKEN for push of dev package to binstar
     - secure: "DP5heLvW3wnHvw6d2tinSHcyAxe0EWEsoL4X3lrGC+BSSy3Fd60pb90zSibK/hcxzV7Cb/x4mC4C7KPgGZEXzvVFH/iF7tg2Yy41XgyuZ5vxacfXICdryoTAlGxrbwACvO/ak+OHEYTtkX3OyFM/f8zV0z7Shz/rOSbSvcEKmpQ="
 

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -18,6 +18,7 @@ requirements:
     - setuptools
     - openmm
     - parmed
+    - tqdm
 
   run:
     - python
@@ -28,12 +29,13 @@ requirements:
     - six
     - openmm
     - parmed
-
+    - tqdm
 
 test:
   requires:
     - nose
     - pymbar
+    - tqdm
   imports:
     - openmmtools
 

--- a/openmmtools/tests/test_integrators.py
+++ b/openmmtools/tests/test_integrators.py
@@ -273,10 +273,11 @@ class TestExternalPerturbationLangevinIntegrator(TestCase):
         parameter_name = 'lambda_electrostatics'
         parameter_initial = 1.0
         parameter_final = 0.0
+        platform_names = [ openmm.Platform.getPlatform(index).getName() for index in range(openmm.Platform.getNumPlatforms()) ]
         for nonbonded_method in ['CutoffPeriodic', 'PME']:
             testsystem = testsystems.AlchemicalWaterBox(nonbondedMethod=getattr(app, nonbonded_method))
-            name = '%s with nonbondedMethod=%s' % (testsystem.name, nonbonded_method)
-            for platform_name in ['CPU', 'OpenCL', 'Reference']:
+            for platform_name in platform_names:
+                name = '%s %s %s' % (testsystem.name, nonbonded_method, platform_name)                
                 self.compare_external_protocol_work_accumulation(testsystem, parameter_name, parameter_initial, parameter_final, platform_name=platform_name, name=name)
 
     def compare_external_protocol_work_accumulation(self, testsystem, parameter_name, parameter_initial, parameter_final, platform_name='Reference', name=None):

--- a/openmmtools/tests/test_integrators.py
+++ b/openmmtools/tests/test_integrators.py
@@ -294,7 +294,7 @@ class TestExternalPerturbationLangevinIntegrator(TestCase):
 
         # TODO: Set precision and determinism if platform is ['OpenCL', 'CUDA']
 
-        nsteps = 100
+        nsteps = 20
         kT = kB * temperature
         integrator = integrators.ExternalPerturbationLangevinIntegrator(splitting="O V R V O", temperature=temperature)
         context = openmm.Context(system, integrator, platform)

--- a/openmmtools/tests/test_integrators.py
+++ b/openmmtools/tests/test_integrators.py
@@ -17,6 +17,8 @@ import numpy
 import inspect
 import pymbar
 
+from tqdm import tqdm
+
 from functools import partial
 from unittest import TestCase
 
@@ -254,31 +256,39 @@ def test_external_protocol_work_accumulation():
     del context, integrator
 
 class TestExternalPerturbationLangevinIntegrator(TestCase):
-    def test_protocol_work_accumulation(self):
+    def test_protocol_work_accumulation_harmonic_oscillator(self):
+        """Testing protocol work accumulation for ExternalPerturbationLangevinIntegrator with HarmonicOscillator
+        """
+        testsystem = testsystems.HarmonicOscillator()
+        parameter_name = 'testsystems_HarmonicOscillator_x0'
+        parameter_initial = 0.0 * unit.angstroms
+        parameter_final = 10.0 * unit.angstroms
         for platform_name in ['Reference', 'CPU']:
-            self.compare_external_protocol_work_accumulation(platform_name)
+            self.compare_external_protocol_work_accumulation(testsystem, parameter_name, parameter_initial, parameter_final, platform_name=platform_name)
 
-    def compare_external_protocol_work_accumulation(self, platform_name='Reference'):
+    def test_protocol_work_accumulation_waterbox(self):
+        """Testing protocol work accumulation for ExternalPerturbationLangevinIntegrator with AlchemicallyDischargedWaterBox
+        """
+        testsystem = testsystems.AlchemicallyDischargedWaterBox()
+        parameter_name = 'lambda_electrostatics'
+        parameter_initial = 1.0
+        parameter_final = 0.0
+        for platform_name in ['Reference', 'CPU']:
+            self.compare_external_protocol_work_accumulation(testsystem, parameter_name, parameter_initial, parameter_final, platform_name=platform_name)
+
+    def compare_external_protocol_work_accumulation(self, testsystem, parameter_name, parameter_initial, parameter_final, platform_name='Reference'):
         """Compare external work accumulation between Reference and CPU platforms.
         """
 
         from openmmtools.constants import kB
-        testsystem = testsystems.HarmonicOscillator()
         system, topology = testsystem.system, testsystem.topology
         temperature = 298.0 * unit.kelvin
-        collision_rate = 1.0 / unit.picoseconds
-        K = 100.0 * unit.kilocalories_per_mole/unit.angstrom**2
-        mass = 39.948 * unit.amu
-        period = unit.sqrt(mass/K)
-        timestep = period / 20.0
         platform = openmm.Platform.getPlatformByName(platform_name)
-        nsteps = 1000
+        nsteps = 100
         kT = kB * temperature
-        x0_initial = 0.0 * unit.angstroms
-        x0_final = 25.0 * unit.angstroms
-
         integrator = integrators.ExternalPerturbationLangevinIntegrator(splitting="O V R V O", temperature=temperature)
         context = openmm.Context(system, integrator, platform)
+        context.setParameter(parameter_name, parameter_initial)
         context.setPositions(testsystem.positions)
         context.setVelocitiesToTemperature(temperature)
         assert(integrator.getGlobalVariableByName('protocol_work') == 0), "Protocol work should be 0 initially"
@@ -286,22 +296,23 @@ class TestExternalPerturbationLangevinIntegrator(TestCase):
         assert(integrator.getGlobalVariableByName('protocol_work') == 0), "There should be no protocol work."
 
         external_protocol_work = 0.0
-        for step in range(nsteps):
+        for step in tqdm(range(nsteps)):
             lambda_value = float(step+1) / float(nsteps)
-            x0 = x0_initial * (1-lambda_value) + x0_final * lambda_value
+            parameter_value = parameter_initial * (1-lambda_value) + parameter_final * lambda_value
             initial_energy = context.getState(getEnergy=True).getPotentialEnergy()
-            context.setParameter('testsystems_HarmonicOscillator_x0', x0)
+            context.setParameter(parameter_name, parameter_value)
             final_energy = context.getState(getEnergy=True).getPotentialEnergy()
             external_protocol_work += (final_energy - initial_energy) / kT
 
             integrator.step(1)
             integrator_protocol_work = integrator.getGlobalVariableByName('protocol_work') * unit.kilojoules_per_mole / kT
 
-            #print('%16e %16e : %16e' % (external_protocol_work, integrator_protocol_work, external_protocol_work - integrator_protocol_work))
-            self.assertAlmostEqual(external_protocol_work, integrator_protocol_work)
+            message = '\n'
+            message += 'protocol work discrepancy noted for %s on platform %s\n' % (testsystem.name, platform_name)
+            message += 'step %5d : external %16e kT | integrator %16e kT | difference %16e kT' % (step, external_protocol_work, integrator_protocol_work, external_protocol_work - integrator_protocol_work)
+            self.assertAlmostEqual(external_protocol_work, integrator_protocol_work, msg=message)
 
         del context, integrator
-
 
 def test_temperature_getter_setter():
     """Test that temperature setter and getter modify integrator variables."""

--- a/openmmtools/tests/test_testsystems.py
+++ b/openmmtools/tests/test_testsystems.py
@@ -98,7 +98,7 @@ fast_testsystems = [
     "CustomLennardJonesFluidMixture",
     "WCAFluid",
     "IdealGas",
-    "WaterBox", "FlexibleWaterBox", "FourSiteWaterBox", "FiveSiteWaterBox", "DischargedWaterBox", "DischargedWaterBoxHsites",
+    "WaterBox", "FlexibleWaterBox", "FourSiteWaterBox", "FiveSiteWaterBox", "DischargedWaterBox", "DischargedWaterBoxHsites", "AlchemicallyDischargedWaterBox",
     "AlanineDipeptideVacuum", "AlanineDipeptideImplicit",
     "MethanolBox",
     "MolecularIdealGas",

--- a/openmmtools/tests/test_testsystems.py
+++ b/openmmtools/tests/test_testsystems.py
@@ -98,7 +98,7 @@ fast_testsystems = [
     "CustomLennardJonesFluidMixture",
     "WCAFluid",
     "IdealGas",
-    "WaterBox", "FlexibleWaterBox", "FourSiteWaterBox", "FiveSiteWaterBox", "DischargedWaterBox", "DischargedWaterBoxHsites", "AlchemicallyDischargedWaterBox",
+    "WaterBox", "FlexibleWaterBox", "FourSiteWaterBox", "FiveSiteWaterBox", "DischargedWaterBox", "DischargedWaterBoxHsites", "AlchemicalWaterBox",
     "AlanineDipeptideVacuum", "AlanineDipeptideImplicit",
     "MethanolBox",
     "MolecularIdealGas",

--- a/openmmtools/testsystems.py
+++ b/openmmtools/testsystems.py
@@ -2896,10 +2896,10 @@ class DischargedWaterBoxHsites(WaterBox):
 
         return
 
-class AlchemicallyDischargedWaterBox(WaterBox):
+class AlchemicalWaterBox(WaterBox):
 
     """
-    Water box test system where a single water molecule can be alchemical discharged.
+    Water box test system where a single water molecule can be alchemically modified.
 
     """
 
@@ -2919,42 +2919,18 @@ class AlchemicallyDischargedWaterBox(WaterBox):
 
         Create a waterbox.
 
-        >>> waterbox = AlchemicallyDischargedWaterBox()
+        >>> waterbox = AlchemicalWaterBox()
         >>> [system, positions] = [waterbox.system, waterbox.positions]
 
         """
-        super(AlchemicallyDischargedWaterBox, self).__init__(*args, **kwargs)
+        super(AlchemicalWaterBox, self).__init__(*args, **kwargs)
 
-        system = self.system
-        forces = {system.getForce(index).__class__.__name__: system.getForce(index) for index in range(system.getNumForces())}
-        force = forces['NonbondedForce']
-
-        # Create a CustomNonbondedForce to handle first water interactions
-        from openmmtools.constants import ONE_4PI_EPS0
-        energy_expression = 'compute_interaction * lambda_electrostatics * ONE_4PI_EPS0*chargeprod/r;'
-        energy_expression += 'chargeprod = charge1*charge2;'
-        energy_expression += 'compute_interaction = is_alchemical1 * (1-is_alchemical2) + is_alchemical2 * (1-is_alchemical1);'
-        energy_expression += "ONE_4PI_EPS0 = %f;" % ONE_4PI_EPS0 # already in OpenMM units
-        custom_force = openmm.CustomNonbondedForce(energy_expression)
-        custom_force.addGlobalParameter('lambda_electrostatics', 1.0)
-        custom_force.addPerParticleParameter('charge')
-        custom_force.addPerParticleParameter('is_alchemical')
-        custom_force.setUseSwitchingFunction(True)
-        custom_force.setUseLongRangeCorrection(False)
-        custom_force.setCutoffDistance(force.getCutoffDistance())
-        custom_force.setSwitchingDistance(force.getSwitchingDistance())
-        system.addForce(custom_force)
-
-        alchemical_atoms = range(0,3) # first water
-        for index in range(system.getNumParticles()):
-            [charge, sigma, epsilon] = force.getParticleParameters(index)
-            custom_force.addParticle([charge, float(index in alchemical_atoms)])
-            if (index in alchemical_atoms):
-                force.setParticleParameters(index, 0 * charge, sigma, epsilon)
-
-        for index in range(force.getNumExceptions()):
-            [particle1, particle2, chargeProd, sigma, epsilon] = force.getExceptionParameters(index)
-            custom_force.addExclusion(particle1, particle2)
+        # Alchemically modify the system
+        from openmmtools.alchemy import AlchemicalRegion, AlchemicalFactory
+        region = AlchemicalRegion(alchemical_atoms=range(3))
+        factory = AlchemicalFactory()
+        alchemical_system = factory.create_alchemical_system(self.system, region)
+        self.system = alchemical_system
 
         return
 

--- a/openmmtools/testsystems.py
+++ b/openmmtools/testsystems.py
@@ -627,7 +627,7 @@ class HarmonicOscillator(TestSystem):
 
     Parameters
     ----------
-    K : simtk.unit.Quantity, optional, default=90.0 * unit.kilocalories_per_mole/unit.angstrom**2
+    K : simtk.unit.Quantity, optional, default=100.0 * unit.kilocalories_per_mole/unit.angstrom**2
         harmonic restraining potential
     mass : simtk.unit.Quantity, optional, default=39.948 * unit.amu
         particle mass
@@ -638,6 +638,13 @@ class HarmonicOscillator(TestSystem):
         Openmm system with the harmonic oscillator
     positions : list
         positions of harmonic oscillator
+
+    Context parameters
+    ------------------
+    testsystems_HarmonicOscillator_K
+        Spring constant of harmonic oscillator
+    testsystems_HarmonicOscillator_x0
+        Reference x position for harmonic oscillator
 
     Notes
     -----
@@ -696,10 +703,12 @@ class HarmonicOscillator(TestSystem):
         system.setDefaultPeriodicBoxVectors([edge,0,0], [0,edge,0], [0,0,edge])
 
         # Add a restrining potential centered at the origin.
-        energy_expression = '(K/2.0) * (x^2 + y^2 + z^2);'
+        energy_expression = '(K/2.0) * ((x-x0)^2 + y^2 + z^2);'
         energy_expression += 'K = testsystems_HarmonicOscillator_K;'
+        energy_expression += 'x0 = testsystems_HarmonicOscillator_x0;'
         force = openmm.CustomExternalForce(energy_expression)
         force.addGlobalParameter('testsystems_HarmonicOscillator_K', K)
+        force.addGlobalParameter('testsystems_HarmonicOscillator_x0', 0.0)
         force.addParticle(0, [])
         system.addForce(force)
 


### PR DESCRIPTION
This adds some additional tests to try to figure out what is going on with @gregoryross's observation that there is a discrepancy between the protocol work measured from computing potential energy changes and reading from the integrator's accumulated protocol work.

So far, I am detecting no significant discrepancies.