### PR TITLE
Cleaned up old GNU License strings, all should be MIT now. 

### DIFF
--- a/openmmtools/integrators.py
+++ b/openmmtools/integrators.py
@@ -15,19 +15,16 @@ COPYRIGHT
 
 @author John D. Chodera <john.chodera@choderalab.org>
 
-All code in this repository is released under the GNU General Public License.
+All code in this repository is released under the MIT License.
 
 This program is free software: you can redistribute it and/or modify it under
-the terms of the GNU General Public License as published by the Free Software
-Foundation, either version 3 of the License, or (at your option) any later
-version.
+the terms of the MIT License.
 
 This program is distributed in the hope that it will be useful, but WITHOUT ANY
 WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
-PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+PARTICULAR PURPOSE.  See the MIT License for more details.
 
-You should have received a copy of the GNU General Public License along with
-this program.  If not, see <http://www.gnu.org/licenses/>.
+You should have received a copy of the MIT License along with this program.
 
 """
 

--- a/openmmtools/mcmc.py
+++ b/openmmtools/mcmc.py
@@ -1,5 +1,25 @@
 #!/usr/bin/env python
 
+"""
+
+COPYRIGHT AND LICENSE
+
+@author John D. Chodera <jchodera@gmail.com>
+
+All code in this repository is released under the MIT License.
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the MIT License.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE.  See the MIT License for more details.
+
+You should have received a copy of the MIT License along with this program.
+
+"""
+
+
 # =============================================================================
 # MODULE DOCSTRING
 # =============================================================================
@@ -82,27 +102,6 @@ the DummyCache.
 
 >>> dummy_cache = cache.DummyContextCache(platform=reference_platform)
 >>> ghmc_move = GHMCMove(context_cache=dummy_cache)
-
-
-
-
-COPYRIGHT AND LICENSE
-
-@author John D. Chodera <jchodera@gmail.com>
-
-All code in this repository is released under the GNU General Public License.
-
-This program is free software: you can redistribute it and/or modify it under
-the terms of the GNU General Public License as published by the Free Software
-Foundation, either version 3 of the License, or (at your option) any later
-version.
-
-This program is distributed in the hope that it will be useful, but WITHOUT ANY
-WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
-PARTICULAR PURPOSE.  See the GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License along with
-this program.  If not, see <http://www.gnu.org/licenses/>.
 
 """
 

--- a/openmmtools/scripts/test_openmm_platforms.py
+++ b/openmmtools/scripts/test_openmm_platforms.py
@@ -14,19 +14,16 @@ COPYRIGHT
 
 @author John D. Chodera <jchodera@gmail.com>
 
-All code in this repository is released under the GNU General Public License.
+All code in this repository is released under the MIT License.
 
 This program is free software: you can redistribute it and/or modify it under
-the terms of the GNU General Public License as published by the Free Software
-Foundation, either version 3 of the License, or (at your option) any later
-version.
+the terms of the MIT License.
 
 This program is distributed in the hope that it will be useful, but WITHOUT ANY
 WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
-PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+PARTICULAR PURPOSE.  See the MIT License for more details.
 
-You should have received a copy of the GNU General Public License along with
-this program.  If not, see <http://www.gnu.org/licenses/>.
+You should have received a copy of the MIT License along with this program.
 
 TODO
 

--- a/openmmtools/testsystems.py
+++ b/openmmtools/testsystems.py
@@ -23,20 +23,16 @@ COPYRIGHT
 @author John D. Chodera <john.chodera@choderalab.org>
 @author Randall J. Radmer <radmer@stanford.edu>
 
-All code in this repository is released under the GNU General Public License.
+All code in this repository is released under the MIT License.
 
 This program is free software: you can redistribute it and/or modify it under
-the terms of the GNU General Public License as published by the Free Software
-Foundation, either version 3 of the License, or (at your option) any later
-version.
+the terms of the MIT License.
 
 This program is distributed in the hope that it will be useful, but WITHOUT ANY
 WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
-PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+PARTICULAR PURPOSE.  See the MIT License for more details.
 
-You should have received a copy of the GNU General Public License along with
-this program.  If not, see <http://www.gnu.org/licenses/>.
-this program.  If not, see <http://www.gnu.org/licenses/>.
+You should have received a copy of the MIT License along with this program.
 
 TODO
 

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ CLASSIFIERS = """\
 Development Status :: 3 - Alpha
 Intended Audience :: Science/Research
 Intended Audience :: Developers
-License :: OSI Approved :: Lesser GNU Public License (LGPL)
+License :: OSI Approved :: MIT License
 Programming Language :: Python
 Programming Language :: Python :: 3
 Topic :: Scientific/Engineering :: Bio-Informatics
@@ -164,7 +164,7 @@ setup(
     description=DOCLINES[0],
     long_description="\n".join(DOCLINES[2:]),
     version=__version__,
-    license='LGPL',
+    license='MIT',
     url='https://github.com/choderalab/openmmtools',
     platforms=['Linux', 'Mac OS-X', 'Unix', 'Windows'],
     classifiers=CLASSIFIERS.splitlines(),


### PR DESCRIPTION
No need to re-release, these were all doc string fixes.