### PR TITLE
ContextCache bugfix and optimization

### DIFF
--- a/openmmtools/cache.py
+++ b/openmmtools/cache.py
@@ -552,7 +552,7 @@ class DummyContextCache(object):
 # GLOBAL CONTEXT CACHE
 # =============================================================================
 
-global_context_cache = ContextCache(capacity=3, time_to_live=50)
+global_context_cache = ContextCache(capacity=None, time_to_live=None)
 
 
 # =============================================================================

--- a/openmmtools/cache.py
+++ b/openmmtools/cache.py
@@ -427,8 +427,8 @@ class ContextCache(object):
 
         """
         # Restore temperature getter/setter before copying attributes.
-        integrators.ThermostatedIntegrator.restore_interface(integrator)
-        integrators.ThermostatedIntegrator.restore_interface(copied_integrator)
+        integrators.RestorableIntegrator.restore_interface(integrator)
+        integrators.RestorableIntegrator.restore_interface(copied_integrator)
 
         for attribute in cls._COMPATIBLE_INTEGRATOR_ATTRIBUTES:
             try:
@@ -447,6 +447,7 @@ class ContextCache(object):
 
         """
         standard_integrator = copy.deepcopy(integrator)
+        integrators.RestorableIntegrator.restore_interface(standard_integrator)
         for attribute, std_value in cls._COMPATIBLE_INTEGRATOR_ATTRIBUTES.items():
             try:
                 getattr(standard_integrator, 'set' + attribute)(std_value)

--- a/openmmtools/tests/test_cache.py
+++ b/openmmtools/tests/test_cache.py
@@ -124,14 +124,32 @@ def test_lru_cache_capacity_property():
 
 def test_lru_cache_time_to_live_property():
     """Decreasing the time to live updates the expiration of elements."""
-    cache = LRUCache(time_to_live=50)
-    for i in range(4):
-        cache[str(i)] = i
+    def add_4_elements(_cache):
+        for i in range(4):
+            _cache[str(i)] = i
+
+    cache = LRUCache(time_to_live=None)
+    add_4_elements(cache)
     assert len(cache) == 4
+
+    # Setting time to live to 1 cause all 4 entries to expire on next access.
     cache.time_to_live = 1
-    assert len(cache) == 1
+    assert len(cache) == 4
     assert cache.time_to_live == 1
-    assert '3' in cache
+    cache['4'] = 4
+    assert len(cache) == 1
+    assert '4' in cache
+
+    # Increase time_to_live.
+    cache.time_to_live = 2
+    add_4_elements(cache)
+    assert len(cache) == 2
+    assert '2' in cache and '3' in cache
+
+    # Setting it back to None makes it limitless.
+    cache.time_to_live = None
+    add_4_elements(cache)
+    assert len(cache) == 4
 
 
 # =============================================================================


### PR DESCRIPTION
Should be ready for review.

In this PR:
- Fix #231: Context cache failure to access `set*`.
  - The problem was in the creation of the integrator hashes. The integrator was copied for standardization, but the interface was not restored, so things like temperature were not set correctly (tagging @pgrinaway ).
- Fix #233: ContextCache should prefer non-default Contexts when integrator is not specified.
  - When no integrator is required and there are multiple `Context`s with compatible thermodynamic state, `ContextCache` now always picks a `Context` with the non-default integrator. This should avoid keeping around an extra `Context` that is not used.
- The default global context cache now has no capacity limit. Until #234 is implemented, the user will have to manually configure it.