### PR TITLE
Use less expensive testsystem in a slow Travis test

### DIFF
--- a/openmmtools/tests/test_integrators.py
+++ b/openmmtools/tests/test_integrators.py
@@ -391,7 +391,6 @@ class TestExternalPerturbationLangevinIntegrator(TestCase):
 
         # Creating the test system with a high frequency barostat.
         testsystem = testsystems.AlchemicalAlanineDipeptide(nonbondedMethod=getattr(app, nonbonded_method))
-        testsystem.system.addForce(openmm.MonteCarloBarostat(1 * unit.atmospheres, temperature, 2))
         context, integrator = self.create_system(testsystem, parameter_name, parameter_initial, temperature, platform_name)
 
         # Number of NCMC steps

--- a/openmmtools/tests/test_integrators.py
+++ b/openmmtools/tests/test_integrators.py
@@ -390,7 +390,7 @@ class TestExternalPerturbationLangevinIntegrator(TestCase):
         nonbonded_method = 'CutoffPeriodic'
 
         # Creating the test system with a high frequency barostat.
-        testsystem = testsystems.AlchemicalWaterBox(nonbondedMethod=getattr(app, nonbonded_method))
+        testsystem = testsystems.AlchemicalAlanineDipeptide(nonbondedMethod=getattr(app, nonbonded_method))
         testsystem.system.addForce(openmm.MonteCarloBarostat(1 * unit.atmospheres, temperature, 2))
         context, integrator = self.create_system(testsystem, parameter_name, parameter_initial, temperature, platform_name)
 

--- a/openmmtools/testsystems.py
+++ b/openmmtools/testsystems.py
@@ -2995,6 +2995,34 @@ class AlanineDipeptideVacuum(TestSystem):
 
         self.system, self.positions = system, positions
 
+class AlchemicalAlanineDipeptide(AlanineDipeptideVacuum):
+    """AlanineDipeptideVacuum test system where all atoms can be alchemically discharged"""
+
+    def __init__(self, *args, **kwargs):
+        """Create a test system where all atoms can be alchemical discharged.
+
+        Context parameters
+        ------------------
+        lambda_electrostatics
+            Coulomb interactions for the first water molecule are scaled by `lambda`
+
+        Examples
+        --------
+
+        >>> alanine_dipeptide = AlchemicalAlanineDipeptide()
+        >>> [system, positions] = [alanine_dipeptide.system, alanine_dipeptide.positions]
+
+        """
+        super(AlchemicalAlanineDipeptide, self).__init__(*args, **kwargs)
+
+        # Alchemically modify the system
+        from openmmtools.alchemy import AlchemicalRegion, AbsoluteAlchemicalFactory
+        region = AlchemicalRegion(alchemical_atoms=range(22))
+        factory = AbsoluteAlchemicalFactory()
+        alchemical_system = factory.create_alchemical_system(self.system, region)
+        self.system = alchemical_system
+
+        return
 #=============================================================================================
 # Alanine dipeptide in implicit solvent.
 #=============================================================================================

--- a/openmmtools/testsystems.py
+++ b/openmmtools/testsystems.py
@@ -3004,7 +3004,7 @@ class AlchemicalAlanineDipeptide(AlanineDipeptideVacuum):
         Context parameters
         ------------------
         lambda_electrostatics
-            Coulomb interactions for the first water molecule are scaled by `lambda`
+            Coulomb interactions are scaled by `lambda`
 
         Examples
         --------


### PR DESCRIPTION
* Adds an `AlchemicalAlanineDipeptide` testsystem
* Replaces `AlchemicalWaterbox` with `AlchemicalAlanineDipeptide` in a slow test

Partially addresses https://github.com/choderalab/openmmtools/issues/238