### PR TITLE
Add forces module.

### DIFF
--- a/docs/forcefactories.rst
+++ b/docs/forcefactories.rst
@@ -1,0 +1,18 @@
+.. _forcefactories::
+
+Cache
+=====
+
+The module :mod:`openmmtools.forcefactories` implements utility methods and factories to configure system forces.
+
+ - :func:`replace_reaction_field`: Configure a system to model the electrostatics with an :class:`UnshiftedReactionField` force.
+
+Cache objects
+-------------
+
+.. currentmodule:: openmmtools.forcefactories
+.. autosummary::
+    :nosignatures:
+    :toctree: api/generated/
+
+    replace_reaction_field

--- a/docs/forces.rst
+++ b/docs/forces.rst
@@ -1,0 +1,22 @@
+.. _forces::
+
+Forces
+======
+
+The module :mod:`openmmtools.forces` implements custom forces that are not natively found in OpenMM.
+
+ - :class:`UnshiftedReactionFieldForce`: A `CustomNonbondedForce <http://docs.openmm.org/7.1.0/api-python/generated/simtk.openmm.openmm.CustomNonbondedForce.html>`_ implementing a reaction field variant with `c_rf` term set to zero and a switching function.
+ - :func:`find_nonbonded_force`: Find the first ``NonbondedForce`` in an OpenMM ``System``.
+ - :func:`iterate_nonbonded_forces`: Iterate over all the ``NonbondedForce``s in an OpenMM ``System``.
+
+Cache objects
+-------------
+
+.. currentmodule:: openmmtools.forces
+.. autosummary::
+    :nosignatures:
+    :toctree: api/generated/
+
+    UnshiftedReactionFieldForce
+    find_nonbonded_force
+    iterate_nonbonded_forces

--- a/docs/forces.rst
+++ b/docs/forces.rst
@@ -5,7 +5,7 @@ Forces
 
 The module :mod:`openmmtools.forces` implements custom forces that are not natively found in OpenMM.
 
- - :class:`UnshiftedReactionFieldForce`: A `CustomNonbondedForce <http://docs.openmm.org/7.1.0/api-python/generated/simtk.openmm.openmm.CustomNonbondedForce.html>`_ implementing a reaction field variant with `c_rf` term set to zero and a switching function.
+ - :class:`UnshiftedReactionFieldForce`: A `CustomNonbondedForce <http://docs.openmm.org/7.1.0/api-python/generated/simtk.openmm.openmm.CustomNonbondedForce.html>`_ implementing a reaction field variant with `c_rf` term set to zero and a switching function. Using the native OpenMM reaction field implementation with `c_rf != 0` can cause issues with hydration free energy calculations.
  - :func:`find_nonbonded_force`: Find the first ``NonbondedForce`` in an OpenMM ``System``.
  - :func:`iterate_nonbonded_forces`: Iterate over all the ``NonbondedForce``s in an OpenMM ``System``.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -53,6 +53,8 @@ Modules
   mcmc
   sampling
   alchemy
+  forces
+  forcefactories
   utils
   scripts
 

--- a/openmmtools/alchemy.py
+++ b/openmmtools/alchemy.py
@@ -2091,20 +2091,20 @@ class AbsoluteAlchemicalFactory(object):
                     add_label(label.format('non-'), force_index2)
 
             # If they are both empty they are identical and any label works.
-            elif force1.getNumBonds() == 0:
+            elif force1.getNumBonds() == 0 and force2.getNumBonds() == 0:
                 add_label(label.format(''), force_index1)
                 add_label(label.format('non-'), force_index2)
 
             # We check that the bond atoms are both alchemical or not.
             else:
-                atom_i, atom_j, _ = force1.getBondParameters(0)
+                atom_i, atom_j, _ = force2.getBondParameters(0)
                 both_alchemical = atom_i in alchemical_atoms and atom_j in alchemical_atoms
                 if both_alchemical:
-                    add_label(label.format(''), force_index1)
-                    add_label(label.format('non-'), force_index2)
-                else:
-                    add_label(label.format('non-'), force_index1)
                     add_label(label.format(''), force_index2)
+                    add_label(label.format('non-'), force_index1)
+                else:
+                    add_label(label.format('non-'), force_index2)
+                    add_label(label.format(''), force_index1)
 
         return force_labels
 

--- a/openmmtools/forcefactories.py
+++ b/openmmtools/forcefactories.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python
+
+# =============================================================================
+# MODULE DOCSTRING
+# =============================================================================
+
+"""
+Factories to manipulate OpenMM System forces.
+
+"""
+
+
+# =============================================================================
+# GLOBAL IMPORTS
+# =============================================================================
+
+import copy
+
+from simtk import openmm, unit
+
+from openmmtools import forces
+
+
+# =============================================================================
+# FACTORY FUNCTIONS
+# =============================================================================
+
+def replace_reaction_field(reference_system, switch_width=1.0*unit.angstrom,
+                           return_copy=True):
+    """Return a system converted to use a switched reaction-field electrostatics.
+
+    This will add an `UnshiftedReactionFieldForce` for each `NonbondedForce`
+    that utilizes `CutoffPeriodic`.
+
+    Note that `AbsoluteAlchemicalFactory.create_alchemical_system()` can NOT
+    handle the resulting `System` object yet since the `CustomNonbondedForce`
+    are not recognized and re-coded.
+
+    Parameters
+    ----------
+    reference_system : simtk.openmm.System
+        The system to use as a reference. This will be modified only if
+        `return_copy` is `False`.
+    switch_width : simtk.unit.Quantity, default 1.0*angstrom
+        Switch width for electrostatics (units of distance).
+    return_copy : bool
+        If `True`, `reference_system` is not modified, and a copy is returned.
+        Setting it to `False` speeds up the function execution but modifies
+        the `reference_system` object.
+
+    Returns
+    -------
+    system : simtk.openmm.System
+        System with reaction-field converted to c_rf = 0
+
+    """
+    if return_copy:
+        system = copy.deepcopy(reference_system)
+    else:
+        system = reference_system
+
+    # Add an UnshiftedReactionFieldForce for each CutoffPeriodic NonbondedForce.
+    for reference_force in forces.iterate_nonbonded_forces(system):
+        if reference_force.getNonbondedMethod() == openmm.NonbondedForce.CutoffPeriodic:
+            reaction_field_force = forces.UnshiftedReactionFieldForce.from_nonbonded_force(reference_force,
+                                                                                           switch_width=switch_width)
+            system.addForce(reaction_field_force)
+
+            # Remove particle electrostatics from reference force, but leave exceptions.
+            for particle_index in range(reference_force.getNumParticles()):
+                charge, sigma, epsilon = reference_force.getParticleParameters(particle_index)
+                reference_force.setParticleParameters(particle_index, abs(0.0*charge), sigma, epsilon)
+
+    return system
+
+
+if __name__ == '__main__':
+    import doctest
+    doctest.testmod()

--- a/openmmtools/forces.py
+++ b/openmmtools/forces.py
@@ -199,9 +199,10 @@ class UnshiftedReactionFieldForce(openmm.CustomNonbondedForce):
             The reaction field force with copied particles.
 
         """
+        # OpenMM gives unitless values.
         cutoff_distance = nonbonded_force.getCutoffDistance()
         reaction_field_dielectric = nonbonded_force.getReactionFieldDielectric()
-        reaction_field_force = cls.__init__(reaction_field_dielectric, cutoff_distance, switch_width)
+        reaction_field_force = cls(cutoff_distance, switch_width, reaction_field_dielectric)
 
         # Set particle charges.
         for particle_index in range(nonbonded_force.getNumParticles()):
@@ -212,6 +213,8 @@ class UnshiftedReactionFieldForce(openmm.CustomNonbondedForce):
         for exception_index in range(nonbonded_force.getNumExceptions()):
             iatom, jatom, chargeprod, sigma, epsilon = nonbonded_force.getExceptionParameters(exception_index)
             reaction_field_force.addExclusion(iatom, jatom)
+
+        return reaction_field_force
 
     @classmethod
     def from_system(cls, system, switch_width=1.0*unit.angstrom):

--- a/openmmtools/forces.py
+++ b/openmmtools/forces.py
@@ -14,8 +14,6 @@ Custom OpenMM Forces classes and utilities.
 # GLOBAL IMPORTS
 # =============================================================================
 
-import copy
-
 from simtk import openmm, unit
 
 from openmmtools.constants import ONE_4PI_EPS0
@@ -70,58 +68,6 @@ def iterate_nonbonded_forces(system):
     for force in system.getForces():
         if isinstance(force, openmm.NonbondedForce):
             yield force
-
-
-# =============================================================================
-# FACTORY FUNCTIONS
-# =============================================================================
-
-def replace_reaction_field(self, reference_system, switch_width=1.0*unit.angstrom,
-                           return_copy=True):
-    """Return a system converted to use a switched reaction-field electrostatics.
-
-    This will add an `UnshiftedReactionFieldForce` for each `NonbondedForce`
-    that utilizes `CutoffPeriodic`.
-
-    Note that `AbsoluteAlchemicalFactory.create_alchemical_system()` can NOT
-    handle the resulting `System` object yet since the `CustomNonbondedForce`
-    are not recognized and re-coded.
-
-    Parameters
-    ----------
-    reference_system : simtk.openmm.System
-        The system to use as a reference. This will be modified only if
-        `return_copy` is `False`.
-    switch_width : simtk.unit.Quantity, default 1.0*angstrom
-        Switch width for electrostatics (units of distance).
-    return_copy : bool
-        If `True`, `reference_system` is not modified, and a copy is returned.
-        Setting it to `False` speeds up the function execution but modifies
-        the `reference_system` object.
-
-    Returns
-    -------
-    system : simtk.openmm.System
-        System with reaction-field converted to c_rf = 0
-
-    """
-    if return_copy:
-        system = copy.deepcopy(reference_system)
-    else:
-        system = reference_system
-
-    # Add an UnshiftedReactionFieldForce for each CutoffPeriodic NonbondedForce.
-    for reference_force in iterate_nonbonded_forces(system):
-        if reference_force.getNonbondedMethod() == openmm.NonbondedForce.CutoffPeriodic:
-            reaction_field_force = UnshiftedReactionFieldForce.from_nonbonded_force(reference_force)
-            system.addForce(reaction_field_force)
-
-            # Remove particle electrostatics from reference force, but leave exceptions.
-            for particle_index in range(reference_force.getNumParticles()):
-                charge, sigma, epsilon = reference_force.getParticleParameters(particle_index)
-                reference_force.setParticleParameters(particle_index, abs(0.0*charge), sigma, epsilon)
-
-    return system
 
 
 # =============================================================================

--- a/openmmtools/forces.py
+++ b/openmmtools/forces.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python
+
+# =============================================================================
+# MODULE DOCSTRING
+# =============================================================================
+
+"""
+Custom OpenMM Forces classes and utilities.
+
+"""
+
+
+# =============================================================================
+# GLOBAL IMPORTS
+# =============================================================================
+
+import copy
+
+from simtk import openmm, unit
+
+from openmmtools.constants import ONE_4PI_EPS0
+
+
+# =============================================================================
+# UTILITY FUNCTIONS
+# =============================================================================
+
+def find_nonbonded_force(system):
+    """Find the first OpenMM `NonbondedForce` in the system.
+
+    Parameters
+    ----------
+    system : simtk.openmm.System
+        The system to search.
+
+    Returns
+    -------
+    nonbonded_force : simtk.openmm.NonbondedForce
+        The first `NonbondedForce` object in `system`.
+
+    Raises
+    ------
+    ValueError
+        If the system contains multiple `NonbondedForce`s
+
+    """
+    nonbonded_force = None
+    for force in system.getForces():
+        if isinstance(force, openmm.NonbondedForce):
+            if nonbonded_force is not None:
+                raise ValueError('The System has multiple NonbondedForces')
+            nonbonded_force = force
+    return nonbonded_force
+
+
+def iterate_nonbonded_forces(system):
+    """Iterate over all OpenMM `NonbondedForce`s in `system`.
+
+    Parameters
+    ----------
+    system : simtk.openmm.System
+        The system to search.
+
+    Yields
+    ------
+    force : simtk.openmm.NonbondedForce
+        A `NonbondedForce` object in `system`.
+
+    """
+    for force in system.getForces():
+        if isinstance(force, openmm.NonbondedForce):
+            yield force
+
+
+# =============================================================================
+# FACTORY FUNCTIONS
+# =============================================================================
+
+def replace_reaction_field(self, reference_system, switch_width=1.0*unit.angstrom,
+                           return_copy=True):
+    """Return a system converted to use a switched reaction-field electrostatics.
+
+    This will add an `UnshiftedReactionFieldForce` for each `NonbondedForce`
+    that utilizes `CutoffPeriodic`.
+
+    Note that `AbsoluteAlchemicalFactory.create_alchemical_system()` can NOT
+    handle the resulting `System` object yet since the `CustomNonbondedForce`
+    are not recognized and re-coded.
+
+    Parameters
+    ----------
+    reference_system : simtk.openmm.System
+        The system to use as a reference. This will be modified only if
+        `return_copy` is `False`.
+    switch_width : simtk.unit.Quantity, default 1.0*angstrom
+        Switch width for electrostatics (units of distance).
+    return_copy : bool
+        If `True`, `reference_system` is not modified, and a copy is returned.
+        Setting it to `False` speeds up the function execution but modifies
+        the `reference_system` object.
+
+    Returns
+    -------
+    system : simtk.openmm.System
+        System with reaction-field converted to c_rf = 0
+
+    """
+    if return_copy:
+        system = copy.deepcopy(reference_system)
+    else:
+        system = reference_system
+
+    # Add an UnshiftedReactionFieldForce for each CutoffPeriodic NonbondedForce.
+    for reference_force in iterate_nonbonded_forces(system):
+        if reference_force.getNonbondedMethod() == openmm.NonbondedForce.CutoffPeriodic:
+            reaction_field_force = UnshiftedReactionFieldForce.from_nonbonded_force(reference_force)
+            system.addForce(reaction_field_force)
+
+            # Remove particle electrostatics from reference force, but leave exceptions.
+            for particle_index in range(reference_force.getNumParticles()):
+                charge, sigma, epsilon = reference_force.getParticleParameters(particle_index)
+                reference_force.setParticleParameters(particle_index, abs(0.0*charge), sigma, epsilon)
+
+    return system
+
+
+# =============================================================================
+# REACTION FIELD
+# =============================================================================
+
+class UnshiftedReactionFieldForce(openmm.CustomNonbondedForce):
+    """A force modelling switched reaction-field electrostatics.
+
+    Contrarily to a normal `NonbondedForce` with `CutoffPeriodic` nonbonded
+    method, this force sets the `c_rf` to 0.0 and uses a switching function
+    to avoid forces discontinuities at the cutoff distance.
+
+    Parameters
+    ----------
+    cutoff_distance : simtk.unit.Quantity, default 15*angstroms
+        The cutoff distance (units of distance).
+    switch_width : simtk.unit.Quantity, default 1.0*angstrom
+        Switch width for electrostatics (units of distance).
+    reaction_field_dielectric : float
+        The dielectric constant used for the solvent.
+
+    """
+
+    def __init__(self, cutoff_distance=15*unit.angstroms, switch_width=1.0*unit.angstrom,
+                 reaction_field_dielectric=78.3):
+        k_rf = cutoff_distance**(-3) * (reaction_field_dielectric - 1.0) / (2.0*reaction_field_dielectric + 1.0)
+
+        # Energy expression omits c_rf constant term.
+        energy_expression = "ONE_4PI_EPS0*chargeprod*(r^(-1) + k_rf*r^2);"
+        energy_expression += "chargeprod = charge1*charge2;"
+        energy_expression += "k_rf = {:f};".format(k_rf.value_in_unit_system(unit.md_unit_system))
+        energy_expression += "ONE_4PI_EPS0 = {:f};".format(ONE_4PI_EPS0)  # already in OpenMM units
+
+        # Create CustomNonbondedForce.
+        super(UnshiftedReactionFieldForce, self).__init__(energy_expression)
+
+        # Add parameters.
+        self.addPerParticleParameter("charge")
+
+        # Configure force.
+        self.setNonbondedMethod(openmm.CustomNonbondedForce.CutoffPeriodic)
+        self.setCutoffDistance(cutoff_distance)
+        self.setUseLongRangeCorrection(False)
+        if switch_width is not None:
+            self.setUseSwitchingFunction(True)
+            self.setSwitchingDistance(cutoff_distance - switch_width)
+        else:  # Truncated
+            self.setUseSwitchingFunction(False)
+
+    @classmethod
+    def from_nonbonded_force(cls, nonbonded_force, switch_width=1.0*unit.angstrom):
+        """Copy constructor from an OpenMM `NonbondedForce`.
+
+        The returned force has same cutoff distance and dielectric, and
+        its particles have the same charges. Exclusions corresponding to
+        `nonbonded_force` exceptions are also added.
+
+        .. warning
+            This only creates the force object. The electrostatics in
+            `nonbonded_force` remains unmodified. Use the function
+            `replace_reaction_field` to correctly convert a system to
+            use an unshifted reaction field potential.
+
+        Parameters
+        ----------
+        nonbonded_force : simtk.openmm.NonbondedForce
+            The nonbonded force to copy.
+        switch_width : simtk.unit.Quantity
+            Switch width for electrostatics (units of distance).
+
+        Returns
+        -------
+        reaction_field_force : UnshiftedReactionFieldForce
+            The reaction field force with copied particles.
+
+        """
+        cutoff_distance = nonbonded_force.getCutoffDistance()
+        reaction_field_dielectric = nonbonded_force.getReactionFieldDielectric()
+        reaction_field_force = cls.__init__(reaction_field_dielectric, cutoff_distance, switch_width)
+
+        # Set particle charges.
+        for particle_index in range(nonbonded_force.getNumParticles()):
+            charge, sigma, epsilon = nonbonded_force.getParticleParameters(particle_index)
+            reaction_field_force.addParticle([charge])
+
+        # Add exclusions to CustomNonbondedForce.
+        for exception_index in range(nonbonded_force.getNumExceptions()):
+            iatom, jatom, chargeprod, sigma, epsilon = nonbonded_force.getExceptionParameters(exception_index)
+            reaction_field_force.addExclusion(iatom, jatom)
+
+    @classmethod
+    def from_system(cls, system, switch_width=1.0*unit.angstrom):
+        """Copy constructor from the first OpenMM `NonbondedForce` in `system`.
+
+        If multiple `NonbondedForce`s are found, an exception is raised.
+
+        .. warning
+            This only creates the force object. The electrostatics in
+            `nonbonded_force` remains unmodified. Use the function
+            `replace_reaction_field` to correctly convert a system to
+            use an unshifted reaction field potential.
+
+        Parameters
+        ----------
+        system : simtk.openmm.System
+            The system containing the nonbonded force to copy.
+        switch_width : simtk.unit.Quantity
+            Switch width for electrostatics (units of distance).
+
+        Returns
+        -------
+        reaction_field_force : UnshiftedReactionFieldForce
+            The reaction field force.
+
+        Raises
+        ------
+        ValueError
+            If multiple `NonbondedForce`s are found in the system.
+
+        See Also
+        --------
+        UnshiftedReactionField.from_nonbonded_force
+
+        """
+        nonbonded_force = find_nonbonded_force(system)
+        return cls.from_nonbonded_force(nonbonded_force, switch_width)
+
+
+if __name__ == '__main__':
+    import doctest
+    doctest.testmod()

--- a/openmmtools/tests/test_alchemy.py
+++ b/openmmtools/tests/test_alchemy.py
@@ -1200,16 +1200,16 @@ class TestAbsoluteAlchemicalFactory(object):
                 # Pre-generate alchemical system.
                 alchemical_system = factory.create_alchemical_system(test_system.system, region)
 
-                # If the test system uses reaction field replace reaction field
-                # of the reference system to allow comparisons.
-                nonbonded_force = forces.find_nonbonded_force(test_system.system)
-                if nonbonded_force.getNonbondedMethod() == openmm.NonbondedForce.CutoffPeriodic:
-                    forcefactories.replace_reaction_field(test_system.system, return_copy=False,
-                                                          switch_width=factory.switch_width)
-
                 # Add test case.
                 cls.test_cases[test_case_name] = (test_system, alchemical_system, region)
                 n_test_cases += 1
+
+            # If the test system uses reaction field replace reaction field
+            # of the reference system to allow comparisons.
+            nonbonded_force = forces.find_nonbonded_force(test_system.system)
+            if nonbonded_force.getNonbondedMethod() == openmm.NonbondedForce.CutoffPeriodic:
+                forcefactories.replace_reaction_field(test_system.system, return_copy=False,
+                                                      switch_width=factory.switch_width)
 
     def test_fully_interacting_energy(self):
         """Compare the energies of reference and fully interacting alchemical system."""

--- a/openmmtools/tests/test_forces.py
+++ b/openmmtools/tests/test_forces.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python
+
+# =============================================================================
+# MODULE DOCSTRING
+# =============================================================================
+
+"""
+Test Force classes in forces.py.
+
+"""
+
+# =============================================================================
+# GLOBAL IMPORTS
+# =============================================================================
+
+from functools import partial
+
+import numpy as np
+
+from openmmtools.forcefactories import *
+from openmmtools import testsystems
+
+
+# =============================================================================
+# CONSTANTS
+# =============================================================================
+
+MAX_FORCE_RELATIVE_ERROR = 1.0e-6  # maximum allowable relative force error
+GLOBAL_FORCE_UNIT = unit.kilojoules_per_mole / unit.nanometers  # controls printed units
+GLOBAL_FORCES_PLATFORM = None  # This is used in every calculation.
+
+
+# =============================================================================
+# TESTING UTILITIES
+# =============================================================================
+
+def create_context(system, integrator, platform=None):
+    """Create a Context.
+
+    If platform is None, GLOBAL_ALCHEMY_PLATFORM is used.
+
+    """
+    if platform is None:
+        platform = GLOBAL_FORCES_PLATFORM
+    if platform is not None:
+        context = openmm.Context(system, integrator, platform)
+    else:
+        context = openmm.Context(system, integrator)
+    return context
+
+
+# =============================================================================
+# UTILITY FUNCTIONS
+# =============================================================================
+
+def compute_forces(system, positions, platform=None, force_group=-1):
+    """Compute forces of the system in the given positions.
+
+    Parameters
+    ----------
+    platform : simtk.openmm.Platform or None, optional
+        If None, the global GLOBAL_ALCHEMY_PLATFORM will be used.
+    force_group : int flag or set of int, optional
+        Passed to the groups argument of Context.getState().
+
+    """
+    timestep = 1.0 * unit.femtoseconds
+    integrator = openmm.VerletIntegrator(timestep)
+    context = create_context(system, integrator, platform)
+    context.setPositions(positions)
+    state = context.getState(getForces=True, groups=force_group)
+    forces = state.getForces(asNumpy=True)
+    del context, integrator, state
+    return forces
+
+
+def compare_system_forces(reference_system, alchemical_system, positions, name="", platform=None):
+    """Check that the forces of reference and modified systems are close.
+
+    Parameters
+    ---------
+    reference_system : simtk.openmm.System
+        Reference System
+    alchemical_system : simtk.openmm.System
+        System to compare to reference
+    positions : simtk.unit.Quantity of shape [nparticles,3] with units of distance
+        The particle positions to use
+    name : str, optional, default=""
+        System name to use for debugging.
+    platform : simtk.openmm.Platform, optional, default=None
+        If specified, use this platform
+
+    """
+    # Compute forces
+    reference_force = compute_forces(reference_system, positions, platform=platform) / GLOBAL_FORCE_UNIT
+    alchemical_force = compute_forces(alchemical_system, positions, platform=platform) / GLOBAL_FORCE_UNIT
+
+    # Check that error is small.
+    def magnitude(vec):
+        return np.sqrt(np.mean(np.sum(vec**2, axis=1)))
+
+    relative_error = magnitude(alchemical_force - reference_force) / magnitude(reference_force)
+    if np.any(np.abs(relative_error) > MAX_FORCE_RELATIVE_ERROR):
+        err_msg = ("Maximum allowable relative force error exceeded (was {:.8f}; allowed {:.8f}).\n"
+                   "alchemical_force = {:.8f}, reference_force = {:.8f}, difference = {:.8f}")
+        raise Exception(err_msg.format(relative_error, MAX_FORCE_RELATIVE_ERROR, magnitude(alchemical_force),
+                                       magnitude(reference_force), magnitude(alchemical_force-reference_force)))
+
+
+def generate_new_positions(system, positions, platform=None, nsteps=50):
+    """Generate new positions by taking a few steps from the old positions.
+
+    Parameters
+    ----------
+    platform : simtk.openmm.Platform or None, optional
+        If None, the global GLOBAL_ALCHEMY_PLATFORM will be used.
+    nsteps : int, optional, default=50
+        Number of steps of dynamics to take.
+
+    Returns
+    -------
+    new_positions : simtk.unit.Quantity of shape [nparticles,3] with units compatible with distance
+        New positions
+
+    """
+    temperature = 300 * unit.kelvin
+    collision_rate = 90 / unit.picoseconds
+    timestep = 1.0 * unit.femtoseconds
+    integrator = openmm.LangevinIntegrator(temperature, collision_rate, timestep)
+    context = create_context(system, integrator, platform)
+    context.setPositions(positions)
+    integrator.step(nsteps)
+    new_positions = context.getState(getPositions=True).getPositions(asNumpy=True)
+    del context, integrator
+    return new_positions
+
+
+# =============================================================================
+# TEST LRU CACHE
+# =============================================================================
+
+def test_replace_reaction_field():
+    """Check that replacing reaction-field electrostatics with Custom*Force
+    yields minimal force differences with original system.
+
+    Note that we cannot test for energy consistency or energy overlap because
+    which atoms are within the cutoff will cause energy difference to vary wildly.
+
+    """
+    test_cases = [
+        testsystems.AlanineDipeptideExplicit(nonbondedMethod=openmm.app.CutoffPeriodic),
+        testsystems.HostGuestExplicit(nonbondedMethod=openmm.app.CutoffPeriodic)
+    ]
+    platform = openmm.Platform.getPlatformByName('Reference')
+    for test_system in test_cases:
+        test_name = test_system.__class__.__name__
+
+        # Replace reaction field.
+        modified_rf_system = replace_reaction_field(test_system.system, switch_width=None)
+
+        # Make sure positions are not at minimum.
+        positions = generate_new_positions(test_system.system, test_system.positions)
+
+        # Test forces.
+        f = partial(compare_system_forces, test_system.system, modified_rf_system, positions,
+                    name=test_name, platform=platform)
+        f.description = "Testing replace_reaction_field on system {}".format(test_name)
+        yield f
+


### PR DESCRIPTION
Fix #251 .

In this PR:
- [x] Add `openmmtools.forces` and `openmmtools.forcefactories` modules.
- [x] Add `UnshiftedReactionFieldForce` class that encapsulate the energy expression of reaction field with `c_rf=0`.
- [x] Move `replace_reaction_field` factory function from `alchemy.AbsoluteAlchemicalFactory` to `forcefactories`.
- [x] Adapt `alchemy` RF tests.