### PR TITLE
Improve PME and RF support in alchemy

### DIFF
--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -18,6 +18,7 @@ requirements:
     - setuptools
     - openmm
     - parmed
+    - tqdm
 
   run:
     - python
@@ -28,7 +29,7 @@ requirements:
     - six
     - openmm
     - parmed
-
+    - tqdm
 
 test:
   requires:

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -18,7 +18,6 @@ requirements:
     - setuptools
     - openmm
     - parmed
-    - tqdm
 
   run:
     - python
@@ -29,7 +28,6 @@ requirements:
     - six
     - openmm
     - parmed
-    - tqdm
 
 test:
   requires:

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -33,7 +33,6 @@ test:
   requires:
     - nose
     - pymbar
-    - tqdm
   imports:
     - openmmtools
 

--- a/openmmtools/alchemy.py
+++ b/openmmtools/alchemy.py
@@ -672,7 +672,7 @@ class AlchemicalFactory(object):
         Options are ['direct-space', 'coulomb'].
         'direct-space' only models the direct space contribution
         'coulomb' includes switched Coulomb interaction
-    alchemical_rf_reatment : str, optional, default = 'switched'
+    alchemical_rf_treatment : str, optional, default = 'switched'
          Controls how alchemical region electrostatics are treated when RF is used
          Options are ['switched', 'shifted']
          'switched' sets c_rf = 0 for all reaction-field interactions and ensures continuity with a switch

--- a/openmmtools/tests/test_alchemy.py
+++ b/openmmtools/tests/test_alchemy.py
@@ -511,14 +511,13 @@ def compare_system_forces(reference_system, alchemical_system, positions, name="
 
     # Check that error is small.
     def magnitude(vec):
-        [nparticles, ndim] = vec.shape
-        return np.sqrt(np.sum(vec**2) / float(nparticles))
+        return np.sqrt(np.mean(np.sum(vec**2, axis=1)))
 
     relative_error = magnitude(alchemical_force - reference_force) / magnitude(reference_force)
     if np.any(np.abs(relative_error) > MAX_FORCE_RELATIVE_ERROR):
         print("========")
         err_msg = "Maximum allowable relative force error exceeded (was {:.8f}; allowed {:.8f}).\nalchemical_force = {:.8f}, reference_force = {:.8f}, difference = {:.8f}"
-        raise Exception(err_msg.format(relative_error, MAX_FORCE_RELATIVE_ERROR, magnitude(alchemical_force), magnitude(reference_force), magnitude(reference_force)))
+        raise Exception(err_msg.format(relative_error, MAX_FORCE_RELATIVE_ERROR, magnitude(alchemical_force), magnitude(reference_force), magnitude(alchemical_force-reference_force)))
 
 def check_interacting_energy_components(reference_system, alchemical_system, alchemical_regions, positions):
     """Compare full and alchemically-modified system energies by energy component.

--- a/openmmtools/tests/test_alchemy.py
+++ b/openmmtools/tests/test_alchemy.py
@@ -773,19 +773,24 @@ def benchmark(reference_system, alchemical_regions, positions, nsteps=500,
     alchemical_integrator.step(1)
 
     # Run simulations.
+    print('Running reference system...')
     timer.start('Run reference system')
     reference_integrator.step(nsteps)
     timer.stop('Run reference system')
 
+    print('Running alchemical system...')
     timer.start('Run alchemical system')
     alchemical_integrator.step(nsteps)
     timer.stop('Run alchemical system')
+    print('Done.')
 
     timer.report_timing()
 
 def benchmark_alchemy_from_pdb():
     """CLI entry point for benchmarking alchemical performance from a PDB file.
     """
+    logging.basicConfig(level=logging.DEBUG)
+
     import mdtraj
     import argparse
     from simtk.openmm import app
@@ -795,6 +800,8 @@ def benchmark_alchemy_from_pdb():
                         help='PDB file to benchmark; only protein forcefields supported for now (no small molecules)')
     parser.add_argument('-s', '--selection', metavar='SELECTION', type=str, action='store', default='not water',
                         help='MDTraj DSL describing alchemical region (default: "not water")')
+    parser.add_argument('-n', '--nsteps', metavar='STEPS', type=int, action='store', default=1000,
+                        help='Number of benchmarking steps (default: 1000)')
     args = parser.parse_args()
     # Read the PDB file
     print('Loading PDB file...')
@@ -816,7 +823,7 @@ def benchmark_alchemy_from_pdb():
     print('There are %d atoms in the alchemical region.' % len(alchemical_atoms))
     # Benchmark
     print('Benchmarking...')
-    benchmark(reference_system, alchemical_region, positions, nsteps=500, timestep=1.0*unit.femtoseconds)
+    benchmark(reference_system, alchemical_region, positions, nsteps=args.nsteps, timestep=1.0*unit.femtoseconds)
 
 def overlap_check(reference_system, alchemical_system, positions, nsteps=50, nsamples=200,
                   cached_trajectory_filename=None, name=""):

--- a/openmmtools/tests/test_alchemy.py
+++ b/openmmtools/tests/test_alchemy.py
@@ -1214,27 +1214,27 @@ class TestAlchemicalFactorySlow(TestAlchemicalFactory):
     def define_systems(cls):
         """Create test systems and shared objects."""
         cls.test_systems = dict()
-        #cls.test_systems['LennardJonesFluid without dispersion correction'] = \
-        #    testsystems.LennardJonesFluid(nparticles=100, dispersion_correction=False)
-        #cls.test_systems['DischargedWaterBox with reaction field, no switch, no dispersion correction'] = \
-        #    testsystems.DischargedWaterBox(dispersion_correction=False, switch=False,
-        #                                   nonbondedMethod=openmm.app.CutoffPeriodic)
-        #cls.test_systems['WaterBox with reaction field, no switch, dispersion correction'] = \
-        #    testsystems.WaterBox(dispersion_correction=False, switch=True, nonbondedMethod=openmm.app.CutoffPeriodic)
-        #cls.test_systems['WaterBox with reaction field, switch, no dispersion correction'] = \
-        #    testsystems.WaterBox(dispersion_correction=False, switch=True, nonbondedMethod=openmm.app.CutoffPeriodic)
+        cls.test_systems['LennardJonesFluid without dispersion correction'] = \
+            testsystems.LennardJonesFluid(nparticles=100, dispersion_correction=False)
+        cls.test_systems['DischargedWaterBox with reaction field, no switch, no dispersion correction'] = \
+            testsystems.DischargedWaterBox(dispersion_correction=False, switch=False,
+                                           nonbondedMethod=openmm.app.CutoffPeriodic)
+        cls.test_systems['WaterBox with reaction field, no switch, dispersion correction'] = \
+            testsystems.WaterBox(dispersion_correction=False, switch=True, nonbondedMethod=openmm.app.CutoffPeriodic)
+        cls.test_systems['WaterBox with reaction field, switch, no dispersion correction'] = \
+            testsystems.WaterBox(dispersion_correction=False, switch=True, nonbondedMethod=openmm.app.CutoffPeriodic)
         cls.test_systems['WaterBox with PME, switch, dispersion correction'] = \
             testsystems.WaterBox(dispersion_correction=True, switch=True, nonbondedMethod=openmm.app.PME)
 
         # Big systems.
-        #cls.test_systems['LysozymeImplicit'] = testsystems.LysozymeImplicit()
-        #cls.test_systems['DHFRExplicit with reaction field'] = \
-        #    testsystems.DHFRExplicit(nonbondedMethod=openmm.app.CutoffPeriodic)
+        cls.test_systems['LysozymeImplicit'] = testsystems.LysozymeImplicit()
+        cls.test_systems['DHFRExplicit with reaction field'] = \
+            testsystems.DHFRExplicit(nonbondedMethod=openmm.app.CutoffPeriodic)
         cls.test_systems['SrcExplicit with PME'] = \
             testsystems.SrcExplicit(nonbondedMethod=openmm.app.PME)
-        #cls.test_systems['SrcExplicit with reaction field'] = \
-        #    testsystems.SrcExplicit(nonbondedMethod=openmm.app.CutoffPeriodic)
-        #cls.test_systems['SrcImplicit'] = testsystems.SrcImplicit()
+        cls.test_systems['SrcExplicit with reaction field'] = \
+            testsystems.SrcExplicit(nonbondedMethod=openmm.app.CutoffPeriodic)
+        cls.test_systems['SrcImplicit'] = testsystems.SrcImplicit()
 
     @classmethod
     def define_regions(cls):

--- a/openmmtools/tests/test_alchemy.py
+++ b/openmmtools/tests/test_alchemy.py
@@ -44,7 +44,7 @@ MAX_FORCE_RELATIVE_ERROR = 1.0e-6 # maximum allowable relative force error
 GLOBAL_ENERGY_UNIT = unit.kilojoules_per_mole  # controls printed units
 GLOBAL_FORCE_UNIT = unit.kilojoules_per_mole / unit.nanometers # controls printed units
 GLOBAL_ALCHEMY_PLATFORM = None  # This is used in every energy calculation.
-GLOBAL_ALCHEMY_PLATFORM = openmm.Platform.getPlatformByName('Reference') # DEBUG: Use OpenCL over CPU platform for testing since OpenCL is deterministic, while CPU is not
+# GLOBAL_ALCHEMY_PLATFORM = openmm.Platform.getPlatformByName('OpenCL') # DEBUG: Use OpenCL over CPU platform for testing since OpenCL is deterministic, while CPU is not
 
 
 # =============================================================================
@@ -788,6 +788,7 @@ def benchmark(reference_system, alchemical_regions, positions, nsteps=500,
 
     timer.report_timing()
 
+
 def benchmark_alchemy_from_pdb():
     """CLI entry point for benchmarking alchemical performance from a PDB file.
     """
@@ -826,6 +827,7 @@ def benchmark_alchemy_from_pdb():
     # Benchmark
     print('Benchmarking...')
     benchmark(reference_system, alchemical_region, positions, nsteps=args.nsteps, timestep=1.0*unit.femtoseconds)
+
 
 def overlap_check(reference_system, alchemical_system, positions, nsteps=50, nsamples=200,
                   cached_trajectory_filename=None, name=""):
@@ -941,6 +943,7 @@ def overlap_check(reference_system, alchemical_system, positions, nsteps=50, nsa
     print(report)
     if dDeltaF > MAX_DEVIATION:
         raise Exception(report)
+
 
 def rstyle(ax):
     """Styles x,y axes to appear like ggplot2
@@ -1275,8 +1278,6 @@ class TestAlchemicalFactory(object):
     def test_overlap(self):
         """Tests overlap between reference and alchemical systems."""
         for test_name, (test_system, alchemical_system, alchemical_region) in self.test_cases.items():
-            reference_system = test_system.system
-            positions = test_system.positions
             #cached_trajectory_filename = os.path.join(os.environ['HOME'], '.cache', 'alchemy', 'tests',
             #                                           test_name + '.pickle')
             cached_trajectory_filename = None

--- a/openmmtools/tests/test_alchemy.py
+++ b/openmmtools/tests/test_alchemy.py
@@ -446,7 +446,7 @@ def compare_system_energies(reference_system, alchemical_system, alchemical_regi
         potentials.append(aa_correction + na_correction)
     else:
         potentials.append(0.0 * GLOBAL_ENERGY_UNIT)
-    
+
     # Check that error is small.
     delta = potentials[1] - potentials[2] - potentials[0]
     if abs(delta) > MAX_DELTA:
@@ -481,7 +481,6 @@ def compare_system_forces(reference_system, alchemical_system, positions, name="
         return np.sqrt(np.sum(vec**2))
 
     relative_error = magnitude(alchemical_force - reference_force) / magnitude(reference_force)
-    print('relative_error = %16e' % relative_error)
     if np.any(np.abs(relative_error) > MAX_FORCE_RELATIVE_ERROR):
         print("========")
         err_msg = "Maximum allowable relative force error exceeded (was {:.8f}; allowed {:.8f})."
@@ -1131,20 +1130,20 @@ class TestAlchemicalFactory(object):
             yield f
 
     def test_replace_reaction_field(self):
-        """Check that replacing reaction-field electrostatics with Custom*Force yields minimal force differences with original system.        
+        """Check that replacing reaction-field electrostatics with Custom*Force yields minimal force differences with original system.
         Note that we cannot test for energy consistency or energy overlap because which atoms are within the cutoff will cause energy difference to vary wildly.
         """
         factory = AlchemicalFactory()
         for test_name, (test_system, alchemical_system, alchemical_region) in self.test_cases.items():
             reference_system = test_system.system
             forces = {force.__class__.__name__: force for force in reference_system.getForces()}
-            if ('NonbondedForce' in forces) and (forces['NonbondedForce'].getNonbondedMethod() == openmm.NonbondedForce.CutoffPeriodic):                
+            if ('NonbondedForce' in forces) and (forces['NonbondedForce'].getNonbondedMethod() == openmm.NonbondedForce.CutoffPeriodic):
                 modified_system = factory.replace_reaction_field(reference_system, switch_width=None)
                 positions = test_system.positions
                 f = partial(compare_system_forces, reference_system, modified_system, positions, name=test_name)
                 f.description = "Testing replace_reaction_field on system {}".format(test_name)
                 yield f
-        
+
     @attr('slow')
     def test_fully_interacting_energy_components(self):
         """Test interacting state energy by force component."""

--- a/openmmtools/tests/test_alchemy.py
+++ b/openmmtools/tests/test_alchemy.py
@@ -46,8 +46,7 @@ MAX_FORCE_RELATIVE_ERROR = 1.0e-6 # maximum allowable relative force error
 GLOBAL_ENERGY_UNIT = unit.kilojoules_per_mole  # controls printed units
 GLOBAL_FORCE_UNIT = unit.kilojoules_per_mole / unit.nanometers # controls printed units
 GLOBAL_ALCHEMY_PLATFORM = None  # This is used in every energy calculation.
-GLOBAL_ALCHEMY_PLATFORM = openmm.Platform.getPlatformByName('OpenCL') # DEBUG
-
+#GLOBAL_ALCHEMY_PLATFORM = openmm.Platform.getPlatformByName('OpenCL') # DEBUG: Use OpenCL over CPU platform for testing since OpenCL is deterministic, while CPU is not
 
 # =============================================================================
 # TESTING UTILITIES

--- a/openmmtools/tests/test_integrators.py
+++ b/openmmtools/tests/test_integrators.py
@@ -17,16 +17,13 @@ import numpy
 import inspect
 import pymbar
 
-from tqdm import tqdm
-
-from functools import partial
 from unittest import TestCase
 
 from simtk import unit
 from simtk import openmm
 
 from openmmtools import integrators, testsystems, alchemy
-from openmmtools.integrators import RestorableIntegrator, ThermostatedIntegrator, NonequilibriumLangevinIntegrator, GHMCIntegrator, GeodesicBAOABIntegrator
+from openmmtools.integrators import RestorableIntegrator, ThermostatedIntegrator, NonequilibriumLangevinIntegrator, GHMCIntegrator
 
 #=============================================================================================
 # CONSTANTS
@@ -348,7 +345,7 @@ class TestExternalPerturbationLangevinIntegrator(TestCase):
         assert(integrator.getGlobalVariableByName('protocol_work') == 0), "There should be no protocol work."
 
         external_protocol_work = 0.0
-        for step in tqdm(range(nsteps), desc=name):
+        for step in range(nsteps):
             lambda_value = float(step+1) / float(nsteps)
             parameter_value = parameter_initial * (1-lambda_value) + parameter_final * lambda_value
             initial_energy = context.getState(getEnergy=True).getPotentialEnergy()

--- a/openmmtools/testsystems.py
+++ b/openmmtools/testsystems.py
@@ -63,6 +63,10 @@ from .constants import kB
 
 pi = np.pi
 
+DEFAULT_EWALD_ERROR_TOLERANCE = 1.0e-5 # default Ewald error tolerance
+DEFAULT_CUTOFF_DISTANCE = 10.0 * unit.angstroms # default cutoff distance
+DEFAULT_SWITCH_WIDTH = 1.5 * unit.angstroms # default switch width
+
 #=============================================================================================
 # SUBROUTINES
 #=============================================================================================
@@ -1741,7 +1745,7 @@ class LennardJonesFluid(TestSystem):
         Also, if not None, use PME for electrostatics.  Obviously this is no
         longer a traditional LJ system, but this option could be useful for
         testing the effect of charges in small systems.
-    ewaldErrorTolerance : float, optional, default=5E-4
+    ewaldErrorTolerance : float, optional, default=DEFAULT_EWALD_ERROR_TOLERANCE
            The Ewald or PME tolerance.  Used only if charge is not None.
 
     Examples
@@ -2446,7 +2450,7 @@ class WaterBox(TestSystem):
 
     """
 
-    def __init__(self, box_edge=25.0*unit.angstroms, cutoff=9*unit.angstroms, model='tip3p', switch_width=1.5*unit.angstroms, constrained=True, dispersion_correction=True, nonbondedMethod=app.PME, ewaldErrorTolerance=5E-4, **kwargs):
+    def __init__(self, box_edge=25.0*unit.angstroms, cutoff=DEFAULT_CUTOFF_DISTANCE, model='tip3p', switch_width=DEFAULT_SWITCH_WIDTH, constrained=True, dispersion_correction=True, nonbondedMethod=app.PME, ewaldErrorTolerance=DEFAULT_EWALD_ERROR_TOLERANCE, **kwargs):
         """
         Create a water box test system.
 
@@ -2455,11 +2459,11 @@ class WaterBox(TestSystem):
 
         box_edge : simtk.unit.Quantity with units compatible with nanometers, optional, default = 2.5 nm
            Edge length for cubic box [should be greater than 2*cutoff]
-        cutoff : simtk.unit.Quantity with units compatible with nanometers, optional, default = 0.9 nm
+        cutoff : simtk.unit.Quantity with units compatible with nanometers, optional, default = DEFAULT_CUTOFF_DISTANCE
            Nonbonded cutoff
         model : str, optional, default = 'tip3p'
            The name of the water model to use ['tip3p', 'tip4p', 'tip4pew', 'tip5p', 'spce']
-        switch_width : simtk.unit.Quantity with units compatible with nanometers, optional, default = 0.5 A
+        switch_width : simtk.unit.Quantity with units compatible with nanometers, optional, default = DEFAULT_SWITCH_WIDTH
            Sets the width of the switch function for Lennard-Jones.
         constrained : bool, optional, default=True
            Sets whether water geometry should be constrained (rigid water implemented via SETTLE) or flexible.
@@ -2467,7 +2471,7 @@ class WaterBox(TestSystem):
            Sets whether the long-range dispersion correction should be used.
         nonbondedMethod : simtk.openmm.app nonbonded method, optional, default=app.PME
            Sets the nonbonded method to use for the water box (one of app.CutoffPeriodic, app.Ewald, app.PME).
-        ewaldErrorTolerance : float, optional, default=5E-4
+        ewaldErrorTolerance : float, optional, default=DEFAULT_EWALD_ERROR_TOLERANCE
            The Ewald or PME tolerance.  Used only if nonbondedMethod is Ewald or PME.
 
         Examples
@@ -2626,7 +2630,7 @@ class FlexiblePMEWaterBox(WaterBox):
         >>> [system, positions] = [waterbox.system, waterbox.positions]
 
         """
-        super(FlexiblePMEWaterBox, self).__init__(constrained=False, nonbonedMethod=app.PME, ewaldErrorTolerance=1.0e-7, *args, **kwargs)
+        super(FlexiblePMEWaterBox, self).__init__(constrained=False, nonbonedMethod=app.PME, *args, **kwargs)
 
 class PMEWaterBox(WaterBox):
 
@@ -2650,7 +2654,7 @@ class PMEWaterBox(WaterBox):
         >>> [system, positions] = [waterbox.system, waterbox.positions]
 
         """
-        super(PMEWaterBox, self).__init__(nonbonedMethod=app.PME, ewaldErrorTolerance=1.0e-7, *args, **kwargs)
+        super(PMEWaterBox, self).__init__(nonbonedMethod=app.PME, *args, **kwargs)
 
 class GiantFlexibleWaterBox(WaterBox):
 
@@ -2992,10 +2996,12 @@ class AlanineDipeptideExplicit(TestSystem):
     hydrogenMass : unit, optional, default=None
         If set, will pass along a modified hydrogen mass for OpenMM to
         use mass repartitioning.
-    switch_width : simtk.unit.Quantity with units compatible with angstroms, optional, default=None
+    cutoff : simtk.unit.Quantity with units compatible with angstroms, optional, default = DEFAULT_CUTOFF_DISTANCE
+        Cutoff distance
+    switch_width : simtk.unit.Quantity with units compatible with angstroms, optional, default = DEFAULT_SWITCH_WIDTH
         switching function is turned on at cutoff - switch_width
         If None, no switch will be applied (e.g. hard cutoff).
-    ewaldErrorTolerance : float, optional, default=5E-4
+    ewaldErrorTolerance : float, optional, default=DEFAULT_EWALD_ERROR_TOLERANCE
            The Ewald or PME tolerance.
 
     Examples
@@ -3005,7 +3011,7 @@ class AlanineDipeptideExplicit(TestSystem):
     >>> (system, positions) = alanine.system, alanine.positions
     """
 
-    def __init__(self, constraints=app.HBonds, rigid_water=True, nonbondedCutoff=9.0 * unit.angstroms, use_dispersion_correction=True, nonbondedMethod=app.PME, hydrogenMass=None, switch_width=None, ewaldErrorTolerance=5E-4, **kwargs):
+    def __init__(self, constraints=app.HBonds, rigid_water=True, nonbondedCutoff=DEFAULT_CUTOFF_DISTANCE, use_dispersion_correction=True, nonbondedMethod=app.PME, hydrogenMass=None, switch_width=DEFAULT_SWITCH_WIDTH, ewaldErrorTolerance=DEFAULT_EWALD_ERROR_TOLERANCE, **kwargs):
 
         TestSystem.__init__(self, **kwargs)
 
@@ -3281,7 +3287,7 @@ class HostGuestExplicit(TestSystem):
     ----------
     constraints : optional, default=simtk.openmm.app.HBonds
     rigid_water : bool, optional, default=True
-    nonbondedCutoff : Quantity, optional, default=9.0 * unit.angstroms
+    nonbondedCutoff : Quantity, optional, default=DEFAULT_CUTOFF_DISTANCE
     use_dispersion_correction : bool, optional, default=True
         If True, the long-range disperson correction will be used.
     nonbondedMethod : simtk.openmm.app nonbonded method, optional, default=app.PME
@@ -3289,10 +3295,10 @@ class HostGuestExplicit(TestSystem):
     hydrogenMass : unit, optional, default=None
         If set, will pass along a modified hydrogen mass for OpenMM to
         use mass repartitioning.
-    switch_width : simtk.unit.Quantity with units compatible with angstroms, optional, default=None
+    switch_width : simtk.unit.Quantity with units compatible with angstroms, optional, default=DEFAULT_SWITCH_WIDTH
         switching function is turned on at cutoff - switch_width
         If None, no switch will be applied (e.g. hard cutoff).
-    ewaldErrorTolerance : float, optional, default=5E-4
+    ewaldErrorTolerance : float, optional, default=DEFAULT_EWALD_ERROR_TOLERANCE
            The Ewald or PME tolerance.
 
     Examples
@@ -3302,7 +3308,7 @@ class HostGuestExplicit(TestSystem):
     >>> (system, positions) = testsystem.system, testsystem.positions
     """
 
-    def __init__(self, constraints=app.HBonds, rigid_water=True, nonbondedCutoff=9.0*unit.angstroms, use_dispersion_correction=True, nonbondedMethod=app.PME, hydrogenMass=None, switch_width=1.5*unit.angstroms, ewaldErrorTolerance=1.0e-6, **kwargs):
+    def __init__(self, constraints=app.HBonds, rigid_water=True, nonbondedCutoff=DEFAULT_CUTOFF_DISTANCE, use_dispersion_correction=True, nonbondedMethod=app.PME, hydrogenMass=None, switch_width=DEFAULT_SWITCH_WIDTH, ewaldErrorTolerance=DEFAULT_EWALD_ERROR_TOLERANCE, **kwargs):
 
         TestSystem.__init__(self, **kwargs)
 
@@ -3347,7 +3353,7 @@ class DHFRExplicit(TestSystem):
     ----------
     constraints : optional, default=simtk.openmm.app.HBonds
     rigid_water : bool, optional, default=True
-    nonbondedCutoff : Quantity, optional, default=8.0 * unit.angstroms
+    nonbondedCutoff : Quantity, optional, default=DEFAULT_CUTOFF_DISTANCE
     use_dispersion_correction : bool, optional, default=True
         If True, the long-range disperson correction will be used.
     nonbondedMethod : simtk.openmm.app nonbonded method, optional, default=app.PME
@@ -3355,10 +3361,10 @@ class DHFRExplicit(TestSystem):
     hydrogenMass : unit, optional, default=None
         If set, will pass along a modified hydrogen mass for OpenMM to
         use mass repartitioning.
-    switch_width : simtk.unit.Quantity with units compatible with angstroms, optional, default=None
+    switch_width : simtk.unit.Quantity with units compatible with angstroms, optional, default=DEFAULT_SWITCH_WIDTH
         switching function is turned on at cutoff - switch_width
         If None, no switch will be applied (e.g. hard cutoff).
-    ewaldErrorTolerance : float, optional, default=5E-4
+    ewaldErrorTolerance : float, optional, default=DEFAULT_EWALD_ERROR_TOLERANCE
            The Ewald or PME tolerance.
 
     Notes
@@ -3368,7 +3374,7 @@ class DHFRExplicit(TestSystem):
     hardware.  For modern GPUs, 0.95 nm may be a good place to start.
     """
 
-    def __init__(self, constraints=app.HBonds, rigid_water=True, nonbondedCutoff=8.0 * unit.angstroms, use_dispersion_correction=True, nonbondedMethod=app.PME, hydrogenMass=None, switch_width=None, ewaldErrorTolerance=5E-4, **kwargs):
+    def __init__(self, constraints=app.HBonds, rigid_water=True, nonbondedCutoff=DEFAULT_CUTOFF_DISTANCE, use_dispersion_correction=True, nonbondedMethod=app.PME, hydrogenMass=None, switch_width=DEFAULT_SWITCH_WIDTH, ewaldErrorTolerance=DEFAULT_EWALD_ERROR_TOLERANCE, **kwargs):
 
         TestSystem.__init__(self, **kwargs)
 
@@ -3506,7 +3512,7 @@ class SrcExplicit(TestSystem):
 
     """
 
-    def __init__(self, nonbondedMethod=app.PME, **kwargs):
+    def __init__(self, nonbondedMethod=app.PME, nonbondedCutoff=DEFAULT_CUTOFF_DISTANCE, switch_width=DEFAULT_SWITCH_WIDTH, ewaldErrorTolerance=DEFAULT_EWALD_ERROR_TOLERANCE, use_dispersion_correction=True, **kwargs):
 
         TestSystem.__init__(self, **kwargs)
 
@@ -3516,7 +3522,16 @@ class SrcExplicit(TestSystem):
         # Construct system.
         forcefields_to_use = ['amber99sbildn.xml', 'tip3p.xml']  # list of forcefields to use in parameterization
         forcefield = app.ForceField(*forcefields_to_use)
-        system = forcefield.createSystem(pdbfile.topology, nonbondedMethod=nonbondedMethod, constraints=app.HBonds)
+        system = forcefield.createSystem(pdbfile.topology, nonbondedMethod=nonbondedMethod, constraints=app.HBonds, 
+                                         ewaldErrorTolerance=ewaldErrorTolerance, nonbondedCutoff=nonbondedCutoff)
+
+        # Set dispersion correction use.
+        forces = {system.getForce(index).__class__.__name__: system.getForce(index) for index in range(system.getNumForces())}
+        forces['NonbondedForce'].setUseDispersionCorrection(use_dispersion_correction)
+
+        if switch_width is not None:
+            forces['NonbondedForce'].setUseSwitchingFunction(True)
+            forces['NonbondedForce'].setSwitchingDistance(nonbondedCutoff - switch_width)
 
         # Get positions.
         positions = pdbfile.getPositions()

--- a/setup.py
+++ b/setup.py
@@ -176,6 +176,9 @@ setup(
     zip_safe=False,
     scripts=[],
     ext_modules=extensions,
-    entry_points={'console_scripts': ['test-openmm-platforms = openmmtools.scripts.test_openmm_platforms:main']},
+    entry_points={'console_scripts': [
+        'test-openmm-platforms = openmmtools.scripts.test_openmm_platforms:main',
+        'benchmark-alchemy = openmmtools.tests.test_alchemy:benchmark_alchemy_from_pdb',
+        ]},
     )
 check_dependencies()


### PR DESCRIPTION
This PR adds a number of new features to `alchemy`, along with some useful updates to `testsystems` to help improve testing of electrostatics handling:

#### Unified defaults for `ewaldErrorTolerance`, `cutoff`, and `switch_width` for `testsystems`

Solvated protein test systems previously used a variety of different default parameters for `ewaldErrorTolerance`, `cutoff`, and `switch_width`, sometimes even relying on OpenMM defaults (which can give poor reweighting behavior). These systems now utilize a single global set of options defined at the top of `testsystems.py` with improved default parameters:
```python
DEFAULT_EWALD_ERROR_TOLERANCE = 1.0e-5 # default Ewald error tolerance
DEFAULT_CUTOFF_DISTANCE = 10.0 * unit.angstroms # default cutoff distance
DEFAULT_SWITCH_WIDTH = 1.5 * unit.angstroms # default switch width
```
This may benefit other projects as well, such as @maxentile's Langevin integrator benchmark.

#### Handling of alchemical region electrostatics for PME

The new `alchemical_pme_treatment` argument to `AlchemicalFactory` allows the user to select two different behaviors for how alchemical region electrostatics should be treated when the system uses PME:
* `direct-space` (default): Only the direct-space interactions, which behaves as `erfc(alpha*r)/r`, are included for interactions involving the alchemical region. This is the current behavior, and is retained as the default.
* `coulomb`: The standard Coulomb interaction, which behaves as `1/r`, is used for interactions involving the alchemical region. A switch is added to ensure force continuity. The switch width is controlled by the optional `switch_width` parameter.

After extensive testing with `TestAlchemicalFactorySlow.test_overlap()`, it appears that the current behavior (`direct-space`) has much lower energy stddev than `coulomb`, which is surprising to me. More study is needed, I imagine, but I am retaining the current behavior for now but leaving the new option is as an optional choice.

#### Handling of alchemical region electrostatics for reaction field (RF)

The new `alchemical_rf_treatment` argument to `AlchemicalFactory` allows the user to select two different behaviors for how alchemical region electrostatics should be treated when the system uses RF:
* `switched` (default): The `c_rf` parameter is set to zero in order to allow hydration free energies to be computed. Note that this also requires the fully-interacting version of the system has its reaction-field `NonbondedForce` replaced with `Custom*Force`s with `c_rf = 0` in a separate call, and that this modified version is used as the reference "fully-interacting system". The new function `AlchemicalFactory.replace_reaction_field()` can be used to do this, returning a new `System` object where this replacement has taken place, but the resulting `System` *cannot* be fed into `AlchemicalFactory.create_alchemical_system()`---the original `System` must be used for that purpose. The idiom is therefore:
```python
factory = AlchemicalFactory(alchemical_rf_treatment='switched')
# Create an alchemically-modified system with c_rf = 0
alchemical_system = factory.create_alchemical_system(reference_system, alchemical_region)
# Now create a replacement for reference_system with c_rf = 0 to use as my fully-interacting system
modified_reference_system = factory.replace_reaction_field(reference_system)
```
A switch is added to the new reaction-field `CustomNonbondedForce` to ensure smooth forces, and can be controlled by `switch_width`. Setting `switch_width = None` disables the switch.
Non-alchemical electrostatics terms are also moved into new `Custom*Force` terms appended to the end of `System`'s list of forces.
* `shifted`: The `c_rf` parameter is retained. This is the previous behavior, but is no longer the default.

This PR addresses #153.
