### PR TITLE
Add option to AbsoluteAlchemicalFactory to disable long-range dispersion correction for alchemical region

### DIFF
--- a/openmmtools/alchemy.py
+++ b/openmmtools/alchemy.py
@@ -1545,7 +1545,7 @@ class AbsoluteAlchemicalFactory(object):
             force.setUseSwitchingFunction(nonbonded_force.getUseSwitchingFunction())
             force.setCutoffDistance(nonbonded_force.getCutoffDistance())
             force.setSwitchingDistance(nonbonded_force.getSwitchingDistance())
-            if (self.disable_alchemical_dispersion_correction is True):
+            if self.disable_alchemical_dispersion_correction:
                 force.setUseLongRangeCorrection(False)
             else:
                 force.setUseLongRangeCorrection(nonbonded_force.getUseDispersionCorrection())

--- a/openmmtools/tests/test_alchemy.py
+++ b/openmmtools/tests/test_alchemy.py
@@ -1307,15 +1307,12 @@ class TestDispersionlessAlchemicalFactory(object):
         cls.test_systems = dict()
         cls.test_systems['LennardJonesFluid with dispersion correction'] = \
             testsystems.LennardJonesFluid(nparticles=100, dispersion_correction=True)
-        cls.test_systems['WaterBox with PME, switch, dispersion correction'] = \
-            testsystems.WaterBox(dispersion_correction=True, switch=True, nonbondedMethod=openmm.app.PME)
 
     @classmethod
     def define_regions(cls):
         """Create shared AlchemicalRegions for test systems in cls.test_regions."""
         cls.test_regions = dict()
         cls.test_regions['LennardJonesFluid'] = AlchemicalRegion(alchemical_atoms=range(10))
-        cls.test_regions['WaterBox'] = AlchemicalRegion(alchemical_atoms=range(3))
 
     @classmethod
     def generate_cases(cls):

--- a/openmmtools/tests/test_alchemy.py
+++ b/openmmtools/tests/test_alchemy.py
@@ -1289,6 +1289,79 @@ class TestAbsoluteAlchemicalFactory(object):
             f.description = "Testing reference/alchemical overlap for {}".format(test_name)
             yield f
 
+class TestDispersionlessAlchemicalFactory(object):
+    """
+    Only test overlap for dispersionless alchemical factory, since energy agreement
+    will be poor.
+    """
+    @classmethod
+    def setup_class(cls):
+        """Create test systems and shared objects."""
+        cls.define_systems()
+        cls.define_regions()
+        cls.generate_cases()
+
+    @classmethod
+    def define_systems(cls):
+        """Create test systems and shared objects."""
+        cls.test_systems = dict()
+        cls.test_systems['LennardJonesFluid with dispersion correction'] = \
+            testsystems.LennardJonesFluid(nparticles=100, dispersion_correction=True)
+        cls.test_systems['WaterBox with PME, switch, dispersion correction'] = \
+            testsystems.WaterBox(dispersion_correction=True, switch=True, nonbondedMethod=openmm.app.PME)
+
+    @classmethod
+    def define_regions(cls):
+        """Create shared AlchemicalRegions for test systems in cls.test_regions."""
+        cls.test_regions = dict()
+        cls.test_regions['LennardJonesFluid'] = AlchemicalRegion(alchemical_atoms=range(10))
+        cls.test_regions['WaterBox'] = AlchemicalRegion(alchemical_atoms=range(3))
+
+    @classmethod
+    def generate_cases(cls):
+        """Generate all test cases in cls.test_cases combinatorially."""
+        cls.test_cases = dict()
+        factory = AbsoluteAlchemicalFactory(disable_alchemical_dispersion_correction=True)
+
+        # We generate all possible combinations of annihilate_sterics/electrostatics
+        # for each test system. We also annihilate bonds, angles and torsions every
+        # 3 test cases so that we test it at least one for each test system and for
+        # each combination of annihilate_sterics/electrostatics.
+        n_test_cases = 0
+        for test_system_name, test_system in cls.test_systems.items():
+
+            # Find standard alchemical region.
+            for region_name, region in cls.test_regions.items():
+                if region_name in test_system_name:
+                    break
+            assert region_name in test_system_name
+
+            # Create all combinations of annihilate_sterics.
+            for annihilate_sterics in itertools.product((True, False), repeat=1):
+                region = region._replace(annihilate_sterics=annihilate_sterics,
+                                         annihilate_electrostatics=True)
+
+                # Create test name.
+                test_case_name = test_system_name[:]
+                if annihilate_sterics:
+                    test_case_name += ', annihilated sterics'
+
+                # Pre-generate alchemical system
+                alchemical_system = factory.create_alchemical_system(test_system.system, region)
+                cls.test_cases[test_case_name] = (test_system, alchemical_system, region)
+
+                n_test_cases += 1
+
+    def test_overlap(self):
+        """Tests overlap between reference and alchemical systems."""
+        for test_name, (test_system, alchemical_system, alchemical_region) in self.test_cases.items():
+            #cached_trajectory_filename = os.path.join(os.environ['HOME'], '.cache', 'alchemy', 'tests',
+            #                                           test_name + '.pickle')
+            cached_trajectory_filename = None
+            f = partial(overlap_check, test_system.system, alchemical_system, test_system.positions,
+                        cached_trajectory_filename=cached_trajectory_filename, name=test_name)
+            f.description = "Testing reference/alchemical overlap for no alchemical dispersion {}".format(test_name)
+            yield f
 
 @attr('slow')
 class TestAbsoluteAlchemicalFactorySlow(TestAbsoluteAlchemicalFactory):


### PR DESCRIPTION
Addresses #217 

This PR adds the option `disable_alchemical_dispersion_correction` to `AbsoluteAlchemicalFactory`. If set to `True`, it will override the dispersion correction for the alchemical region, forcing it off. This is important when speed is desired for nonequilibrium switching where `lambda_sterics` is changing frequently; otherwise, if the long-range dispersion correction is active, the dispersion correction will be recomputed on the CPU every time `lambda_sterics` is altered, incurring a ~0.5 s overhead/timestep, potentially slowing things down by 100x.

Example:
```python
new_factory = AbsoluteAlchemicalFactory(consistent_exceptions=False, disable_alchemical_dispersion_correction=True)
reference_system = testsystems.WaterBox().system
alchemical_region = AlchemicalRegion(alchemical_atoms=[0, 1, 2])
alchemical_system = new_factory.create_alchemical_system(reference_system, alchemical_region)
```

An overlap test is added to ensure that a water box and LJ fluid retain good overlap with their unmodified systems when this option is in use. We can't test energy differences because disabling the dispersion correction for some atoms introduces a non-constant additive term.