### PR TITLE
[WIP] Implement basic tagging system for testsystems

### DIFF
--- a/openmmtools/tests/test_testsystems.py
+++ b/openmmtools/tests/test_testsystems.py
@@ -85,6 +85,7 @@ def test_properties_all_testsystems():
         logging.info(f.description)
         yield f
 
+# TODO: Convert these to 'fast' tags within testsystems
 fast_testsystems = [
     "HarmonicOscillator",
     "PowerOscillator",
@@ -139,6 +140,17 @@ def check_potential_energy(system, positions):
     # Clean up
     del context, integrator
 
+def test_tags():
+    """Test that all testsystems have working tag property.
+    """
+    testsystem_classes = get_all_subclasses(testsystems.TestSystem)
+    for testsystem_class in testsystem_classes:
+        class_name = testsystem_class.__name__
+        testsystem = testsystem_class()
+        tags = testsystem.tags
+        assert(type(tags) == set)
+        # TODO: Later enforce that all testsystems have at least one tag.
+
 def test_energy_all_testsystems(skip_slow_tests=False):
     """Testing computation of potential energy for all systems.
     """
@@ -156,9 +168,12 @@ def test_energy_all_testsystems(skip_slow_tests=False):
             print(e)
             print("Skipping %s due to missing dependency" % class_name)
             continue
-        f = partial(check_potential_energy, testsystem.system, testsystem.positions)
-        f.description = "Testing potential energy for testsystem %s" % class_name
-        yield f
+
+        # Only test systems not marked as slow
+        if 'slow' not in testsystem.tags:
+            f = partial(check_potential_energy, testsystem.system, testsystem.positions)
+            f.description = "Testing potential energy for testsystem %s" % class_name
+            yield f
 
 def check_topology(system, topology):
     """Check the topology object contains the correct number of atoms.

--- a/openmmtools/testsystems.py
+++ b/openmmtools/testsystems.py
@@ -46,6 +46,7 @@ TODO
 
 import os
 import os.path
+import copy
 import numpy as np
 import numpy.random
 import itertools
@@ -416,6 +417,8 @@ class TestSystem(object):
         positions of test system
     topology : list
         topology of the test system
+    tags: set of str
+        Attributes that can be used to tag properties or categories of the test system.
 
     Notes
     -----
@@ -445,6 +448,10 @@ class TestSystem(object):
 
     >>> (system_xml, positions_xml) = testsystem.serialize()
 
+    Check if the test system has certain attributes.
+
+    >>> if 'slow' in testsystem.tags: print('system is slow to run')
+
     """
 
     def __init__(self, **kwargs):
@@ -463,6 +470,9 @@ class TestSystem(object):
 
         # Empty topology.
         self._topology = app.Topology()
+
+        # Set attributes
+        self._tags = set()
 
         return
 
@@ -504,6 +514,11 @@ class TestSystem(object):
     @topology.deleter
     def topology(self):
         del self._topology
+
+    @property
+    def tags(self):
+        """Attributes of the test system."""
+        return copy.deepcopy(self._tags)
 
     @property
     def analytical_properties(self):
@@ -3917,6 +3932,7 @@ class AMOEBAProteinBox(TestSystem):
 
     def __init__(self, **kwargs):
         TestSystem.__init__(self, **kwargs)
+        self._tags.add('slow')
 
         pdb_filename = get_data_filename("data/amoeba/1AP4_14_wat.pdb")
         pdbfile = app.PDBFile(pdb_filename)


### PR DESCRIPTION
Addresses #190 

This PR begins to implement a system where we can add keyword tags to each system to enable autodiscovery of testsystems that have useful properties, like are quick to run on travis (or too slow to run on travis).

Instead of having the initializer define the tags, it would be useful to be able to query this without having to actually construct the object, since that construction itself can be slow. I'm still trying to think of how best to tackle that.