### PR TITLE
Fix sphinx docs

### DIFF
--- a/docs/cache.rst
+++ b/docs/cache.rst
@@ -5,10 +5,6 @@ Cache
 
 The module :mod:`openmmtools.cache` implements a shared LRU cache for OpenMM `Context <http://docs.openmm.org/7.1.0/api-python/generated/simtk.openmm.openmm.Context.html>`_ objects that tries to minimize the number of objects in memory at the same time.
 
- - :class:`LRUCache`: A simple LRU cache with a dictionary-like interface. It supports a maximum capacity and expiration.
- - :class:`ContextCache`: A LRU cache for OpenMM `Context <http://docs.openmm.org/7.1.0/api-python/generated/simtk.openmm.openmm.Context.html>`_ objects.
- - ``global_context_cache``: A shared :class:`ContextCache` that minimizes the number of `Context <http://docs.openmm.org/7.1.0/api-python/generated/simtk.openmm.openmm.Context.html>`_ creations when employing :class:`MCMCMove`s.
-
 Cache objects
 -------------
 
@@ -19,3 +15,4 @@ Cache objects
 
     LRUCache
     ContextCache
+    global_context_cache

--- a/docs/forcefactories.rst
+++ b/docs/forcefactories.rst
@@ -1,15 +1,12 @@
 .. _forcefactories::
 
-Cache
-=====
+Force Factories
+===============
 
 The module :mod:`openmmtools.forcefactories` implements utility methods and factories to configure system forces.
 
- - :func:`replace_reaction_field`: Configure a system to model the electrostatics with an :class:`UnshiftedReactionField` force.
- - :func:`restrain_atoms`: Apply a soft harmonic restraint to the given atoms.
-
-Cache objects
--------------
+Force Factories
+---------------
 
 .. currentmodule:: openmmtools.forcefactories
 .. autosummary::

--- a/docs/forces.rst
+++ b/docs/forces.rst
@@ -5,10 +5,6 @@ Forces
 
 The module :mod:`openmmtools.forces` implements custom forces that are not natively found in OpenMM.
 
- - :class:`UnshiftedReactionFieldForce`: A `CustomNonbondedForce <http://docs.openmm.org/7.1.0/api-python/generated/simtk.openmm.openmm.CustomNonbondedForce.html>`_ implementing a reaction field variant with `c_rf` term set to zero and a switching function. Using the native OpenMM reaction field implementation with `c_rf != 0` can cause issues with hydration free energy calculations.
- - :func:`find_nonbonded_force`: Find the first ``NonbondedForce`` in an OpenMM ``System``.
- - :func:`iterate_nonbonded_forces`: Iterate over all the ``NonbondedForce``s in an OpenMM ``System``.
-
 Useful Custom Forces
 --------------------
 

--- a/docs/forces.rst
+++ b/docs/forces.rst
@@ -9,8 +9,8 @@ The module :mod:`openmmtools.forces` implements custom forces that are not nativ
  - :func:`find_nonbonded_force`: Find the first ``NonbondedForce`` in an OpenMM ``System``.
  - :func:`iterate_nonbonded_forces`: Iterate over all the ``NonbondedForce``s in an OpenMM ``System``.
 
-Cache objects
--------------
+Useful Custom Forces
+--------------------
 
 .. currentmodule:: openmmtools.forces
 .. autosummary::
@@ -18,5 +18,14 @@ Cache objects
     :toctree: api/generated/
 
     UnshiftedReactionFieldForce
+
+Utility functions
+--------------------
+
+.. currentmodule:: openmmtools.forces
+.. autosummary::
+    :nosignatures:
+    :toctree: api/generated/
+
     find_nonbonded_force
     iterate_nonbonded_forces

--- a/openmmtools/cache.py
+++ b/openmmtools/cache.py
@@ -27,7 +27,7 @@ from openmmtools import integrators
 # =============================================================================
 
 class LRUCache(object):
-    """A simple LRU cache.
+    """A simple LRU cache with a dictionary-like interface that supports maximum capacity and expiration.
 
     It can be configured to have a maximum number of elements (capacity)
     and an element expiration (time_to_live) measured in number of accesses
@@ -570,7 +570,7 @@ class DummyContextCache(object):
 # =============================================================================
 
 global_context_cache = ContextCache(capacity=None, time_to_live=None)
-
+"""A shared ContextCache that minimizes Context object creating when using MCMCMove."""
 
 # =============================================================================
 # CACHE ENTRY (MODULE INTERNAL USAGE)

--- a/openmmtools/forcefactories.py
+++ b/openmmtools/forcefactories.py
@@ -29,7 +29,7 @@ from openmmtools import forces
 
 def replace_reaction_field(reference_system, switch_width=1.0*unit.angstrom,
                            return_copy=True, shifted=False):
-    """Return a system converted to use a switched reaction-field electrostatics.
+    """Return a system converted to use a switched reaction-field electrostatics using :class:`openmmtools.forces.UnshiftedReactionField`.
 
     This will add an `UnshiftedReactionFieldForce` or `SwitchedReactionFieldForce`
     for each `NonbondedForce` that utilizes `CutoffPeriodic`.

--- a/openmmtools/forces.py
+++ b/openmmtools/forces.py
@@ -52,7 +52,7 @@ def find_nonbonded_force(system):
 
 
 def iterate_nonbonded_forces(system):
-    """Iterate over all OpenMM `NonbondedForce`s in `system`.
+    """Iterate over all OpenMM ``NonbondedForce``s in an OpenMM system.
 
     Parameters
     ----------


### PR DESCRIPTION
* Fix Force API documentation, which contained misnamed "Cache objects" and repeated information
* Fix Cache API documentation, which repeated information 
* Fix Force Factories docs, which contained misnamed "Cache objects"