### PR TITLE
Memory optimization for ThermodynamicState and reset velocities

### DIFF
--- a/openmmtools/cache.py
+++ b/openmmtools/cache.py
@@ -370,7 +370,7 @@ class ContextCache(object):
                 context = self._lru[matching_context_ids[0]]  # Return first found.
             else:
                 # We have to create a new Context. Use a likely-to-be-used Integrator.
-                integrator = integrators.GHMCIntegrator(temperature=thermodynamic_state.temperature)
+                integrator = integrators.GeodesicBAOABIntegrator(temperature=thermodynamic_state.temperature)
 
         if context is None:
             # Determine the Context id matching the pair state-integrator.

--- a/openmmtools/states.py
+++ b/openmmtools/states.py
@@ -16,6 +16,7 @@ Classes that represent a portion of the state of an OpenMM context.
 
 import abc
 import copy
+import weakref
 
 import numpy as np
 from simtk import openmm, unit
@@ -287,14 +288,14 @@ class ThermodynamicState(object):
         The returned system is a copy and can be modified without
         altering the internal state of ThermodynamicState. In order
         to ensure a consistent thermodynamic state, the system has
-        a Thermostat force. You can use get_system() to obtained a
+        a Thermostat force. You can use `get_system()` to obtain a
         copy of the system without the thermostat. The method
-        create_context then takes care of removing the thermostat
+        `create_context()` then takes care of removing the thermostat
         when an integrator with a coupled heat bath is used (e.g.
-        LangevinIntegrator).
+        `LangevinIntegrator`).
 
         It can be set only to a system which is consistent with the
-        current thermodynamic state. Use set_system() if you want to
+        current thermodynamic state. Use `set_system()` if you want to
         correct the thermodynamic state of the system automatically
         before assignment.
 
@@ -303,9 +304,6 @@ class ThermodynamicState(object):
         ThermodynamicState.get_system
         ThermodynamicState.set_system
         ThermodynamicState.create_context
-
-        Examples
-        --------
 
         """
         return self.get_system()
@@ -363,16 +361,9 @@ class ThermodynamicState(object):
         >>> state.set_system(alanine.system, fix_state=True)
 
         """
+        # Copy the system to avoid modifications during standardization.
         system = copy.deepcopy(system)
-        if fix_state:
-            self._set_system_thermostat(system, self.temperature)
-            barostat = self._set_system_pressure(system, self.pressure)
-            if barostat is not None:
-                self._set_barostat_temperature(barostat, self.temperature)
-        else:
-            self._check_system_consistency(system)
-        self._system = system
-        self._cached_standard_system_hash = None  # Invalidate cache.
+        self._unsafe_set_system(system, fix_state)
 
     def get_system(self, remove_thermostat=False, remove_barostat=False):
         """Manipulate and return the system.
@@ -419,33 +410,43 @@ class ThermodynamicState(object):
         []
 
         """
-        system = copy.deepcopy(self._system)
-        if remove_thermostat:
-            self._remove_thermostat(system)
+        system = copy.deepcopy(self._standard_system)
+
+        # Remove or configure standard pressure barostat.
         if remove_barostat:
             self._pop_barostat(system)
+        else:  # Set pressure of standard barostat.
+            self._set_system_pressure(system, self.pressure)
+
+        # Set temperature of standard thermostat and barostat.
+        if not (remove_barostat and remove_thermostat):
+            self._set_system_temperature(system, self.temperature)
+
+        # Remove or configure standard temperature thermostat.
+        if remove_thermostat:
+            self._remove_thermostat(system)
+
         return system
 
     @property
     def temperature(self):
         """Constant temperature of the thermodynamic state."""
-        return self._thermostat.getDefaultTemperature()
+        return self._temperature
 
     @temperature.setter
     def temperature(self, value):
         if value is None:
             raise ThermodynamicsError(ThermodynamicsError.NONE_TEMPERATURE)
-        self._set_system_thermostat(self._system, value)
-        barostat = self._barostat
-        if barostat is not None:
-            self._set_barostat_temperature(barostat, value)
+        self._temperature = value
 
     @property
     def kT(self):
+        """Thermal energy per mole."""
         return constants.kB * self.temperature
 
     @property
     def beta(self):
+        """Thermodynamic beta in units of mole/energy."""
         return 1.0 / self.kT
 
     @property
@@ -457,17 +458,22 @@ class ThermodynamicState(object):
         If it is set to None, the barostat will be removed.
 
         """
-        barostat = self._barostat
-        if barostat is None:
-            return None
-        return barostat.getDefaultPressure()
+        return self._pressure
 
     @pressure.setter
-    def pressure(self, value):
-        # Invalidate cache if the ensemble changes.
-        if (value is None) != (self._barostat is None):
-            self._cached_standard_system_hash = None
-        self._set_system_pressure(self._system, value)
+    def pressure(self, new_pressure):
+        old_pressure = self._pressure
+        self._pressure = new_pressure
+
+        # If we change ensemble, we need to modify the standard system.
+        if (new_pressure is None) != (old_pressure is None):
+            # The barostat will be removed/added since fix_state is True.
+            try:
+                self.set_system(self._standard_system, fix_state=True)
+            except ThermodynamicsError:
+                # Restore old pressure to keep object consistent.
+                self._pressure = old_pressure
+                raise
 
     @property
     def barostat(self):
@@ -482,50 +488,61 @@ class ThermodynamicState(object):
         this to None will place the system in an NVT ensemble.
 
         """
-        return copy.deepcopy(self._barostat)
+        # Retrieve the barostat with standard temperature/pressure, then
+        # set temperature and pressure to the thermodynamic state values.
+        barostat = copy.deepcopy(self._find_barostat(self._standard_system))
+        if barostat is not None:  # NPT ensemble.
+            self._set_barostat_pressure(barostat, self.pressure)
+            self._set_barostat_temperature(barostat, self.temperature)
+        return barostat
 
     @barostat.setter
-    def barostat(self, value):
-        if value is None:
-            # Reset the standard system hash only if we actually switch to NVT.
-            if self._pop_barostat(self._system) is not None:
-                self._cached_standard_system_hash = None
-        else:
-            old_barostat = self._pop_barostat(self._system)
-            new_barostat = copy.deepcopy(value)
-            self._system.addForce(new_barostat)
-            try:
-                self._check_internal_consistency()
-            except Exception as e:
-                # Restore old barostat to leave state consistent.
-                self.barostat = old_barostat
-                raise e
-            self._cached_standard_system_hash = None
+    def barostat(self, new_barostat):
+        # If None, just remove the barostat from the standard system.
+        if new_barostat is None:
+            self.pressure = None
+            return
+
+        # Remember old pressure in case something goes wrong.
+        old_pressure = self.pressure
+
+        # Build the system with the new barostat.
+        system = self.get_system(remove_barostat=True)
+        system.addForce(copy.deepcopy(new_barostat))
+
+        # Update the internally stored standard system, and restore the old
+        # pressure if something goes wrong (e.g. the system is not periodic).
+        try:
+            self._pressure = new_barostat.getDefaultPressure()
+            self._unsafe_set_system(system, fix_state=False)
+        except ThermodynamicsError:
+            self._pressure = old_pressure
+            raise
 
     @property
     def volume(self):
-        """Constant volume of the thermodynamic state.
+        """Constant volume of the thermodynamic state (read-only).
 
-        Read-only. If the volume is allowed to fluctuate, or if the
-        system is not in a periodic box this is None.
+        If the volume is allowed to fluctuate, or if the system is
+        not in a periodic box this is None.
 
         """
         if self.pressure is not None:  # Volume fluctuates.
             return None
-        if not self._system.usesPeriodicBoundaryConditions():
+        if not self._standard_system.usesPeriodicBoundaryConditions():
             return None
-        box_vectors = self._system.getDefaultPeriodicBoxVectors()
+        box_vectors = self._standard_system.getDefaultPeriodicBoxVectors()
         return _box_vectors_volume(box_vectors)
 
     @property
     def n_particles(self):
         """Number of particles (read-only)."""
-        return self._system.getNumParticles()
+        return self._standard_system.getNumParticles()
 
     @property
     def is_periodic(self):
         """True if the system is in a periodic box (read-only)."""
-        return self._system.usesPeriodicBoundaryConditions()
+        return self._standard_system.usesPeriodicBoundaryConditions()
 
     def reduced_potential(self, context_state):
         """Reduced potential in this thermodynamic state.
@@ -629,8 +646,8 @@ class ThermodynamicState(object):
         The property is symmetric and transitive.
 
         This is faster than checking compatibility of a Context object
-        through is_context_compatible since, and it should be preferred
-        when possible.
+        through is_context_compatible, and it should be preferred when
+        possible.
 
         Parameters
         ----------
@@ -703,7 +720,20 @@ class ThermodynamicState(object):
         ThermodynamicState.is_state_compatible
 
         """
-        context_system_hash = self._get_standard_system_hash(context.getSystem())
+        # Avoid modifying the context system during standardization.
+        context_system = copy.deepcopy(context.getSystem())
+        context_integrator = context.getIntegrator()
+
+        # If the temperature is controlled by the integrator, the compatibility
+        # is independent on the parameters of the thermostat, so we add one
+        # identical to self._standard_system. We don't care if the integrator's
+        # temperature != self.temperature, so we set check_consistency=False.
+        if self._is_integrator_thermostated(context_integrator, check_consistency=False):
+            thermostat = self._find_thermostat(self._standard_system)
+            context_system.addForce(copy.deepcopy(thermostat))
+
+        # Compute and compare standard system hash.
+        context_system_hash = self._standardize_and_hash(context_system)
         is_compatible = self._standard_system_hash == context_system_hash
         return is_compatible
 
@@ -776,12 +806,11 @@ class ThermodynamicState(object):
         # With CompoundIntegrator, at least one must be thermostated.
         is_thermostated = self._is_integrator_thermostated(integrator)
 
-        # If integrator is coupled to heat bath, remove system thermostat.
-        system = copy.deepcopy(self._system)
-        if is_thermostated:
-            self._remove_thermostat(system)
+        # Get a copy of the system. If integrator is coupled
+        # to heat bath, remove the system thermostat.
+        system = self.get_system(remove_thermostat=is_thermostated)
 
-        # Create platform.
+        # Create context.
         if platform is None:
             return openmm.Context(system, integrator)
         else:
@@ -836,7 +865,7 @@ class ThermodynamicState(object):
         # Apply pressure and temperature to barostat.
         barostat = self._find_barostat(system)
         if barostat is not None:
-            if self._barostat is None:
+            if self._pressure is None:
                 # The context is NPT but this is NVT.
                 raise ThermodynamicsError(ThermodynamicsError.INCOMPATIBLE_ENSEMBLE)
 
@@ -853,7 +882,7 @@ class ThermodynamicState(object):
                                                     getParameters=True)
                     context.reinitialize()
                     context.setState(openmm_state)
-        elif self._barostat is not None:
+        elif self._pressure is not None:
             # The context is NVT but this is NPT.
             raise ThermodynamicsError(ThermodynamicsError.INCOMPATIBLE_ENSEMBLE)
 
@@ -868,26 +897,51 @@ class ThermodynamicState(object):
             integrator = context.getIntegrator()
             self._set_integrator_temperature(integrator)
 
+    # -------------------------------------------------------------------------
+    # Magic methods
+    # -------------------------------------------------------------------------
+
+    def __copy__(self):
+        """Overwrite normal implementation to share standard system."""
+        cls = self.__class__
+        new_state = cls.__new__(cls)
+        new_state.__dict__.update({k: v for k, v in self.__dict__.items()
+                                   if k != '_standard_system'})
+        new_state.__dict__['_standard_system'] = self._standard_system
+        return new_state
+
+    def __deepcopy__(self, memo):
+        """Overwrite normal implementation to share standard system."""
+        cls = self.__class__
+        new_state = cls.__new__(cls)
+        memo[id(self)] = new_state
+        for k, v in self.__dict__.items():
+            if k != '_standard_system':
+                new_state.__dict__[k] = copy.deepcopy(v, memo)
+        new_state.__dict__['_standard_system'] = self._standard_system
+        return new_state
+
     def __getstate__(self):
         """Return a dictionary representation of the state."""
-        # We serialize the standardized system, with temperature and pressure.
-        # This way, if the user wants to store multiple compatible ThermodynamicStates
-        # it is possible to store only one system for all of them, greatly reducing
-        # the hard disk consumption.
-        standardized_system = copy.deepcopy(self._system)
-        self._standardize_system(standardized_system)
-        serialized_system = openmm.XmlSerializer.serialize(standardized_system)
-        # We might as well update the cached hash.
-        if self._cached_standard_system_hash is None:
-            self._cached_standard_system_hash = serialized_system.__hash__()
+        serialized_system = openmm.XmlSerializer.serialize(self._standard_system)
         return dict(standard_system=serialized_system, temperature=self.temperature,
                     pressure=self.pressure)
 
     def __setstate__(self, serialization):
         """Set the state from a dictionary representation."""
-        deserialized_system = openmm.XmlSerializer.deserialize(serialization['standard_system'])
-        self._initialize(deserialized_system, temperature=serialization['temperature'],
-                         pressure=serialization['pressure'])
+        self._temperature = serialization['temperature']
+        self._pressure = serialization['pressure']
+
+        serialized_system = serialization['standard_system']
+        self._standard_system_hash = serialized_system.__hash__()
+
+        # Check first if we have already the system in the cache.
+        try:
+            self._standard_system = self._standard_system_cache[self._standard_system_hash]
+        except KeyError:
+            system = openmm.XmlSerializer.deserialize(serialized_system)
+            self._standard_system_cache[self._standard_system_hash] = system
+            self._standard_system = system
 
     # -------------------------------------------------------------------------
     # Internal-usage: initialization
@@ -895,27 +949,33 @@ class ThermodynamicState(object):
 
     def _initialize(self, system, temperature=None, pressure=None):
         """Initialize the thermodynamic state."""
-        # The standard system hash is cached and computed on-demand.
-        self._cached_standard_system_hash = None
+        # Avoid modifying the original system when setting temperature and pressure.
+        system = copy.deepcopy(system)
 
-        # Do not modify original system.
-        self._system = copy.deepcopy(system)
+        # If pressure is None, we try to infer the pressure from the barostat.
+        barostat = self._find_barostat(system)
+        if pressure is None and barostat is not None:
+            self._pressure = barostat.getDefaultPressure()
+        else:
+            self._pressure = pressure  # Pressure here can also be None.
 
-        # If temperature is None, the user must specify a thermostat.
+        # If temperature is None, we infer the temperature from a thermostat.
         if temperature is None:
-            if self._thermostat is None:
+            thermostat = self._find_thermostat(system)
+            if thermostat is None:
                 raise ThermodynamicsError(ThermodynamicsError.NO_THERMOSTAT)
-            # Read temperature from thermostat and pass it to barostat.
-            temperature = self.temperature
+            self._temperature = thermostat.getDefaultTemperature()
+        else:
+            self._temperature = temperature
 
-        # Set thermostat and barostat temperature.
-        self.temperature = temperature
-
-        # Set barostat pressure.
+        # Fix system temperature/pressure if requested.
+        if temperature is not None:
+            self._set_system_temperature(system, temperature)
         if pressure is not None:
-            self.pressure = pressure
+            self._set_system_pressure(system, pressure)
 
-        self._check_internal_consistency()
+        # We can use the unsafe set_system since the system has been copied.
+        self._unsafe_set_system(system, fix_state=False)
 
     # -------------------------------------------------------------------------
     # Internal-usage: system handling
@@ -925,16 +985,41 @@ class ThermodynamicState(object):
     # just consistent between ThermodynamicStates to make comparison
     # of standard system hashes possible. We set this to round floats
     # and use OpenMM units to avoid funniness due to precision errors
-    # caused by periodic binary representation/unit conversion.
+    # caused by unit conversion.
     _STANDARD_PRESSURE = 1.0*unit.bar
     _STANDARD_TEMPERATURE = 273.0*unit.kelvin
 
     _NONPERIODIC_NONBONDED_METHODS = {openmm.NonbondedForce.NoCutoff,
                                       openmm.NonbondedForce.CutoffNonPeriodic}
 
-    def _check_internal_consistency(self):
-        """Shortcut self._check_system_consistency(self._system)."""
-        self._check_system_consistency(self._system)
+    # Shared cache of standard systems to minimize memory consumption
+    # when simulating a lot of thermodynamic states. The cache holds
+    # only weak references so ThermodynamicState objects must keep the
+    # system as an internal variable.
+    _standard_system_cache = weakref.WeakValueDictionary()
+
+    def _unsafe_set_system(self, system, fix_state):
+        """This implements self.set_system but modifies the passed system."""
+        # Configure temperature and pressure.
+        if fix_state:
+            # We just need to add/remove the barostat according to the ensemble.
+            # Temperature and pressure of thermostat and barostat will be set
+            # to their standard value afterwards.
+            self._set_system_pressure(system, self.pressure)
+        else:
+            # If the flag is deactivated, we check that temperature
+            # and pressure of the system are correct.
+            self._check_system_consistency(system)
+
+        # Standardize system and compute hash.
+        self._standard_system_hash = self._standardize_and_hash(system)
+
+        # Check if the standard system is already in the weakref cache.
+        try:
+            self._standard_system = self._standard_system_cache[self._standard_system_hash]
+        except KeyError:
+            self._standard_system_cache[self._standard_system_hash] = system
+            self._standard_system = system
 
     def _check_system_consistency(self, system):
         """Check system consistency with this ThermodynamicState.
@@ -969,7 +1054,7 @@ class ThermodynamicState(object):
                                          self.temperature):
             raise TE(TE.INCONSISTENT_THERMOSTAT)
 
-        # This raises MULTIPLE_BAROSTATS and UNSUPPORTED_BAROSTAT.
+        # This line raises MULTIPLE_BAROSTATS and UNSUPPORTED_BAROSTAT.
         barostat = self._find_barostat(system)
         if barostat is not None:
             if not self._is_barostat_consistent(barostat):
@@ -984,7 +1069,7 @@ class ThermodynamicState(object):
                     nonbonded_method = force.getNonbondedMethod()
                     if nonbonded_method in self._NONPERIODIC_NONBONDED_METHODS:
                         raise TE(TE.BAROSTATED_NONPERIODIC)
-        elif self._barostat is not None:
+        elif self.pressure is not None:
             raise TE(TE.NO_BAROSTAT)
 
     @classmethod
@@ -996,12 +1081,12 @@ class ThermodynamicState(object):
         standard systems, and is_state_compatible will return True if
         the (cached) serialization of the standard systems are identical.
 
-        Here, the standard system has the barostat pressure/temperature
-        set to _STANDARD_PRESSURE/TEMPERATURE (if a barostat exist), and
-        the thermostat removed (if it is present). Removing the thermostat
-        means that systems that will enforce a temperature through an
-        integrator coupled to a heat bath will be compatible as well. The
-        method apply_to_context then sets the parameters in the Context.
+        If no thermostat is present, an AndersenThermostat is added. The
+        presence of absence of a barostat determine whether this system is
+        in NPT or NVT ensemble. Pressure and temperature of barostat (if
+        any) and thermostat are set to _STANDARD_PRESSURE/TEMPERATURE.
+        If present, the barostat force is pushed at the end so that the
+        order of the two forces won't matter.
 
         Effectively this means that only same systems in the same ensemble
         (NPT or NVT) are compatible between each other.
@@ -1018,37 +1103,25 @@ class ThermodynamicState(object):
         ThermodynamicState.is_context_compatible
 
         """
-        cls._remove_thermostat(system)
-        barostat = cls._find_barostat(system)
+        # This adds a thermostat if it doesn't exist already. This way
+        # the comparison between system using thermostat with different
+        # parameters (e.g. collision frequency) will fail as expected.
+        cls._set_system_temperature(system, cls._STANDARD_TEMPERATURE)
+
+        # We need to be sure that thermostat and barostat always are
+        # in the same order, as the hash depends on the Forces order.
+        # Here we push the barostat at the end.
+        barostat = cls._pop_barostat(system)
         if barostat is not None:
             barostat.setDefaultPressure(cls._STANDARD_PRESSURE)
-            cls._set_barostat_temperature(barostat, cls._STANDARD_TEMPERATURE)
-
+            system.addForce(barostat)
 
     @classmethod
-    def _get_standard_system_hash(cls, system):
-        """Return the serialization hash of the standard system."""
-        standard_system = copy.deepcopy(system)
-        cls._standardize_system(standard_system)
-        system_serialization = openmm.XmlSerializer.serialize(standard_system)
+    def _standardize_and_hash(cls, system):
+        """Standardize the system and return its hash."""
+        cls._standardize_system(system)
+        system_serialization = openmm.XmlSerializer.serialize(system)
         return system_serialization.__hash__()
-
-    @property
-    def _standard_system_hash(self):
-        """Shortcut for _get_standard_system_hash(self._system).
-
-        This property is marked for internal usage since we may change
-        this system in the future, but ContextCache makes use of this
-        property too.
-
-        See Also
-        --------
-        cache.ContextCache._generate_context_id
-
-        """
-        if self._cached_standard_system_hash is None:
-            self._cached_standard_system_hash = self._get_standard_system_hash(self._system)
-        return self._cached_standard_system_hash
 
     # -------------------------------------------------------------------------
     # Internal-usage: integrator handling
@@ -1066,7 +1139,7 @@ class ThermodynamicState(object):
             integrators.ThermostatedIntegrator.restore_interface(integrator)
             yield integrator
 
-    def _is_integrator_thermostated(self, integrator):
+    def _is_integrator_thermostated(self, integrator, check_consistency=True):
         """True if integrator is coupled to a heat bath.
 
         If integrator is a CompoundIntegrator, it returns true if at least
@@ -1075,8 +1148,9 @@ class ThermodynamicState(object):
         Raises
         ------
         ThermodynamicsError
-            If integrator is couple to a heat bath at a different
-            temperature than this thermodynamic state.
+            If check_consistency is True and the integrator is
+            coupled to a heat bath at a different temperature
+            than this thermodynamic state.
 
         """
         # Loop over integrators to handle CompoundIntegrators.
@@ -1088,7 +1162,8 @@ class ThermodynamicState(object):
                 pass
             else:
                 # Raise exception if the heat bath is at the wrong temperature.
-                if not utils.is_quantity_close(temperature, self.temperature):
+                if (check_consistency and
+                        not utils.is_quantity_close(temperature, self.temperature)):
                     err_code = ThermodynamicsError.INCONSISTENT_INTEGRATOR
                     raise ThermodynamicsError(err_code)
                 is_thermostated = True
@@ -1102,38 +1177,24 @@ class ThermodynamicState(object):
         If integrator is a CompoundIntegrator, it sets the temperature
         of every sub-integrator.
 
-        Returns
-        -------
-        has_changed : bool
-            True if the integrator temperature has changed.
-
         """
         def set_temp(_integrator):
             try:
                 if not utils.is_quantity_close(_integrator.getTemperature(),
                                                self.temperature):
                     _integrator.setTemperature(self.temperature)
-                    return True
             except AttributeError:
                 pass
-            return False
 
         # Loop over integrators to handle CompoundIntegrators.
-        has_changed = False
         for _integrator in self._loop_over_integrators(integrator):
-            has_changed = has_changed or set_temp(_integrator)
-        return has_changed
+            set_temp(_integrator)
 
     # -------------------------------------------------------------------------
     # Internal-usage: barostat handling
     # -------------------------------------------------------------------------
 
     _SUPPORTED_BAROSTATS = {'MonteCarloBarostat'}
-
-    @property
-    def _barostat(self):
-        """Shortcut for self._find_barostat(self._system)."""
-        return self._find_barostat(self._system)
 
     @classmethod
     def _find_barostat(cls, system):
@@ -1170,7 +1231,9 @@ class ThermodynamicState(object):
         """
         barostat_id = cls._find_barostat_index(system)
         if barostat_id is not None:
-            barostat = system.getForce(barostat_id)
+            # We need to copy the barostat since we don't own
+            # its memory (i.e. we can't add it back to the system).
+            barostat = copy.deepcopy(system.getForce(barostat_id))
             system.removeForce(barostat_id)
             return barostat
         return None
@@ -1182,7 +1245,7 @@ class ThermodynamicState(object):
         Returns
         -------
         barostat_id : int
-            The index of the barostat force in self._system or None if
+            The index of the barostat force in system or None if
             no barostat is found.
 
         Raises
@@ -1225,12 +1288,6 @@ class ThermodynamicState(object):
             The pressure with units compatible to bars. If None, the
             barostat of the system is removed.
 
-        Returns
-        -------
-        barostat : OpenMM Force object or None
-            The current barostat of the system. None if the barostat
-            was removed.
-
         Raises
         ------
         ThermodynamicsError
@@ -1239,7 +1296,7 @@ class ThermodynamicState(object):
         """
         if pressure is None:  # If new pressure is None, remove barostat.
             self._pop_barostat(system)
-            return None
+            return
 
         if not system.usesPeriodicBoundaryConditions():
             raise ThermodynamicsError(ThermodynamicsError.BAROSTATED_NONPERIODIC)
@@ -1250,7 +1307,6 @@ class ThermodynamicState(object):
             system.addForce(barostat)
         else:  # Set existing barostat
             self._set_barostat_pressure(barostat, pressure)
-        return barostat
 
     @staticmethod
     def _set_barostat_pressure(barostat, pressure):
@@ -1296,11 +1352,6 @@ class ThermodynamicState(object):
     # Internal-usage: thermostat handling
     # -------------------------------------------------------------------------
 
-    @property
-    def _thermostat(self):
-        """Shortcut for self._find_thermostat(self._system)."""
-        return self._find_thermostat(self._system)
-
     @classmethod
     def _find_thermostat(cls, system):
         """Return the first thermostat in the system.
@@ -1328,8 +1379,6 @@ class ThermodynamicState(object):
         thermostat_id = cls._find_thermostat_index(system)
         if thermostat_id is not None:
             system.removeForce(thermostat_id)
-            return True
-        return False
 
     @staticmethod
     def _find_thermostat_index(system):
@@ -1342,46 +1391,31 @@ class ThermodynamicState(object):
             raise ThermodynamicsError(ThermodynamicsError.MULTIPLE_THERMOSTATS)
         return thermostat_ids[0]
 
-    def _is_thermostat_consistent(self, thermostat):
-        """Check thermostat temperature."""
-        return utils.is_quantity_close(thermostat.getDefaultTemperature(), self.temperature)
-
     @classmethod
-    def _set_system_thermostat(cls, system, temperature):
-        """Configure the system thermostat.
+    def _set_system_temperature(cls, system, temperature):
+        """Configure thermostat and barostat to the given temperature.
 
-        If temperature is None and the system has a thermostat, it is
-        removed. Otherwise the thermostat temperature is set, or a new
-        AndersenThermostat is added if it doesn't exist.
+        The thermostat temperature is set, or a new AndersenThermostat
+        is added if it doesn't exist.
 
         Parameters
         ----------
         system : simtk.openmm.System
             The system to modify.
-        temperature : simtk.unit.Quantity or None
-            The temperature for the thermostat, or None to remove it.
-
-        Returns
-        -------
-        has_changed : bool
-            True if the thermostat has changed, False if it was already
-            configured with the correct temperature.
+        temperature : simtk.unit.Quantity
+            The temperature for the thermostat.
 
         """
-        has_changed = False
-        if temperature is None:  # Remove thermostat.
-            has_changed = cls._remove_thermostat(system)
-        else:  # Add/configure existing thermostat.
-            thermostat = cls._find_thermostat(system)
-            if thermostat is None:
-                thermostat = openmm.AndersenThermostat(temperature, 1.0/unit.picosecond)
-                system.addForce(thermostat)
-                has_changed = True
-            elif not utils.is_quantity_close(thermostat.getDefaultTemperature(),
-                                             temperature):
-                thermostat.setDefaultTemperature(temperature)
-                has_changed = True
-        return has_changed
+        thermostat = cls._find_thermostat(system)
+        if thermostat is None:
+            thermostat = openmm.AndersenThermostat(temperature, 1.0/unit.picosecond)
+            system.addForce(thermostat)
+        else:
+            thermostat.setDefaultTemperature(temperature)
+
+        barostat = cls._find_barostat(system)
+        if barostat is not None:
+            cls._set_barostat_temperature(barostat, temperature)
 
 
 # =============================================================================
@@ -1953,6 +1987,34 @@ class CompoundThermodynamicState(ThermodynamicState):
     def __init__(self, thermodynamic_state, composable_states):
         self._initialize(thermodynamic_state, composable_states)
 
+    def get_system(self, **kwargs):
+        """Manipulate and return the system.
+
+        With default arguments, this is equivalent as the system property.
+        By setting the arguments it is possible to obtain a modified copy
+        of the system without the thermostat or the barostat.
+
+        Parameters
+        ----------
+        remove_thermostat : bool
+            If True, the system thermostat is removed.
+        remove_barostat : bool
+            If True, the system barostat is removed.
+
+        Returns
+        -------
+        system : simtk.openmm.System
+            The system of this ThermodynamicState.
+
+        """
+        system = super(CompoundThermodynamicState, self).get_system(**kwargs)
+
+        # The system returned by ThermodynamicState has standard parameters,
+        # so we need to set them to the actual value of the composable states.
+        for s in self._composable_states:
+            s.apply_to_system(system)
+        return system
+
     def set_system(self, system, fix_state=False):
         """Allow to set the system and fix its thermodynamic state.
 
@@ -1973,10 +2035,8 @@ class CompoundThermodynamicState(ThermodynamicState):
         ThermodynamicState.set_system
 
         """
-        for s in self._composable_states:
-            if fix_state is True:
-                s.apply_to_system(system)
-            else:
+        if fix_state is False:
+            for s in self._composable_states:
                 s.check_system_consistency(system)
         super(CompoundThermodynamicState, self).set_system(system, fix_state)
 
@@ -2019,25 +2079,13 @@ class CompoundThermodynamicState(ThermodynamicState):
             s.apply_to_context(context)
 
     def __getattr__(self, name):
-        def setter_decorator(func, composable_state):
-            def _setter_decorator(*args, **kwargs):
-                func(*args, **kwargs)
-                composable_state.apply_to_system(self._system)
-            return _setter_decorator
-
         # Called only if the attribute couldn't be found in __dict__.
         # In this case we fall back to composable state, in the given order.
         for s in self._composable_states:
             try:
-                attr = getattr(s, name)
+                return getattr(s, name)
             except AttributeError:
                 pass
-            else:
-                if name.startswith('set_'):
-                    # Decorate the setter so that apply_to_system is called
-                    # after the attribute is modified.
-                    attr = setter_decorator(attr, s)
-                return attr
 
         # Attribute not found, fall back to normal behavior.
         return super(CompoundThermodynamicState, self).__getattribute__(name)
@@ -2056,7 +2104,6 @@ class CompoundThermodynamicState(ThermodynamicState):
             for s in self._composable_states:
                 if any(name in C.__dict__ for C in s.__class__.__mro__):
                     s.__setattr__(name, value)
-                    s.apply_to_system(self._system)
                     return
 
             # No attribute found. This is monkey patching.
@@ -2107,13 +2154,14 @@ class CompoundThermodynamicState(ThermodynamicState):
                               {'_composable_bases': composable_bases})
         self.__dict__ = thermodynamic_state.__dict__
 
-        # Set the stored system to the given states. Setting
-        # self._composable_states signals __setattr__ to start
-        # searching in composable states as well, so this must
-        # be the last new attribute set in the constructor.
+        # Setting self._composable_states signals __setattr__ to start
+        # searching in composable states as well, so this must be the
+        # last new attribute set in the constructor.
         self._composable_states = composable_states
-        for s in self._composable_states:
-            s.apply_to_system(self._system)
+
+        # This call causes the thermodynamic state standard system
+        # to be standardized also w.r.t. all the composable states.
+        self.set_system(self._standard_system, fix_state=True)
 
     @classmethod
     def _standardize_system(cls, system):

--- a/openmmtools/states.py
+++ b/openmmtools/states.py
@@ -236,7 +236,7 @@ class ThermodynamicState(object):
     >>> pressure = 1.0*unit.atmosphere
     >>> state.pressure = pressure
     >>> state.pressure
-    Quantity(value=1.01325, unit=bar)
+    Quantity(value=1.0, unit=atmosphere)
     >>> state.volume is None
     True
 

--- a/openmmtools/tests/test_alchemy.py
+++ b/openmmtools/tests/test_alchemy.py
@@ -1557,16 +1557,8 @@ class TestAlchemicalState(object):
         test_cases = copy.deepcopy(self.test_cases)
 
         for state, defined_lambdas in test_cases:
-            undefined_lambdas = AlchemicalState._get_supported_parameters() - defined_lambdas
             alchemical_state = AlchemicalState.from_system(state.system)
             compound_state = states.CompoundThermodynamicState(state, [alchemical_state])
-
-            # Undefined properties raise an exception when assigned.
-            for parameter_name in undefined_lambdas:
-                assert getattr(compound_state, parameter_name) is None
-                with nose.tools.assert_raises(AlchemicalStateError):
-                    setattr(compound_state, parameter_name, 0.4)
-                setattr(compound_state, parameter_name, None)  # Keep state consistent.
 
             # Defined properties can be assigned and read.
             for parameter_name in defined_lambdas:

--- a/openmmtools/tests/test_states.py
+++ b/openmmtools/tests/test_states.py
@@ -15,6 +15,7 @@ Test State classes in states.py.
 
 import nose
 import pickle
+import operator
 
 from openmmtools import testsystems
 from openmmtools.states import *
@@ -124,6 +125,24 @@ class TestThermodynamicState(object):
         return [(False, verlet), (False, velocity_verlet), (False, compound_verlet),
                 (True, langevin), (True, ghmc), (True, custom_ghmc), (True, compound_ghmc)]
 
+    def test_single_instance_standard_system(self):
+        """ThermodynamicState should store only 1 System per compatible state."""
+        state_nvt_300 = ThermodynamicState(system=self.alanine_explicit, temperature=300*unit.kelvin)
+        state_nvt_350 = ThermodynamicState(system=self.alanine_explicit, temperature=350*unit.kelvin)
+        state_npt_1 = ThermodynamicState(system=self.alanine_explicit, pressure=1.0*unit.atmosphere)
+        state_npt_2 = ThermodynamicState(system=self.alanine_explicit, pressure=2.0*unit.atmosphere)
+        assert state_nvt_300._standard_system == state_nvt_350._standard_system
+        assert state_nvt_300._standard_system != state_npt_1._standard_system
+        assert state_npt_1._standard_system == state_npt_2._standard_system
+
+    def test_deepcopy(self):
+        """Test that copy/deepcopy doesn't generate a new System instance."""
+        state = ThermodynamicState(system=self.barostated_alanine)
+        copied_state = copy.copy(state)
+        deepcopied_state = copy.deepcopy(state)
+        assert state._standard_system == copied_state._standard_system
+        assert state._standard_system == deepcopied_state._standard_system
+
     def test_method_find_barostat(self):
         """ThermodynamicState._find_barostat() method."""
         barostat = ThermodynamicState._find_barostat(self.barostated_alanine)
@@ -168,17 +187,6 @@ class TestThermodynamicState(object):
         barostat = openmm.MonteCarloBarostat(pressure, temperature + 10*unit.kelvin)
         assert not state._is_barostat_consistent(barostat)
 
-    def test_method_is_thermostat_consistent(self):
-        """ThermodynamicState._is_thermostat_consistent() method."""
-        temperature = self.std_temperature
-        collision_freq = 1.0/unit.picosecond
-        state = ThermodynamicState(self.alanine_explicit, temperature)
-
-        thermostat = openmm.AndersenThermostat(temperature, collision_freq)
-        assert state._is_thermostat_consistent(thermostat)
-        thermostat.setDefaultTemperature(temperature + 1.0*unit.kelvin)
-        assert not state._is_thermostat_consistent(thermostat)
-
     def test_method_set_barostat_temperature(self):
         """ThermodynamicState._set_barostat_temperature() method."""
         barostat = openmm.MonteCarloBarostat(self.std_pressure, self.std_temperature)
@@ -188,26 +196,20 @@ class TestThermodynamicState(object):
         assert get_barostat_temperature(barostat) == new_temperature
         assert not ThermodynamicState._set_barostat_temperature(barostat, new_temperature)
 
-    def test_method_set_system_thermostat(self):
-        """ThermodynamicState._set_system_thermostat() method."""
+    def test_method_set_system_temperature(self):
+        """ThermodynamicState._set_system_temperature() method."""
         system = copy.deepcopy(self.alanine_no_thermostat)
         assert ThermodynamicState._find_thermostat(system) is None
 
         # Add a thermostat to the system.
-        assert ThermodynamicState._set_system_thermostat(system, self.std_temperature)
+        ThermodynamicState._set_system_temperature(system, self.std_temperature)
         thermostat = ThermodynamicState._find_thermostat(system)
         assert thermostat.getDefaultTemperature() == self.std_temperature
 
-        # Change temperature of existing barostat.
+        # Change temperature of thermostat and barostat.
         new_temperature = self.std_temperature + 1.0*unit.kelvin
-        assert ThermodynamicState._set_system_thermostat(system, new_temperature)
+        ThermodynamicState._set_system_temperature(system, new_temperature)
         assert thermostat.getDefaultTemperature() == new_temperature
-        assert not ThermodynamicState._set_system_thermostat(system, new_temperature)
-
-        # Remove system thermostat.
-        assert ThermodynamicState._set_system_thermostat(system, None)
-        assert ThermodynamicState._find_thermostat(system) is None
-        assert not ThermodynamicState._set_system_thermostat(system, None)
 
     def test_property_temperature(self):
         """ThermodynamicState.temperature property."""
@@ -218,7 +220,7 @@ class TestThermodynamicState(object):
         temperature = self.std_temperature + 10.0*unit.kelvin
         state.temperature = temperature
         assert state.temperature == temperature
-        assert get_barostat_temperature(state._barostat) == temperature
+        assert get_barostat_temperature(state.barostat) == temperature
 
         # Setting temperature to None raise error.
         with nose.tools.assert_raises(ThermodynamicsError) as cm:
@@ -228,10 +230,12 @@ class TestThermodynamicState(object):
     def test_method_set_system_pressure(self):
         """ThermodynamicState._set_system_pressure() method."""
         state = ThermodynamicState(self.alanine_explicit, self.std_temperature)
-        state._set_system_pressure(state._system, None)
-        assert state._barostat is None
-        state._set_system_pressure(state._system, self.std_pressure)
-        assert state._barostat.getDefaultPressure() == self.std_pressure
+        system = state.system
+        assert state._find_barostat(system) is None
+        state._set_system_pressure(system, self.std_pressure)
+        assert state._find_barostat(system).getDefaultPressure() == self.std_pressure
+        state._set_system_pressure(system, None)
+        assert state._find_barostat(system) is None
 
     def test_property_pressure_barostat(self):
         """ThermodynamicState.pressure and barostat properties."""
@@ -251,8 +255,12 @@ class TestThermodynamicState(object):
                 state.barostat = new_barostat
             assert cm.exception.code == ThermodynamicsError.BAROSTATED_NONPERIODIC
 
+            assert state.pressure is None
+            assert state.barostat is None
+
         # Correctly reads and set system pressures
         periodic_testcases = [self.alanine_explicit]
+        print('ON IT!')
         for system in periodic_testcases:
             state = ThermodynamicState(system, self.std_temperature)
             assert state.pressure is None
@@ -287,23 +295,12 @@ class TestThermodynamicState(object):
             assert state.pressure == self.std_pressure
 
             # Setting pressure to None removes barostat and viceversa.
-            # Changing ensemble also reset the cached system hash.
             state.pressure = None
-            state._standard_system_hash  # cause the system hash to be cached
             assert state.barostat is None
-            state.pressure = self.std_pressure
-            assert state._cached_standard_system_hash is None
-            state._standard_system_hash
-            state.pressure = None
-            assert state._cached_standard_system_hash is None
 
-            state._standard_system_hash
-            state.barostat = barostat
-            assert state._cached_standard_system_hash is None
-            state._standard_system_hash
+            state.pressure = self.std_pressure
             state.barostat = None
             assert state.pressure is None
-            assert state._cached_standard_system_hash is None
 
             # It is impossible to assign an unsupported barostat with incorrect temperature
             new_temperature = self.std_temperature + 10.0*unit.kelvin
@@ -378,8 +375,9 @@ class TestThermodynamicState(object):
         assert cm.exception.code == ThermodynamicsError.NO_THERMOSTAT
 
         state.set_system(system, fix_state=True)
-        assert state._thermostat.getDefaultTemperature() == self.std_temperature
-        assert state._barostat is None
+        thermostat = state._find_thermostat(state.system)
+        assert utils.is_quantity_close(thermostat.getDefaultTemperature(), self.std_temperature)
+        assert state.barostat is None
 
         # In NPT, we can't set the system without adding a barostat.
         system = state.system  # System with thermostat.
@@ -389,22 +387,24 @@ class TestThermodynamicState(object):
         assert cm.exception.code == ThermodynamicsError.NO_BAROSTAT
 
         state.set_system(system, fix_state=True)
-        assert state._barostat.getDefaultPressure() == self.std_pressure
-        assert get_barostat_temperature(state._barostat) == self.std_temperature
+        assert state.barostat.getDefaultPressure() == self.std_pressure
+        assert get_barostat_temperature(state.barostat) == self.std_temperature
 
     def test_method_get_system(self):
         """ThermodynamicState.get_system() method."""
-        state = ThermodynamicState(self.alanine_explicit, self.std_temperature,
-                                   self.std_pressure)
+        temperature = 400 * unit.kelvin
+        pressure = 10 * unit.bar
+        state = ThermodynamicState(self.alanine_explicit, temperature, pressure)
 
         # Normally a system has both barostat and thermostat
         system = state.get_system()
-        assert state._find_barostat(system) is not None
-        assert state._find_thermostat(system) is not None
+        assert state._find_barostat(system).getDefaultPressure() == pressure
+        assert state._find_thermostat(system).getDefaultTemperature() == temperature
 
         # We can request a system without thermostat or barostat.
         system = state.get_system(remove_thermostat=True)
         assert state._find_thermostat(system) is None
+        assert get_barostat_temperature(state._find_barostat(system)) == temperature
         system = state.get_system(remove_barostat=True)
         assert state._find_barostat(system) is None
 
@@ -427,17 +427,17 @@ class TestThermodynamicState(object):
 
         # If we don't specify pressure, no barostat is added
         state = ThermodynamicState(system=system, temperature=self.std_temperature)
-        assert state._barostat is None
+        assert state.barostat is None
 
         # If we specify pressure, barostat is added
         state = ThermodynamicState(system=system, temperature=self.std_temperature,
                                    pressure=self.std_pressure)
-        assert state._barostat is not None
+        assert state.barostat is not None
 
         # If we feed a barostat with an inconsistent temperature, it's fixed.
         state = ThermodynamicState(self.inconsistent_temperature_alanine,
                                    temperature=self.std_temperature)
-        assert state._is_barostat_consistent(state._barostat)
+        assert state._is_barostat_consistent(state.barostat)
 
         # If we feed a barostat with an inconsistent pressure, it's fixed.
         state = ThermodynamicState(self.inconsistent_pressure_alanine,
@@ -458,22 +458,24 @@ class TestThermodynamicState(object):
             ThermodynamicState(system=system)
         assert cm.exception.code == ThermodynamicsError.NO_THERMOSTAT
 
-        # With thermostat, temperature is inferred correctly,
-        # and the barostat temperature is set correctly as well.
-        system = copy.deepcopy(self.barostated_alanine)
+        # With thermostat, temperature is inferred correctly.
+        system = copy.deepcopy(self.alanine_explicit)
         new_temperature = self.std_temperature + 1.0*unit.kelvin
-        barostat = ThermodynamicState._find_barostat(system)
-        assert get_barostat_temperature(barostat) != new_temperature  # Precondition.
         thermostat = ThermodynamicState._find_thermostat(system)
         thermostat.setDefaultTemperature(new_temperature)
         state = ThermodynamicState(system=system)
         assert state.temperature == new_temperature
-        assert get_barostat_temperature(state._barostat) == new_temperature
+
+        # If barostat is inconsistent, an error is raised.
+        system.addForce(openmm.MonteCarloBarostat(self.std_pressure, self.std_temperature))
+        with nose.tools.assert_raises(ThermodynamicsError) as cm:
+            ThermodynamicState(system=system)
+        assert cm.exception.code == ThermodynamicsError.INCONSISTENT_BAROSTAT
 
         # Specifying temperature overwrite thermostat.
         state = ThermodynamicState(system=system, temperature=self.std_temperature)
         assert state.temperature == self.std_temperature
-        assert get_barostat_temperature(state._barostat) == self.std_temperature
+        assert get_barostat_temperature(state.barostat) == self.std_temperature
 
     def test_method_is_integrator_thermostated(self):
         """ThermodynamicState._is_integrator_thermostated method."""
@@ -504,41 +506,35 @@ class TestThermodynamicState(object):
 
         for thermostated, integrator in test_cases:
             if thermostated:
-                assert state._set_integrator_temperature(integrator)
+                state._set_integrator_temperature(integrator)
                 for _integrator in ThermodynamicState._loop_over_integrators(integrator):
                     try:
                         assert _integrator.getTemperature() == new_temperature
                     except AttributeError:  # handle CompoundIntegrator case
                         pass
-                assert not state._set_integrator_temperature(integrator)
             else:
                 # It doesn't explode with integrators not coupled to a heat bath
-                assert not state._set_integrator_temperature(integrator)
+                state._set_integrator_temperature(integrator)
 
     def test_method_standardize_system(self):
         """ThermodynamicState._standardize_system() class method."""
-        # Nothing happens if system has neither barostat nor thermostat.
-        nvt_system = copy.deepcopy(self.alanine_no_thermostat)
-        ThermodynamicState._standardize_system(nvt_system)
-        assert nvt_system.__getstate__() == self.alanine_no_thermostat.__getstate__()
+
+        def check_barostat_thermostat(_system, cmp_op):
+            barostat = ThermodynamicState._find_barostat(_system)
+            thermostat = ThermodynamicState._find_thermostat(_system)
+            assert cmp_op(barostat.getDefaultPressure(), self.std_pressure)
+            assert cmp_op(get_barostat_temperature(barostat), self.std_temperature)
+            assert cmp_op(thermostat.getDefaultTemperature(), self.std_temperature)
 
         # Create NPT system in non-standard state.
         npt_state = ThermodynamicState(self.inconsistent_pressure_alanine,
                                        self.std_temperature + 1.0*unit.kelvin)
-        barostat = npt_state._barostat
-        thermostat = npt_state._thermostat
-        assert barostat.getDefaultPressure() != self.std_pressure
-        assert get_barostat_temperature(barostat) != self.std_temperature
-        assert thermostat.getDefaultTemperature() != self.std_temperature
-
-        # With NPT system, the barostat is set to standard
-        # and the thermostat is removed.
         npt_system = npt_state.system
+        check_barostat_thermostat(npt_system, operator.ne)
+
+        # Standardize system sets pressure and temperature to standard.
         ThermodynamicState._standardize_system(npt_system)
-        barostat = ThermodynamicState._find_barostat(npt_system)
-        assert barostat.getDefaultPressure() == self.std_pressure
-        assert get_barostat_temperature(barostat) == self.std_temperature
-        assert ThermodynamicState._find_thermostat(npt_system) is None
+        check_barostat_thermostat(npt_system, operator.eq)
 
     def test_method_create_context(self):
         """ThermodynamicState.create_context() method."""
@@ -581,12 +577,15 @@ class TestThermodynamicState(object):
 
     def test_method_is_compatible(self):
         """ThermodynamicState context and state compatibility methods."""
+
         def check_compatibility(state1, state2, is_compatible):
+            """Check compatibility of contexts thermostated by force or integrator."""
             assert state1.is_state_compatible(state2) is is_compatible
             assert state2.is_state_compatible(state1) is is_compatible
             time_step = 1.0*unit.femtosecond
+            friction = 5.0/unit.picosecond
             integrator1 = openmm.VerletIntegrator(time_step)
-            integrator2 = openmm.VerletIntegrator(time_step)
+            integrator2 = openmm.LangevinIntegrator(state2.temperature, friction, time_step)
             context1 = state1.create_context(integrator1)
             context2 = state2.create_context(integrator2)
             assert state1.is_context_compatible(context2) is is_compatible
@@ -611,13 +610,6 @@ class TestThermodynamicState(object):
         barostated_alanine2 = copy.deepcopy(barostated_alanine)
         barostated_alanine2.pressure = barostated_alanine.pressure + 0.2*unit.bars
         check_compatibility(barostated_alanine, barostated_alanine2, True)
-
-        # If we change system/ensemble, cached values are updated correctly.
-        toluene_implicit.system = self.toluene_vacuum
-        check_compatibility(toluene_vacuum, toluene_implicit, True)
-
-        barostated_alanine2.pressure = None  # Switch to NVT.
-        check_compatibility(barostated_alanine, barostated_alanine2, False)
 
     def test_method_apply_to_context(self):
         """ThermodynamicState.apply_to_context() method."""
@@ -996,8 +988,9 @@ class TestCompoundThermodynamicState(object):
         new_temperature = self.std_temperature + 1.0*unit.kelvin
         compound_state.pressure = self.std_pressure
         compound_state.temperature = new_temperature
-        assert compound_state._barostat.getDefaultPressure() == self.std_pressure
-        assert compound_state._thermostat.getDefaultTemperature() == new_temperature
+        barostat = compound_state.barostat
+        assert barostat.getDefaultPressure() == self.std_pressure
+        assert get_barostat_temperature(barostat) == new_temperature
 
     def test_constructor_set_state(self):
         """IComposableState.set_state is called on construction."""
@@ -1052,21 +1045,21 @@ class TestCompoundThermodynamicState(object):
         thermodynamic_state.pressure = self.std_pressure + 1.0*unit.bar
         compound_state = CompoundThermodynamicState(thermodynamic_state, [self.dummy_state])
 
-        system = thermodynamic_state.system
+        # Standardizing the system fixes both ThermodynamicState and DummyState parameters.
+        system = compound_state.system
         barostat = ThermodynamicState._find_barostat(system)
         assert barostat.getDefaultPressure() != self.std_pressure
         assert self.get_dummy_parameter(system) == self.dummy_parameter
         compound_state._standardize_system(system)
+        barostat = ThermodynamicState._find_barostat(system)
         assert barostat.getDefaultPressure() == self.std_pressure
         assert self.get_dummy_parameter(system) == self.DummyState.standard_dummy_parameter
 
-        # We still haven't computed the ThermodynamicState system hash
-        # (pre-condition). Check that the standard system hash is correct.
-        assert thermodynamic_state._cached_standard_system_hash is None
+        # Check that the standard system hash is correct.
         standard_hash = openmm.XmlSerializer.serialize(system).__hash__()
         assert standard_hash == compound_state._standard_system_hash
 
-        # Check that is_state_compatible work.
+        # Check that is_state_compatible works.
         undummied_alanine = testsystems.AlanineDipeptideExplicit().system
         incompatible_state = ThermodynamicState(undummied_alanine, self.std_temperature)
         assert not compound_state.is_state_compatible(incompatible_state)

--- a/openmmtools/utils.py
+++ b/openmmtools/utils.py
@@ -428,7 +428,7 @@ def deserialize(serialization):
     module_name, class_name = names  # unpack
     module = importlib.import_module(module_name)
     cls = getattr(module, class_name)
-    instance = object.__new__(cls)
+    instance = cls.__new__(cls)
     try:
         instance.__setstate__(serialization)
     except AttributeError:


### PR DESCRIPTION
Ready for review.

- Memory optimization of system hold by `ThermodynamicState`.
  - `ThermodynamicState` now uses a `weakref` cache to keep in memory only one instance of standard system per compatible state.
  - Copy and deepcopy defaults have been overridden to avoid copying the internal system.
  - Deserialization has been optimized to avoid deserializing the system when possible and using the cache instead.
- Optimization of how we reassign velocities in `BaseIntegratorMove`.
  - I realized today (thanks to @maxentile) that the current approach to `setVelocitiesToTemperature` ended up setting the velocities twice: first with `SamplerState.apply_to_context()` and then with `setVelocitiesToTemperature()`. This adds a `reassign_velocities` argument in the constructor of `BaseIntegratorMove` and fixes the problem.
- Switch to gBAOAB as fallback integrator in `ContextCache` when the user doesn't care about the integrator and there are no cached `Context` in the given `ThermodynamicState`.