### PR TITLE
Added conda-forge as a channel requirement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ script:
   - conda config --add channels ${ORGNAME}
   # Add omnia dev channels
   - conda config --add channels https://conda.anaconda.org/omnia/label/dev
+  # Add conda-forge channel back to top priority
+  - conda config --add channels conda-forge
   # Build the recipe
   - conda build devtools/conda-recipe
   # Install the package
@@ -33,7 +35,6 @@ script:
 env:
   matrix:
     - python=2.7  CONDA_PY=27
-    - python=3.4  CONDA_PY=34
     - python=3.5  CONDA_PY=35
     - python=3.6  CONDA_PY=36
   global:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,6 +24,7 @@ install:
   - ps: . ".\\devtools\\appveyor\\install.ps1"
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
   - conda config --add channels http://conda.binstar.org/omnia
+  - conda config --add channels conda-forge
 
 build: false
 

--- a/devtools/travis-ci/install.sh
+++ b/devtools/travis-ci/install.sh
@@ -17,8 +17,7 @@ bash $MINICONDA -b -p $MINICONDA_HOME
 export PIP_ARGS="-U"
 export PATH=$MINICONDA_HOME/bin:$PATH
 conda config --add channels conda-forge
-conda update --yes conda\>=4.3
-conda install --yes conda-build jinja2 anaconda-client pip
+conda install --yes conda\>=4.3 conda-build jinja2 anaconda-client pip
 
 # Restore original directory
 popd

--- a/devtools/travis-ci/install.sh
+++ b/devtools/travis-ci/install.sh
@@ -16,8 +16,9 @@ bash $MINICONDA -b -p $MINICONDA_HOME
 # Configure miniconda
 export PIP_ARGS="-U"
 export PATH=$MINICONDA_HOME/bin:$PATH
+conda config --add channels conda-forge
 conda update --yes conda
-conda install --yes conda-build=2.1.5 jinja2 anaconda-client pip
+conda install --yes conda-build jinja2 anaconda-client pip
 
 # Restore original directory
 popd

--- a/devtools/travis-ci/install.sh
+++ b/devtools/travis-ci/install.sh
@@ -17,7 +17,7 @@ bash $MINICONDA -b -p $MINICONDA_HOME
 export PIP_ARGS="-U"
 export PATH=$MINICONDA_HOME/bin:$PATH
 conda config --add channels conda-forge
-conda update --yes conda
+conda update --yes conda\>=4.3
 conda install --yes conda-build jinja2 anaconda-client pip
 
 # Restore original directory

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -43,7 +43,7 @@ You can install the latest stable release build of openmmtools via the ``conda``
 
 .. code-block:: none
 
-   $ conda config --add channels omnia
+   $ conda config --add channels omnia --add channels conda-forge
    $ conda install openmmtools
 
 This version is recommended for all users not actively developing new algorithms for alchemical free energy calculations.
@@ -59,7 +59,7 @@ The bleeding-edge, absolute latest, very likely unstable development build of op
 
 .. code-block:: bash
 
-   $ conda config --add channels omnia
+   $ conda config --add channels omnia --add channels conda-forge
    $ conda install openmmtools-dev
 
 .. warning:: Development builds may be unstable and are generally subjected to less testing than releases.  Use at your own risk!


### PR DESCRIPTION
- Adds `conda-forge` as channel for testing
- Updates install documentation
- Drops Python 3.4 support

Pre-requisite to #135