### PR TITLE
Revert integrator defaults to avoid costly bookkeeping

### DIFF
--- a/openmmtools/integrators.py
+++ b/openmmtools/integrators.py
@@ -943,7 +943,7 @@ class LangevinIntegrator(ThermostatedIntegrator):
                  splitting="V R O R V",
                  constraint_tolerance=1e-8,
                  measure_shadow_work=False,
-                 measure_heat=True,
+                 measure_heat=False,
                  ):
         """Create a Langevin integrator with the prescribed operator splitting.
 
@@ -972,7 +972,7 @@ class LangevinIntegrator(ThermostatedIntegrator):
         measure_shadow_work : boolean, default: False
             Accumulate the shadow work performed by the symplectic substeps, in the global `shadow_work`
 
-        measure_heat : boolean, default: True
+        measure_heat : boolean, default: False
             Accumulate the heat exchanged with the bath in each step, in the global `heat`
         """
 
@@ -1630,7 +1630,7 @@ class AlchemicalNonequilibriumLangevinIntegrator(NonequilibriumLangevinIntegrato
         measure_shadow_work : boolean, default: False
             Accumulate the shadow work performed by the symplectic substeps, in the global `shadow_work`
 
-        measure_heat : boolean, default: True
+        measure_heat : boolean, default: False
             Accumulate the heat exchanged with the bath in each step, in the global `heat`
 
         nsteps_neq : int, default: 100
@@ -1845,7 +1845,7 @@ class BAOABIntegrator(LangevinIntegrator):
         measure_shadow_work : boolean, default: False
             Accumulate the shadow work performed by the symplectic substeps, in the global `shadow_work`
 
-        measure_heat : boolean, default: True
+        measure_heat : boolean, default: False
             Accumulate the heat exchanged with the bath in each step, in the global `heat`
 
         References
@@ -1890,7 +1890,7 @@ class GeodesicBAOABIntegrator(LangevinIntegrator):
         measure_shadow_work : boolean, default: False
             Accumulate the shadow work performed by the symplectic substeps, in the global `shadow_work`
 
-        measure_heat : boolean, default: True
+        measure_heat : boolean, default: False
             Accumulate the heat exchanged with the bath in each step, in the global `heat`
 
         References

--- a/openmmtools/integrators.py
+++ b/openmmtools/integrators.py
@@ -1144,7 +1144,7 @@ class LangevinIntegrator(ThermostatedIntegrator):
            If dimensionless=True, the protocol work in kT (float).
            Otherwise, the unit-bearing protocol work in units of energy.
         """
-        if not self._measure_heat:
+        if not self._measure_work:
             raise Exception("This integrator must be constructed with 'measure_shadow_work=True' to measure shadow work.")
         return self._get_energy_with_units("shadow_work", dimensionless=dimensionless)
 

--- a/openmmtools/integrators.py
+++ b/openmmtools/integrators.py
@@ -1144,7 +1144,7 @@ class LangevinIntegrator(ThermostatedIntegrator):
            If dimensionless=True, the protocol work in kT (float).
            Otherwise, the unit-bearing protocol work in units of energy.
         """
-        if not self._measure_work:
+        if not self._measure_shadow_work:
             raise Exception("This integrator must be constructed with 'measure_shadow_work=True' to measure shadow work.")
         return self._get_energy_with_units("shadow_work", dimensionless=dimensionless)
 

--- a/openmmtools/tests/test_integrators.py
+++ b/openmmtools/tests/test_integrators.py
@@ -237,7 +237,6 @@ def test_vvvr_shadow_work_accumulation():
     integrator.step(25)
     assert(integrator.get_shadow_work(dimensionless=True) != 0), "integrator.get_shadow_work() should be nonzero after dynamics"
 
-    # test default (`measure_shadow_work=False`, `measure_heat=True`) --> absence of a global `shadow_work`
     integrator = integrators.VVVRIntegrator(temperature)
     context = openmm.Context(system, integrator)
     context.setPositions(testsystem.positions)
@@ -264,7 +263,6 @@ def test_baoab_heat_accumulation():
     integrator.step(25)
     assert(integrator.get_heat(dimensionless=True) != 0), "integrator.get_heat() should be nonzero after dynamics"
 
-    # test default (`measure_shadow_work=False`, `measure_heat=True`) --> absence of a global `shadow_work`
     integrator = integrators.VVVRIntegrator(temperature)
     context = openmm.Context(system, integrator)
     context.setPositions(testsystem.positions)
@@ -301,7 +299,6 @@ def test_external_protocol_work_accumulation():
     assert (integrator.protocol_work == (pe_2 - pe_1)), "The potential energy difference should be equal to protocol work."
     del context, integrator
 
-    # Test default (`measure_protocol_work=False`, `measure_heat=True`) --> absence of a global `protocol_work`
     integrator = integrators.VVVRIntegrator(temperature)
     context = openmm.Context(system, integrator)
     context.setPositions(testsystem.positions)


### PR DESCRIPTION
Addresses most of the performance drop mentioned in https://github.com/choderalab/openmmtools/issues/210 , by reverting the `measure_heat` default to `False`, as it was in v0.8.3., avoiding 3-4 unnecessary `addComputeSum`s per timestep.

A subsequent PR will eliminate redundant calls to `addConstrainVelocities`, addressing the remaining ~5% performance drop.