### PR TITLE
ExternalPerturbationLangevinIntegrator barostat fix

### DIFF
--- a/openmmtools/integrators.py
+++ b/openmmtools/integrators.py
@@ -1454,10 +1454,6 @@ class NonequilibriumLangevinIntegrator(LangevinIntegrator):
         Override the base class to insert reset steps around the integrator.
         """
 
-        # Integrate
-        self.addUpdateContextState()
-        self.addComputeTemperatureDependentConstants({"sigma": "sqrt(kT/m)"})
-
         #if the step is zero,
         self.beginIfBlock('step = 0')
         self.addConstrainPositions()
@@ -1576,9 +1572,6 @@ class ExternalPerturbationLangevinIntegrator(LangevinIntegrator):
         self.addComputeGlobal("protocol_work", "protocol_work + (perturbed_pe - unperturbed_pe)")
 
         # Computing context updates, such as from the barostat, _after_ computing protocol work.
-        self.addUpdateContextState()
-        self.addComputeTemperatureDependentConstants({"sigma": "sqrt(kT/m)"})
-
         super(ExternalPerturbationLangevinIntegrator, self).add_integrator_steps(splitting, measure_shadow_work, measure_heat, ORV_counts, force_group_nV, mts)
         self.addComputeGlobal("unperturbed_pe", "energy")
 

--- a/openmmtools/integrators.py
+++ b/openmmtools/integrators.py
@@ -954,10 +954,6 @@ class LangevinIntegrator(ThermostatedIntegrator):
             self.addPerDofVariable("vold", 0)
             self.addPerDofVariable("xold", 0)
 
-        # Integrate
-        self.addUpdateContextState()
-        self.addComputeTemperatureDependentConstants({"sigma": "sqrt(kT/m)"})
-
         self.add_integrator_steps(splitting, measure_shadow_work, measure_heat, ORV_counts, force_group_nV, mts)
 
     def add_integrator_steps(self, splitting, measure_shadow_work, measure_heat, ORV_counts, force_group_nV, mts):
@@ -978,6 +974,10 @@ class LangevinIntegrator(ThermostatedIntegrator):
         mts : bool
             Whether this integrator defines an MTS integrator
         """
+        # Integrate
+        self.addUpdateContextState()
+        self.addComputeTemperatureDependentConstants({"sigma": "sqrt(kT/m)"})
+
         for i, step in enumerate(splitting.split()):
             self.substep_function(step, measure_shadow_work, measure_heat, ORV_counts['R'], force_group_nV, mts)
 
@@ -1453,6 +1453,11 @@ class NonequilibriumLangevinIntegrator(LangevinIntegrator):
         """
         Override the base class to insert reset steps around the integrator.
         """
+
+        # Integrate
+        self.addUpdateContextState()
+        self.addComputeTemperatureDependentConstants({"sigma": "sqrt(kT/m)"})
+
         #if the step is zero,
         self.beginIfBlock('step = 0')
         self.addConstrainPositions()
@@ -1566,7 +1571,14 @@ class ExternalPerturbationLangevinIntegrator(LangevinIntegrator):
         self.addComputeGlobal("unperturbed_pe", "energy")
         self.addComputeGlobal("protocol_work", "0.0")
         self.endBlock()
+
+        # Calculate the protocol work
         self.addComputeGlobal("protocol_work", "protocol_work + (perturbed_pe - unperturbed_pe)")
+
+        # Computing context updates, such as from the barostat, _after_ computing protocol work.
+        self.addUpdateContextState()
+        self.addComputeTemperatureDependentConstants({"sigma": "sqrt(kT/m)"})
+
         super(ExternalPerturbationLangevinIntegrator, self).add_integrator_steps(splitting, measure_shadow_work, measure_heat, ORV_counts, force_group_nV, mts)
         self.addComputeGlobal("unperturbed_pe", "energy")
 

--- a/openmmtools/tests/test_integrators.py
+++ b/openmmtools/tests/test_integrators.py
@@ -280,6 +280,26 @@ class TestExternalPerturbationLangevinIntegrator(TestCase):
                 name = '%s %s %s' % (testsystem.name, nonbonded_method, platform_name)                
                 self.compare_external_protocol_work_accumulation(testsystem, parameter_name, parameter_initial, parameter_final, platform_name=platform_name, name=name)
 
+    def test_protocol_work_accumulation_waterbox_barostat(self):
+        """
+        Testing protocol work accumulation for ExternalPerturbationLangevinIntegrator with AlchemicalWaterBox
+        with an active barostat. For brevity, only using CutoffPeriodic as the non-bonded method.
+        """
+        from simtk.openmm import app
+        parameter_name = 'lambda_electrostatics'
+        parameter_initial = 1.0
+        parameter_final = 0.0
+        platform_names = [ openmm.Platform.getPlatform(index).getName() for index in range(openmm.Platform.getNumPlatforms()) ]
+        nonbonded_method = 'CutoffPeriodic'
+        testsystem = testsystems.AlchemicalWaterBox(nonbondedMethod=getattr(app, nonbonded_method))
+
+        # Adding the barostat with a high frequency
+        testsystem.system.addForce(openmm.MonteCarloBarostat(1*unit.atmospheres, 300*unit.kelvin, 2))
+
+        for platform_name in platform_names:
+            name = '%s %s %s' % (testsystem.name, nonbonded_method, platform_name)
+            self.compare_external_protocol_work_accumulation(testsystem, parameter_name, parameter_initial, parameter_final, platform_name=platform_name, name=name)
+
     def compare_external_protocol_work_accumulation(self, testsystem, parameter_name, parameter_initial, parameter_final, platform_name='Reference', name=None):
         """Compare external work accumulation between Reference and CPU platforms.
         """

--- a/openmmtools/tests/test_integrators.py
+++ b/openmmtools/tests/test_integrators.py
@@ -186,6 +186,27 @@ def test_integrator_decorators():
     assert integrator.acceptance_rate == 1.0
 
 
+def test_single_force_update():
+    """
+    Ensures that addUpdateContextState() is called only once for all custom integrators, except the
+    NonequilibriumLangevinIntegrator which requires an alchmical system.
+    """
+    custom_integrators = get_all_custom_integrators()
+    for integrator_name, integrator_class in custom_integrators:
+        # The NonequilibriumLangevinIntegrator requires an alchemical function.
+        if issubclass(integrator_class, integrators.NonequilibriumLangevinIntegrator):
+            integrator = integrator_class(alchemical_functions={})
+        else:
+            integrator = integrator_class()
+        num_force_update = 0
+        for i in range(integrator.getNumComputations()):
+            step_type, target, expr = integrator.getComputationStep(i)
+
+            if step_type == 5:
+                num_force_update += 1
+        assert num_force_update == 1
+
+
 def test_vvvr_shadow_work_accumulation():
     """When `measure_shadow_work==True`, assert that global `shadow_work` is initialized to zero and
     reaches a nonzero value after integrating a few dozen steps.

--- a/openmmtools/tests/test_integrators.py
+++ b/openmmtools/tests/test_integrators.py
@@ -160,10 +160,11 @@ def test_stabilities():
 
     for test_name, test in test_cases.items():
         for integrator_name, integrator_class in custom_integrators:
-            # Need an alchemical system to test this
+            # The NonequilibriumLangevinIntegrator requires an alchemical function.
             if issubclass(integrator_class, integrators.NonequilibriumLangevinIntegrator):
-                continue
-            integrator = integrator_class()
+                integrator = integrator_class(alchemical_functions={})
+            else:
+                integrator = integrator_class()
             integrator.__doc__ = integrator_name
             check_stability.description = ("Testing {} for stability over a short number of "
                                            "integration steps of a {}.").format(integrator_name, test_name)


### PR DESCRIPTION
Fix made to address Issue #173. This fix addresses the fact that a barostat, when present, was erroneously affecting the protocol work when calculated with the `ExternalPerturbationLangevinIntegrator`. The work-around was to move 
```
self.addUpdateContextState()
self.addComputeTemperatureDependentConstants({"sigma": "sqrt(kT/m)"})
````
to inside `add_integrator_steps()`. This makes it possible to separate the protocol work measurement from energy changes due to the barostat or the center of mass remover.