### PR TITLE
Fix typo in LangevinIntegrator property

### DIFF
--- a/openmmtools/integrators.py
+++ b/openmmtools/integrators.py
@@ -1202,7 +1202,7 @@ class LangevinIntegrator(ThermostatedIntegrator):
     @property
     def is_metropolized(self):
         """Return True if this integrator is Metropolized, False otherwise."""
-        return self._is_metropolized
+        return self._metropolized_integrator
 
     def _add_integrator_steps(self):
         """Add the steps to the integrator--this can be overridden to place steps around the integration.


### PR DESCRIPTION
It looks like there was a typo on the `is_metropolized` property where `_is_metropolized` does not appear to be assigned anywhere. Changing this to instead use the `_metropolized_integrator` attribute.