### PR TITLE
Add new LangevinSplittingDynamicsMove

### DIFF
--- a/docs/mcmc.rst
+++ b/docs/mcmc.rst
@@ -130,6 +130,7 @@ A number of MCMC component move types that can be arranged into groups or subcla
     MetropolizedMove
     IntegratorMove
     LangevinDynamicsMove
+    LangevinSplittingDynamicsMove
     GHMCMove
     HMCMove
     MonteCarloBarostatMove

--- a/openmmtools/integrators.py
+++ b/openmmtools/integrators.py
@@ -1917,10 +1917,11 @@ class GeodesicBAOABIntegrator(LangevinIntegrator):
         super(GeodesicBAOABIntegrator, self).__init__(*args, **kwargs)
 
 class GHMCIntegrator(LangevinIntegrator):
+    """Create a generalized hybrid Monte Carlo (GHMC) integrator."""
 
     def __init__(self, *args, **kwargs):
         """
-        Create a generalized hybrid Monte Carlo (GHMC) integrator.
+
 
         Parameters
         ----------

--- a/openmmtools/mcmc.py
+++ b/openmmtools/mcmc.py
@@ -1204,14 +1204,12 @@ class LangevinSplittingDynamicsMove(LangevinDynamicsMove):
 
     or create a Langevin move with specified splitting.
 
-    >>> move = LangevinSplittingDynamicsMove(splitting="V { R O R } V")
+    >>> move = LangevinSplittingDynamicsMove(splitting="O { V R V } O")
 
     Where this splitting is a 5 step symplectic integrator:
 
-        1. Half-step velocity updates (V),
-        2. Hybrid Metropolized step around the half position updates (R) with Ornstein-Uhlenbeck (O) interactions with
-            the stochastic heat bath interactions.
-        3. A final half-step in velocity
+        *. Ornstein-Uhlenbeck (O) interactions with the stochastic heat bath interactions
+        *. Hybrid Metropolized step around the half-step velocity updates (V) with full position updates (R).
 
     Perform one update of the sampler state. The sampler state is updated
     with the new state.

--- a/openmmtools/tests/test_mcmc.py
+++ b/openmmtools/tests/test_mcmc.py
@@ -368,7 +368,7 @@ def test_metropolized_moves():
 
 def test_langevin_splitting_move():
     """Test that the langevin splitting mcmc move works with different splittings"""
-    splittings = ["V R O R V", "V R R R O R R R V", "V { R O R } V"]
+    splittings = ["V R O R V", "V R R R O R R R V", "O { V R V } O"]
     testsystem = testsystems.AlanineDipeptideVacuum()
     sampler_state = SamplerState(testsystem.positions)
     thermodynamic_state = ThermodynamicState(testsystem.system, 300*unit.kelvin)

--- a/openmmtools/tests/test_mcmc.py
+++ b/openmmtools/tests/test_mcmc.py
@@ -261,6 +261,7 @@ def test_moves_serialization():
     test_cases = [
         IntegratorMove(openmm.VerletIntegrator(1.0*unit.femtosecond), n_steps=10),
         LangevinDynamicsMove(),
+        LangevinSplittingDynamicsMove(),
         GHMCMove(),
         HMCMove(context_cache=context_cache),
         MonteCarloBarostatMove(context_cache=dummy_cache),
@@ -363,6 +364,20 @@ def test_metropolized_moves():
         # Check that we were able to generate both an accepted and a rejected move.
         assert len(move.atom_subset) != 0, ('Could not generate an accepted and rejected '
                                             'move for class {}'.format(move_class.__name__))
+
+
+def test_langevin_splitting_move():
+    """Test that the langevin splitting mcmc move works with different splittings"""
+    splittings = ["V R O R V", "V R R R O R R R V", "V { R O R } V"]
+    testsystem = testsystems.AlanineDipeptideVacuum()
+    sampler_state = SamplerState(testsystem.positions)
+    thermodynamic_state = ThermodynamicState(testsystem.system, 300*unit.kelvin)
+    for splitting in splittings:
+        move = LangevinSplittingDynamicsMove(splitting=splitting)
+        # Create MCMC sampler
+        sampler = MCMCSampler(thermodynamic_state, sampler_state, move=move)
+        sampler.run(1)
+
 
 
 # =============================================================================

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ import subprocess
 DOCLINES = __doc__.split("\n")
 
 ########################
-VERSION = "0.13.0"
+VERSION = "0.13.1"
 ISRELEASED = False
 __version__ = VERSION
 ########################

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ import subprocess
 DOCLINES = __doc__.split("\n")
 
 ########################
-VERSION = "0.13.1"
+VERSION = "0.13.0"
 ISRELEASED = False
 __version__ = VERSION
 ########################


### PR DESCRIPTION
Uses the custom `LangevinDynamics` integrator with optional splitting and metropolization strings.

Could use review by @maxentile (especially the test), and possibly @andrrizzi if possible (I know you are out)