### PR TITLE
ContextCache retrieves same context with two consecutive calls.

### DIFF
--- a/openmmtools/cache.py
+++ b/openmmtools/cache.py
@@ -347,7 +347,8 @@ class ContextCache(object):
 
         If the integrator is not provided, this will search the cache for
         any Context in the given ThermodynamicState, regardless of its
-        integrator.
+        integrator. In this case, the method guarantees that two consecutive
+        calls with the same thermodynamic state will retrieve the same context.
 
         This creates a new Context if no compatible one has been cached.
         If a compatible Context exists, the ThermodynamicState is applied
@@ -387,8 +388,10 @@ class ContextCache(object):
                 # Only one match.
                 context = self._lru[matching_context_ids[0]]
             else:
-                # Multiple matches, prefer non-default Integrator.
-                for context_id in matching_context_ids:
+                # Multiple matches, prefer the non-default Integrator.
+                # Always pick the least recently used to make two consective
+                # calls retrieving the same integrator.
+                for context_id in reversed(matching_context_ids):
                     if context_id[1] != self._default_integrator_id():
                         context = self._lru[context_id]
                         break

--- a/openmmtools/tests/test_cache.py
+++ b/openmmtools/tests/test_cache.py
@@ -260,9 +260,19 @@ class TestContextCache(object):
         assert state1.is_context_compatible(context)
         assert isinstance(integrator, type(self.verlet_2fs)), type(integrator)
 
+        # When it has a choice, ContextCache picks the same context
+        # in consecutive calls with same thermodynamic state.
+        # First add another integrator so that ContextCache has 2 possible options.
+        assert type(self.langevin_2fs_310k) is not type(default_integrator)  # test precondition
+        cache.get_context(state1, copy.deepcopy(self.langevin_2fs_310k))
+        assert len(cache) == 3
+        context, integrator = cache.get_context(state1)
+        for i in range(5):  # 5 attempts to make the test fail
+            assert cache.get_context(state1)[0] is context
+
         # With an incompatible state, a new Context is created.
         cache.get_context(state2)
-        assert len(cache) == 3
+        assert len(cache) == 4
 
     def test_cache_capacity_ttl(self):
         """Check that the cache capacity and time_to_live work as expected."""


### PR DESCRIPTION
This fixes a problem where in some cases `ContextCache.get_context(state, integrator=None)` would pick two different `Context`s after two consecutive calls with the same `state`. The advantage of having always the same context is that the user doesn't necessarily have to set positions and save some time.