### PR TITLE
Virtual sites in alchemical factory and add ions in WaterBox

### DIFF
--- a/openmmtools/alchemy.py
+++ b/openmmtools/alchemy.py
@@ -807,6 +807,12 @@ class AbsoluteAlchemicalFactory(object):
         # the forces that we remodel to be alchemically modified.
         alchemical_system = copy.deepcopy(reference_system)
 
+        # Check that there are no virtual sites to alchemically modify.
+        for particle_index in range(reference_system.getNumParticles()):
+            if (reference_system.isVirtualSite(particle_index) and
+                        particle_index in alchemical_region.alchemical_atoms):
+                raise ValueError('Alchemically modified virtual sites are not supported')
+
         # Modify forces as appropriate. We delete the forces that
         # have been processed modified at the end of the for loop.
         forces_to_remove = []

--- a/openmmtools/tests/test_alchemy.py
+++ b/openmmtools/tests/test_alchemy.py
@@ -1126,7 +1126,7 @@ class TestAbsoluteAlchemicalFactory(object):
         cls.test_systems['LennardJonesCluster'] = testsystems.LennardJonesCluster()
         cls.test_systems['LennardJonesFluid with dispersion correction'] = \
             testsystems.LennardJonesFluid(nparticles=100, dispersion_correction=True)
-        cls.test_systems['WaterBox with reaction field, no switch, no dispersion correction'] = \
+        cls.test_systems['TIP3P WaterBox with reaction field, no switch, no dispersion correction'] = \
             testsystems.WaterBox(dispersion_correction=False, switch=False, nonbondedMethod=openmm.app.CutoffPeriodic)
         cls.test_systems['TIP4P-EW WaterBox and NaCl with PME'] = \
             testsystems.WaterBox(nonbondedMethod=openmm.app.PME, model='tip4pew', ionic_strength=200*unit.millimolar)
@@ -1151,8 +1151,8 @@ class TestAbsoluteAlchemicalFactory(object):
         cls.test_regions = dict()
         cls.test_regions['LennardJonesCluster'] = AlchemicalRegion(alchemical_atoms=range(2))
         cls.test_regions['LennardJonesFluid'] = AlchemicalRegion(alchemical_atoms=range(10))
-        cls.test_regions['WaterBox'] = AlchemicalRegion(alchemical_atoms=range(3))
-        cls.test_regions['WaterBox and NaCl'] = AlchemicalRegion(alchemical_atoms=range(2))  # Modify ions.
+        cls.test_regions['TIP3P WaterBox'] = AlchemicalRegion(alchemical_atoms=range(3))
+        cls.test_regions['TIP4P-EW WaterBox and NaCl'] = AlchemicalRegion(alchemical_atoms=range(4))  # Modify ions.
         cls.test_regions['Toluene'] = AlchemicalRegion(alchemical_atoms=range(6))  # Only partially modified.
         cls.test_regions['AlanineDipeptide'] = AlchemicalRegion(alchemical_atoms=range(22))
         cls.test_regions['HostGuestExplicit'] = AlchemicalRegion(alchemical_atoms=range(126, 156))

--- a/openmmtools/tests/test_alchemy.py
+++ b/openmmtools/tests/test_alchemy.py
@@ -1128,6 +1128,8 @@ class TestAbsoluteAlchemicalFactory(object):
             testsystems.LennardJonesFluid(nparticles=100, dispersion_correction=True)
         cls.test_systems['WaterBox with reaction field, no switch, no dispersion correction'] = \
             testsystems.WaterBox(dispersion_correction=False, switch=False, nonbondedMethod=openmm.app.CutoffPeriodic)
+        cls.test_systems['TIP4P-EW WaterBox and NaCl with PME'] = \
+            testsystems.WaterBox(nonbondedMethod=openmm.app.PME, model='tip4pew', ionic_strength=200*unit.millimolar)
 
         # Vacuum and implicit.
         cls.test_systems['AlanineDipeptideVacuum'] = testsystems.AlanineDipeptideVacuum()
@@ -1150,6 +1152,7 @@ class TestAbsoluteAlchemicalFactory(object):
         cls.test_regions['LennardJonesCluster'] = AlchemicalRegion(alchemical_atoms=range(2))
         cls.test_regions['LennardJonesFluid'] = AlchemicalRegion(alchemical_atoms=range(10))
         cls.test_regions['WaterBox'] = AlchemicalRegion(alchemical_atoms=range(3))
+        cls.test_regions['WaterBox and NaCl'] = AlchemicalRegion(alchemical_atoms=range(2))  # Modify ions.
         cls.test_regions['Toluene'] = AlchemicalRegion(alchemical_atoms=range(6))  # Only partially modified.
         cls.test_regions['AlanineDipeptide'] = AlchemicalRegion(alchemical_atoms=range(22))
         cls.test_regions['HostGuestExplicit'] = AlchemicalRegion(alchemical_atoms=range(126, 156))


### PR DESCRIPTION
Ready for review!

- Fix #258 : add support for virtual sites in `AbsoluteAlchemicalFactory`.
- Add `positive_ion`, `negative_ion` and `ionic_strength` constructor arguments to `WaterBox`. This was necessary to create a TIP4P test with something that could be alchemically modified (the ions).