### PR TITLE
Hotfix 0.11.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ DOCLINES = __doc__.split("\n")
 
 ########################
 VERSION = "0.11.2"
-ISRELEASED = False
+ISRELEASED = True
 __version__ = VERSION
 ########################
 CLASSIFIERS = """\


### PR DESCRIPTION
* Fixes bug in Python2/3 compatibility with encoding strings being unreadable by OpenMM in fringe case of using decompressed old serialization style with Python 2
* Speeds up two very slow tests, saving >10 min in tests