### PR TITLE
Add option for switched/shifted reaction field

### DIFF
--- a/openmmtools/forcefactories.py
+++ b/openmmtools/forcefactories.py
@@ -26,11 +26,11 @@ from openmmtools import forces
 # =============================================================================
 
 def replace_reaction_field(reference_system, switch_width=1.0*unit.angstrom,
-                           return_copy=True):
+                           return_copy=True, shifted=False):
     """Return a system converted to use a switched reaction-field electrostatics.
 
-    This will add an `UnshiftedReactionFieldForce` for each `NonbondedForce`
-    that utilizes `CutoffPeriodic`.
+    This will add an `UnshiftedReactionFieldForce` or `SwitchedReactionFieldForce`
+    for each `NonbondedForce` that utilizes `CutoffPeriodic`.
 
     Note that `AbsoluteAlchemicalFactory.create_alchemical_system()` can NOT
     handle the resulting `System` object yet since the `CustomNonbondedForce`
@@ -41,12 +41,14 @@ def replace_reaction_field(reference_system, switch_width=1.0*unit.angstrom,
     reference_system : simtk.openmm.System
         The system to use as a reference. This will be modified only if
         `return_copy` is `False`.
-    switch_width : simtk.unit.Quantity, default 1.0*angstrom
+    switch_width : simtk.unit.Quantity, default=1.0*angstrom
         Switch width for electrostatics (units of distance).
-    return_copy : bool
+    return_copy : bool, optional, default=True
         If `True`, `reference_system` is not modified, and a copy is returned.
         Setting it to `False` speeds up the function execution but modifies
         the `reference_system` object.
+    shifted : bool, optional, default=False
+        If `True`, a shited reaction-field will be used.
 
     Returns
     -------
@@ -59,11 +61,15 @@ def replace_reaction_field(reference_system, switch_width=1.0*unit.angstrom,
     else:
         system = reference_system
 
-    # Add an UnshiftedReactionFieldForce for each CutoffPeriodic NonbondedForce.
+    if shifted:
+        force_constructor = getattr(forces, 'SwitchedReactionFieldForce')
+    else:
+        force_constructor = getattr(forces, 'UnshiftedReactionFieldForce')
+
+    # Add an reaction field for each CutoffPeriodic NonbondedForce.
     for reference_force in forces.iterate_nonbonded_forces(system):
         if reference_force.getNonbondedMethod() == openmm.NonbondedForce.CutoffPeriodic:
-            reaction_field_force = forces.UnshiftedReactionFieldForce.from_nonbonded_force(reference_force,
-                                                                                           switch_width=switch_width)
+            reaction_field_force = force_constructor.from_nonbonded_force(reference_force, switch_width=switch_width)
             system.addForce(reaction_field_force)
 
             # Remove particle electrostatics from reference force, but leave exceptions.

--- a/openmmtools/forces.py
+++ b/openmmtools/forces.py
@@ -199,6 +199,128 @@ class UnshiftedReactionFieldForce(openmm.CustomNonbondedForce):
         nonbonded_force = find_nonbonded_force(system)
         return cls.from_nonbonded_force(nonbonded_force, switch_width)
 
+class SwitchedReactionFieldForce(openmm.CustomNonbondedForce):
+    """A force modelling switched reaction-field electrostatics.
+
+    Parameters
+    ----------
+    cutoff_distance : simtk.unit.Quantity, default 15*angstroms
+        The cutoff distance (units of distance).
+    switch_width : simtk.unit.Quantity, default 1.0*angstrom
+        Switch width for electrostatics (units of distance).
+    reaction_field_dielectric : float
+        The dielectric constant used for the solvent.
+
+    """
+
+    def __init__(self, cutoff_distance=15*unit.angstroms, switch_width=1.0*unit.angstrom,
+                 reaction_field_dielectric=78.3):
+        k_rf = cutoff_distance**(-3) * (reaction_field_dielectric - 1.0) / (2.0*reaction_field_dielectric + 1.0)
+        c_rf = cutoff_distance**(-1) * (3*reaction_field_dielectric) / (2.0*reaction_field_dielectric + 1.0)
+
+        # Energy expression omits c_rf constant term.
+        energy_expression = "ONE_4PI_EPS0*chargeprod*(r^(-1) + k_rf*r^2 - c_rf);"
+        energy_expression += "chargeprod = charge1*charge2;"
+        energy_expression += "k_rf = {:f};".format(k_rf.value_in_unit_system(unit.md_unit_system))
+        energy_expression += "c_rf = {:f};".format(c_rf.value_in_unit_system(unit.md_unit_system))
+        energy_expression += "ONE_4PI_EPS0 = {:f};".format(ONE_4PI_EPS0)  # already in OpenMM units
+
+        # Create CustomNonbondedForce.
+        super(SwitchedReactionFieldForce, self).__init__(energy_expression)
+
+        # Add parameters.
+        self.addPerParticleParameter("charge")
+
+        # Configure force.
+        self.setNonbondedMethod(openmm.CustomNonbondedForce.CutoffPeriodic)
+        self.setCutoffDistance(cutoff_distance)
+        self.setUseLongRangeCorrection(False)
+        if switch_width is not None:
+            self.setUseSwitchingFunction(True)
+            self.setSwitchingDistance(cutoff_distance - switch_width)
+        else:  # Truncated
+            self.setUseSwitchingFunction(False)
+
+    @classmethod
+    def from_nonbonded_force(cls, nonbonded_force, switch_width=1.0*unit.angstrom):
+        """Copy constructor from an OpenMM `NonbondedForce`.
+
+        The returned force has same cutoff distance and dielectric, and
+        its particles have the same charges. Exclusions corresponding to
+        `nonbonded_force` exceptions are also added.
+
+        .. warning
+            This only creates the force object. The electrostatics in
+            `nonbonded_force` remains unmodified. Use the function
+            `replace_reaction_field` to correctly convert a system to
+            use an unshifted reaction field potential.
+
+        Parameters
+        ----------
+        nonbonded_force : simtk.openmm.NonbondedForce
+            The nonbonded force to copy.
+        switch_width : simtk.unit.Quantity
+            Switch width for electrostatics (units of distance).
+
+        Returns
+        -------
+        reaction_field_force : UnshiftedReactionFieldForce
+            The reaction field force with copied particles.
+
+        """
+        # OpenMM gives unitless values.
+        cutoff_distance = nonbonded_force.getCutoffDistance()
+        reaction_field_dielectric = nonbonded_force.getReactionFieldDielectric()
+        reaction_field_force = cls(cutoff_distance, switch_width, reaction_field_dielectric)
+
+        # Set particle charges.
+        for particle_index in range(nonbonded_force.getNumParticles()):
+            charge, sigma, epsilon = nonbonded_force.getParticleParameters(particle_index)
+            reaction_field_force.addParticle([charge])
+
+        # Add exclusions to CustomNonbondedForce.
+        for exception_index in range(nonbonded_force.getNumExceptions()):
+            iatom, jatom, chargeprod, sigma, epsilon = nonbonded_force.getExceptionParameters(exception_index)
+            reaction_field_force.addExclusion(iatom, jatom)
+
+        return reaction_field_force
+
+    @classmethod
+    def from_system(cls, system, switch_width=1.0*unit.angstrom):
+        """Copy constructor from the first OpenMM `NonbondedForce` in `system`.
+
+        If multiple `NonbondedForce`s are found, an exception is raised.
+
+        .. warning
+            This only creates the force object. The electrostatics in
+            `nonbonded_force` remains unmodified. Use the function
+            `replace_reaction_field` to correctly convert a system to
+            use an unshifted reaction field potential.
+
+        Parameters
+        ----------
+        system : simtk.openmm.System
+            The system containing the nonbonded force to copy.
+        switch_width : simtk.unit.Quantity
+            Switch width for electrostatics (units of distance).
+
+        Returns
+        -------
+        reaction_field_force : UnshiftedReactionFieldForce
+            The reaction field force.
+
+        Raises
+        ------
+        ValueError
+            If multiple `NonbondedForce`s are found in the system.
+
+        See Also
+        --------
+        UnshiftedReactionField.from_nonbonded_force
+
+        """
+        nonbonded_force = find_nonbonded_force(system)
+        return cls.from_nonbonded_force(nonbonded_force, switch_width)
 
 if __name__ == '__main__':
     import doctest

--- a/openmmtools/tests/test_forces.py
+++ b/openmmtools/tests/test_forces.py
@@ -167,3 +167,17 @@ def test_replace_reaction_field():
         f.description = "Testing replace_reaction_field on system {}".format(test_name)
         yield f
 
+    for test_system in test_cases:
+        test_name = test_system.__class__.__name__
+
+        # Replace reaction field.
+        modified_rf_system = replace_reaction_field(test_system.system, switch_width=None, shifted=True)
+
+        # Make sure positions are not at minimum.
+        positions = generate_new_positions(test_system.system, test_system.positions)
+
+        # Test forces.
+        f = partial(compare_system_forces, test_system.system, modified_rf_system, positions,
+                    name=test_name, platform=platform)
+        f.description = "Testing replace_reaction_field on system {} with shifted=True".format(test_name)
+        yield f


### PR DESCRIPTION
We're having some trouble with @maxentile with the unshifted reaction field, so I've added an optional argument `shifted` that can be set to `True` to `replace_reaction_field` so @maxentile can use it to simply ensure continuity at the cutoff for standard OpenMM reaction field.