### PR TITLE
Compress serialized state strings

### DIFF
--- a/openmmtools/states.py
+++ b/openmmtools/states.py
@@ -952,14 +952,14 @@ class ThermodynamicState(object):
         self._pressure = serialization['pressure']
 
         serialized_system = serialization['standard_system']
+        # Decompress system
+        serialized_system = zlib.decompress(serialized_system).decode(self._ENCODING)
         self._standard_system_hash = serialized_system.__hash__()
 
         # Check first if we have already the system in the cache.
         try:
             self._standard_system = self._standard_system_cache[self._standard_system_hash]
         except KeyError:
-            # Decompress system
-            serialized_system = zlib.decompress(serialized_system).decode(self._ENCODING)
             system = openmm.XmlSerializer.deserialize(serialized_system)
             self._standard_system_cache[self._standard_system_hash] = system
             self._standard_system = system
@@ -1142,8 +1142,6 @@ class ThermodynamicState(object):
         """Standardize the system and return its hash."""
         cls._standardize_system(system)
         system_serialization = openmm.XmlSerializer.serialize(system)
-        # Compress
-        system_serialization = zlib.compress(system_serialization.encode(cls._ENCODING))
         return system_serialization.__hash__()
 
     # -------------------------------------------------------------------------

--- a/openmmtools/states.py
+++ b/openmmtools/states.py
@@ -952,8 +952,14 @@ class ThermodynamicState(object):
         self._pressure = serialization['pressure']
 
         serialized_system = serialization['standard_system']
-        # Decompress system
-        serialized_system = zlib.decompress(serialized_system).decode(self._ENCODING)
+        # Decompress system, if need be
+        try:
+            serialized_system = zlib.decompress(serialized_system).decode(self._ENCODING)
+        except (TypeError, zlib.error):  # Py3/2 throws different error types
+            # Catch the "serialization is not compressed" error, do nothing to string.
+            # Preserves backwards compatibility
+            pass
+
         self._standard_system_hash = serialized_system.__hash__()
 
         # Check first if we have already the system in the cache.

--- a/openmmtools/tests/test_alchemy.py
+++ b/openmmtools/tests/test_alchemy.py
@@ -18,6 +18,7 @@ from __future__ import print_function
 
 import os
 import sys
+import zlib
 import pickle
 import itertools
 from functools import partial
@@ -1732,6 +1733,9 @@ class TestAlchemicalState(object):
         # The serialized system is standard.
         serialization = utils.serialize(compound_state)
         serialized_standard_system = serialization['thermodynamic_state']['standard_system']
+        # Decompress the serialized_system
+        serialized_standard_system = zlib.decompress(serialized_standard_system).decode(
+            states.ThermodynamicState._ENCODING)
         assert serialized_standard_system.__hash__() == compound_state._standard_system_hash
 
         # The object is deserialized correctly.

--- a/openmmtools/tests/test_states.py
+++ b/openmmtools/tests/test_states.py
@@ -1111,8 +1111,12 @@ def test_states_serialization():
 
 def test_backwards_serialization_compression_compatibility():
     test_system = testsystems.AlanineDipeptideImplicit()
-    state = ThermodynamicState(test_system.system, temperature=300 * unit.kelvin)
-    uncompressed_system_serialization = openmm.XmlSerializer.serialize(test_system.system)
+    system = test_system.system
+    state = ThermodynamicState(system, temperature=300 * unit.kelvin)
+    new_system = state.system
+    # Cast the system to a standard system
+    state._standardize_system(new_system)
+    uncompressed_system_serialization = openmm.XmlSerializer.serialize(new_system)
     compressed_serialization = utils.serialize(state)
     replaced_serialization = copy.deepcopy(compressed_serialization)
     replaced_serialization['standard_system'] = uncompressed_system_serialization

--- a/openmmtools/tests/test_states.py
+++ b/openmmtools/tests/test_states.py
@@ -14,6 +14,7 @@ Test State classes in states.py.
 # =============================================================================
 
 import nose
+import zlib
 import pickle
 import operator
 
@@ -1056,7 +1057,10 @@ class TestCompoundThermodynamicState(object):
         assert self.get_dummy_parameter(system) == self.DummyState.standard_dummy_parameter
 
         # Check that the standard system hash is correct.
-        standard_hash = openmm.XmlSerializer.serialize(system).__hash__()
+        standard_hash = zlib.compress(
+            openmm.XmlSerializer.serialize(system).encode(
+                ThermodynamicState._ENCODING)
+            ).__hash__()
         assert standard_hash == compound_state._standard_system_hash
 
         # Check that is_state_compatible works.

--- a/openmmtools/tests/test_states.py
+++ b/openmmtools/tests/test_states.py
@@ -14,7 +14,6 @@ Test State classes in states.py.
 # =============================================================================
 
 import nose
-import zlib
 import pickle
 import operator
 
@@ -1057,10 +1056,7 @@ class TestCompoundThermodynamicState(object):
         assert self.get_dummy_parameter(system) == self.DummyState.standard_dummy_parameter
 
         # Check that the standard system hash is correct.
-        standard_hash = zlib.compress(
-            openmm.XmlSerializer.serialize(system).encode(
-                ThermodynamicState._ENCODING)
-            ).__hash__()
+        standard_hash = openmm.XmlSerializer.serialize(system).__hash__()
         assert standard_hash == compound_state._standard_system_hash
 
         # Check that is_state_compatible works.

--- a/openmmtools/tests/test_states.py
+++ b/openmmtools/tests/test_states.py
@@ -1107,3 +1107,16 @@ def test_states_serialization():
         original_pickle = pickle.dumps(test_state)
         deserialized_pickle = pickle.dumps(deserialized_state)
         assert original_pickle == deserialized_pickle
+
+
+def test_backwards_serialization_compression_compatibility():
+    system = testsystems.AlanineDipeptideImplicit()
+    state = ThermodynamicState(system.system, temperature=300 * unit.kelvin)
+    uncompressed_system_serialization = openmm.XmlSerializer.serialize(system)
+    compressed_serialization = utils.serialize(state)
+    replaced_serialization = copy.deepcopy(compressed_serialization)
+    replaced_serialization['standard_system'] = uncompressed_system_serialization
+    replaced_state = utils.deserialize(replaced_serialization)
+    assert state.is_state_compatible(replaced_state)
+    assert utils.serialize(replaced_state)['standard_system'] == compressed_serialization['standard_system']
+

--- a/openmmtools/tests/test_states.py
+++ b/openmmtools/tests/test_states.py
@@ -1110,9 +1110,9 @@ def test_states_serialization():
 
 
 def test_backwards_serialization_compression_compatibility():
-    system = testsystems.AlanineDipeptideImplicit()
-    state = ThermodynamicState(system.system, temperature=300 * unit.kelvin)
-    uncompressed_system_serialization = openmm.XmlSerializer.serialize(system)
+    test_system = testsystems.AlanineDipeptideImplicit()
+    state = ThermodynamicState(test_system.system, temperature=300 * unit.kelvin)
+    uncompressed_system_serialization = openmm.XmlSerializer.serialize(test_system.system)
     compressed_serialization = utils.serialize(state)
     replaced_serialization = copy.deepcopy(compressed_serialization)
     replaced_serialization['standard_system'] = uncompressed_system_serialization


### PR DESCRIPTION
This PR makes all serialized systems compressed strings under a default encoding to save space when saved on disk, and space in memory. Small amount of overhead added (< 5 seconds) for compression action.

@andrrizzi did I miss anyplace to check for the compression?

Progress towards choderalab/yank#702