### PR TITLE
Fix ideal gas failures

### DIFF
--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -19,7 +19,7 @@ requirements:
     - openmm
     - parmed
     - mdtraj
-
+    
   run:
     - python
     - cython

--- a/openmmtools/mcmc.py
+++ b/openmmtools/mcmc.py
@@ -288,7 +288,7 @@ class MCMCSampler(object):
         # Retrieve data.
         self.sampler_state.update_from_context(context)
 
-        timer.report_timing()
+        #timer.report_timing()
 
 
 # =============================================================================
@@ -656,8 +656,8 @@ class BaseIntegratorMove(object):
         timer.start("{}: Context request".format(move_name))
         context, integrator = context_cache.get_context(thermodynamic_state, integrator)
         timer.stop("{}: Context request".format(move_name))
-        logger.debug("{}: Context obtained, platform is {}".format(
-            move_name, context.getPlatform().getName()))
+        #logger.debug("{}: Context obtained, platform is {}".format(
+        #    move_name, context.getPlatform().getName()))
 
         # Perform the integration.
         for attempt_counter in range(self.n_restart_attempts + 1):
@@ -714,7 +714,7 @@ class BaseIntegratorMove(object):
         sampler_state.update_from_context(context_state)
         timer.stop("{}: update sampler state".format(move_name))
 
-        timer.report_timing()
+        #timer.report_timing()
 
     @abc.abstractmethod
     def _get_integrator(self, thermodynamic_state):
@@ -891,7 +891,7 @@ class MetropolizedMove(object):
 
         # Print timing information.
         timer.stop(benchmark_id)
-        timer.report_timing()
+        #timer.report_timing()
 
     def __getstate__(self):
         if self.context_cache is None:

--- a/openmmtools/tests/test_mcmc.py
+++ b/openmmtools/tests/test_mcmc.py
@@ -141,9 +141,9 @@ def subtest_mcmc_expectation(testsystem, move):
             testsystem.__class__.__name__)
 
         potential_expectation = testsystem.get_potential_expectation(thermodynamic_state) / kT
-        [t0, g, Neff_max] = timeseries.detectEquilibration(potential_n, fast=False)
+        [t0, g, Neff_max] = timeseries.detectEquilibration(potential_n)
         potential_mean = potential_n[t0:].mean()
-        dpotential_mean = potential_n[t0:].std() / Neff_max
+        dpotential_mean = potential_n[t0:].std() / np.sqrt(Neff_max)
         potential_error = potential_mean - potential_expectation
         nsigma = abs(potential_error) / dpotential_mean
 
@@ -164,9 +164,9 @@ def subtest_mcmc_expectation(testsystem, move):
             testsystem.__class__.__name__)
 
         volume_expectation = testsystem.get_volume_expectation(thermodynamic_state) / (unit.nanometers**3)
-        [t0, g, Neff_max] = timeseries.detectEquilibration(volume_n, fast=False)
+        [t0, g, Neff_max] = timeseries.detectEquilibration(volume_n)
         volume_mean = volume_n[t0:].mean()
-        dvolume_mean = volume_n[t0:].std() / Neff_max
+        dvolume_mean = volume_n[t0:].std() / np.sqrt(Neff_max)
         volume_error = volume_mean - volume_expectation
         nsigma = abs(volume_error) / dvolume_mean
 

--- a/openmmtools/tests/test_mcmc.py
+++ b/openmmtools/tests/test_mcmc.py
@@ -91,7 +91,7 @@ def subtest_mcmc_expectation(testsystem, move):
 
     # Test settings.
     temperature = 298.0 * unit.kelvin
-    niterations = 250  # number of production iterations
+    niterations = 500  # number of production iterations
     if system.usesPeriodicBoundaryConditions():
         pressure = 1.0*unit.atmosphere
     else:

--- a/openmmtools/tests/test_mcmc.py
+++ b/openmmtools/tests/test_mcmc.py
@@ -91,8 +91,7 @@ def subtest_mcmc_expectation(testsystem, move):
 
     # Test settings.
     temperature = 298.0 * unit.kelvin
-    nequil = 10  # number of equilibration iterations
-    niterations = 40  # number of production iterations
+    niterations = 100  # number of production iterations
     if system.usesPeriodicBoundaryConditions():
         pressure = 1.0*unit.atmosphere
     else:
@@ -109,9 +108,8 @@ def subtest_mcmc_expectation(testsystem, move):
                                              temperature=temperature,
                                              pressure=pressure)
 
-    # Create MCMC sampler and equilibrate.
+    # Create MCMC sampler
     sampler = MCMCSampler(thermodynamic_state, sampler_state, move=move)
-    sampler.run(nequil)
 
     # Accumulate statistics.
     x_n = np.zeros([niterations], np.float64)  # x_n[i] is the x position of atom 1 after iteration i, in angstroms
@@ -143,17 +141,17 @@ def subtest_mcmc_expectation(testsystem, move):
             testsystem.__class__.__name__)
 
         potential_expectation = testsystem.get_potential_expectation(thermodynamic_state) / kT
-        potential_mean = potential_n.mean()
-        g = timeseries.statisticalInefficiency(potential_n, fast=True)
-        dpotential_mean = potential_n.std() / np.sqrt(niterations / g)
+        [t0, g, Neff_max] = timeseries.detectEquilibration(potential_n)
+        potential_mean = potential_n[t0:].mean()
+        dpotential_mean = potential_n[t0:].std() / Neff_max
         potential_error = potential_mean - potential_expectation
         nsigma = abs(potential_error) / dpotential_mean
 
         err_msg = ('Potential energy expectation\n'
                    'observed {:10.5f} +- {:10.5f}kT | expected {:10.5f} | '
-                   'error {:10.5f} +- {:10.5f} ({:.1f} sigma)\n'
+                   'error {:10.5f} +- {:10.5f} ({:.1f} sigma) | t0 {:5d} | g {:5.1f} | Neff {:8.1f}\n'
                    '----------------------------------------------------------------------------').format(
-            potential_mean, dpotential_mean, potential_expectation, potential_error, dpotential_mean, nsigma)
+            potential_mean, dpotential_mean, potential_expectation, potential_error, dpotential_mean, nsigma, t0, g, Neff_max)
         assert nsigma <= NSIGMA_CUTOFF, err_msg.format()
         if debug:
             print(err_msg)
@@ -166,17 +164,17 @@ def subtest_mcmc_expectation(testsystem, move):
             testsystem.__class__.__name__)
 
         volume_expectation = testsystem.get_volume_expectation(thermodynamic_state) / (unit.nanometers**3)
-        volume_mean = volume_n.mean()
-        g = timeseries.statisticalInefficiency(volume_n, fast=True)
-        dvolume_mean = volume_n.std() / np.sqrt(niterations / g)
+        [t0, g, Neff_max] = timeseries.detectEquilibration(volume_n)
+        volume_mean = volume_n[t0:].mean()
+        dvolume_mean = volume_n[t0:].std() / Neff_max
         volume_error = volume_mean - volume_expectation
         nsigma = abs(volume_error) / dvolume_mean
 
         err_msg = ('Volume expectation\n'
                    'observed {:10.5f} +- {:10.5f}kT | expected {:10.5f} | '
-                   'error {:10.5f} +- {:10.5f} ({:.1f} sigma)\n'
+                   'error {:10.5f} +- {:10.5f} ({:.1f} sigma) | t0 {:5d} | g {:5.1f} | Neff {:8.1f}\n'
                    '----------------------------------------------------------------------------').format(
-            volume_mean, dvolume_mean, volume_expectation, volume_error, dvolume_mean, nsigma)
+            volume_mean, dvolume_mean, volume_expectation, volume_error, dvolume_mean, nsigma, t0, g, Neff_max)
         assert nsigma <= NSIGMA_CUTOFF, err_msg.format()
         if debug:
             print(err_msg)

--- a/openmmtools/tests/test_mcmc.py
+++ b/openmmtools/tests/test_mcmc.py
@@ -141,7 +141,7 @@ def subtest_mcmc_expectation(testsystem, move):
             testsystem.__class__.__name__)
 
         potential_expectation = testsystem.get_potential_expectation(thermodynamic_state) / kT
-        [t0, g, Neff_max] = timeseries.detectEquilibration(potential_n)
+        [t0, g, Neff_max] = timeseries.detectEquilibration(potential_n, fast=False)
         potential_mean = potential_n[t0:].mean()
         dpotential_mean = potential_n[t0:].std() / Neff_max
         potential_error = potential_mean - potential_expectation
@@ -164,7 +164,7 @@ def subtest_mcmc_expectation(testsystem, move):
             testsystem.__class__.__name__)
 
         volume_expectation = testsystem.get_volume_expectation(thermodynamic_state) / (unit.nanometers**3)
-        [t0, g, Neff_max] = timeseries.detectEquilibration(volume_n)
+        [t0, g, Neff_max] = timeseries.detectEquilibration(volume_n, fast=False)
         volume_mean = volume_n[t0:].mean()
         dvolume_mean = volume_n[t0:].std() / Neff_max
         volume_error = volume_mean - volume_expectation

--- a/openmmtools/tests/test_mcmc.py
+++ b/openmmtools/tests/test_mcmc.py
@@ -91,7 +91,7 @@ def subtest_mcmc_expectation(testsystem, move):
 
     # Test settings.
     temperature = 298.0 * unit.kelvin
-    niterations = 100  # number of production iterations
+    niterations = 250  # number of production iterations
     if system.usesPeriodicBoundaryConditions():
         pressure = 1.0*unit.atmosphere
     else:

--- a/openmmtools/testsystems.py
+++ b/openmmtools/testsystems.py
@@ -658,7 +658,7 @@ class HarmonicOscillator(TestSystem):
     Notes
     -----
 
-    The natural period of a harmonic oscillator is T = sqrt(m/K), so you will want to use an
+    The natural period of a harmonic oscillator is T = 2*pi*sqrt(m/K), so you will want to use an
     integration timestep smaller than ~ T/10.
 
     The standard deviation in position in each dimension is sigma = (kT / K)^(1/2)


### PR DESCRIPTION
There have been a number of stochastic test failures for the ideal gas barostat test, so I've tried to update the test to be more reliable.

Instead of fixing the number of equilibration iterations, I've increased the total number of iterations and used `pymbar.timeseries.detectEquilibration()` to identify the production region. Unfortunately, it seems like I'm getting real test failures at this point. Locally, I see things like:
```
======================================================================
FAIL: Testing MCMC expectation for HarmonicOscillator
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/choderaj/miniconda3/lib/python3.5/site-packages/nose/case.py", line 198, in runTest
    self.test(*self.arg)
  File "/Users/choderaj/github/choderalab/openmmtools/openmmtools/openmmtools/tests/test_mcmc.py", line 155, in subtest_mcmc_expectation
    assert nsigma <= NSIGMA_CUTOFF, err_msg.format()
AssertionError: Potential energy expectation
observed    1.81022 +-    0.01639kT | expected    1.50000 | error    0.31022 +-    0.01639 (18.9 sigma) | t0     0 | g   1.0 | Neff    101.0
----------------------------------------------------------------------------
======================================================================
FAIL: Testing MCMC expectation for IdealGas
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/choderaj/miniconda3/lib/python3.5/site-packages/nose/case.py", line 198, in runTest
    self.test(*self.arg)
  File "/Users/choderaj/github/choderalab/openmmtools/openmmtools/openmmtools/tests/test_mcmc.py", line 178, in subtest_mcmc_expectation
    assert nsigma <= NSIGMA_CUTOFF, err_msg.format()
AssertionError: Volume expectation
observed 8664.27240 +-    6.54014kT | expected 8811.36331 | error -147.09091 +-    6.54014 (22.5 sigma) | t0    17 | g   1.1 | Neff     76.8
----------------------------------------------------------------------------
```
It would be useful if @andrrizzi @maxentile @Lnaden might be able to take a look at what could be going on here. We will want to sort these out before the YANK 1.0 release or Langevin paper submission.