### PR TITLE
Change Travis builds to Test Dev and Non-dev OpenMM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ script:
   # Add org channel
   - conda config --add channels ${ORGNAME}
   # Add omnia dev channels
-  - conda config --add channels https://conda.anaconda.org/omnia/label/dev
+  - if [ ! $NODEVOMNIA ]; then conda config --add channels https://conda.anaconda.org/omnia/label/dev; fi
   # Add conda-forge channel back to top priority
   - conda config --add channels conda-forge
   # Build the recipe
@@ -36,6 +36,7 @@ env:
   matrix:
     - python=2.7  CONDA_PY=27
     - python=3.5  CONDA_PY=35
+    - python=3.5  CONDA_PY=35 NODEVOMNIA=true
     - python=3.6  CONDA_PY=36
   global:
     - ORGNAME="omnia" # the name of the organization

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,3 +51,8 @@ env:
 after_success:
   - echo "after_success"
   - if [ "$TRAVIS_SECURE_ENV_VARS" == true ]; then source devtools/travis-ci/after_success.sh; fi
+
+branches:
+ only:
+  - master
+  - travis-nodev

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,3 +56,4 @@ branches:
  only:
   - master
   - travis-nodev
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-language: python
+language: c
 sudo: false
 addons:
   apt:
@@ -34,25 +34,21 @@ script:
 
 env:
   matrix:
-    include:
-    - python: '2.7'
-      env: python=2.7 CONDA_PY=27
-    - python: '3.5'
-      env: python=3.5 CONDA_PY=35
-    - python: '3.5'
-      env: python=3.5 CONDA_PY=35 DEVOMNIA=true
-    - python: '3.6'
-      env: python=3.6 CONDA_PY=36
-    allow_failures:
-    - python: '3.5'
-      env: python=3.5 CONDA_PY=35 DEVOMNIA=true
+    - python=2.7 CONDA_PY=27
+    - python=3.5 CONDA_PY=35
+    - python=3.5 CONDA_PY=35 DEVOMNIA=true
+    - python=3.6 CONDA_PY=36
 
-  global:
-    - ORGNAME="omnia" # the name of the organization
-    - PACKAGENAME="openmmtools" # the name of your package
-    - OPENMM_CPU_THREADS="1" # only use one CPU thread for determinism
-    # encrypted BINSTAR_TOKEN for push of dev package to binstar
-    - secure: "DP5heLvW3wnHvw6d2tinSHcyAxe0EWEsoL4X3lrGC+BSSy3Fd60pb90zSibK/hcxzV7Cb/x4mC4C7KPgGZEXzvVFH/iF7tg2Yy41XgyuZ5vxacfXICdryoTAlGxrbwACvO/ak+OHEYTtkX3OyFM/f8zV0z7Shz/rOSbSvcEKmpQ="
+    global:
+      - ORGNAME="omnia" # the name of the organization
+      - PACKAGENAME="openmmtools" # the name of your package
+      - OPENMM_CPU_THREADS="1" # only use one CPU thread for determinism
+      # encrypted BINSTAR_TOKEN for push of dev package to binstar
+      - secure: "DP5heLvW3wnHvw6d2tinSHcyAxe0EWEsoL4X3lrGC+BSSy3Fd60pb90zSibK/hcxzV7Cb/x4mC4C7KPgGZEXzvVFH/iF7tg2Yy41XgyuZ5vxacfXICdryoTAlGxrbwACvO/ak+OHEYTtkX3OyFM/f8zV0z7Shz/rOSbSvcEKmpQ="
+
+matrix:
+  allow_failures:
+  - env: python=3.5 CONDA_PY=35 DEVOMNIA=true
 
 after_success:
   - echo "after_success"

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ script:
   # Add org channel
   - conda config --add channels ${ORGNAME}
   # Add omnia dev channels
-  - if [ ! $NODEVOMNIA ]; then conda config --add channels https://conda.anaconda.org/omnia/label/dev; fi
+  - if [ $DEVOMNIA ]; then conda config --add channels https://conda.anaconda.org/omnia/label/dev; fi
   # Add conda-forge channel back to top priority
   - conda config --add channels conda-forge
   # Build the recipe
@@ -36,8 +36,11 @@ env:
   matrix:
     - python=2.7  CONDA_PY=27
     - python=3.5  CONDA_PY=35
-    - python=3.5  CONDA_PY=35 NODEVOMNIA=true
+    - python=3.5  CONDA_PY=35 DEVOMNIA=true
     - python=3.6  CONDA_PY=36
+    allow_failures:
+      - env: python=3.5  CONDA_PY=35 DEVOMNIA=true
+
   global:
     - ORGNAME="omnia" # the name of the organization
     - PACKAGENAME="openmmtools" # the name of your package

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,6 @@ addons:
     sources:
     - ubuntu-toolchain-r-test
 
-python:
-  - '2.7'
-  - '3.5'
-  - '3.5dev'
-  - '3.6'
-
 install:
   - bash -x devtools/travis-ci/install.sh
   - export PYTHONUNBUFFERED=true
@@ -41,16 +35,17 @@ script:
 env:
   matrix:
     include:
-     - python: '2.7'
-       env: python=2.7 CONDA_PY=27
-     - python: '3.5'
-       env: python=3.5 CONDA_PY=35
-     - python: '3.5dev'
-       env: python=3.5 CONDA_PY=35 DEVOMNIA=true
-     - python: '3.6'
-       env: python=3.6 CONDA_PY=36
+    - python: '2.7'
+      env: python=2.7 CONDA_PY=27
+    - python: '3.5'
+      env: python=3.5 CONDA_PY=35
+    - python: '3.5'
+      env: python=3.5 CONDA_PY=35 DEVOMNIA=true
+    - python: '3.6'
+      env: python=3.6 CONDA_PY=36
     allow_failures:
-      - python: '3.5dev'
+    - python: '3.5'
+      env: python=3.5 CONDA_PY=35 DEVOMNIA=true
 
   global:
     - ORGNAME="omnia" # the name of the organization

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,15 @@
-language: c
+language: python
 sudo: false
 addons:
   apt:
     sources:
     - ubuntu-toolchain-r-test
+
+python:
+  - '2.7'
+  - '3.5'
+  - '3.5dev'
+  - '3.6'
 
 install:
   - bash -x devtools/travis-ci/install.sh
@@ -34,12 +40,17 @@ script:
 
 env:
   matrix:
-    - python=2.7  CONDA_PY=27
-    - python=3.5  CONDA_PY=35
-    - python=3.5  CONDA_PY=35 DEVOMNIA=true
-    - python=3.6  CONDA_PY=36
+    include:
+     - python: '2.7'
+       env: python=2.7 CONDA_PY=27
+     - python: '3.5'
+       env: python=3.5 CONDA_PY=35
+     - python: '3.5dev'
+       env: python=3.5 CONDA_PY=35 DEVOMNIA=true
+     - python: '3.6'
+       env: python=3.6 CONDA_PY=36
     allow_failures:
-      - env: python=3.5  CONDA_PY=35 DEVOMNIA=true
+      - python: '3.5dev'
 
   global:
     - ORGNAME="omnia" # the name of the organization

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,13 +38,12 @@ env:
     - python=3.5 CONDA_PY=35
     - python=3.5 CONDA_PY=35 DEVOMNIA=true
     - python=3.6 CONDA_PY=36
-
-    global:
-      - ORGNAME="omnia" # the name of the organization
-      - PACKAGENAME="openmmtools" # the name of your package
-      - OPENMM_CPU_THREADS="1" # only use one CPU thread for determinism
-      # encrypted BINSTAR_TOKEN for push of dev package to binstar
-      - secure: "DP5heLvW3wnHvw6d2tinSHcyAxe0EWEsoL4X3lrGC+BSSy3Fd60pb90zSibK/hcxzV7Cb/x4mC4C7KPgGZEXzvVFH/iF7tg2Yy41XgyuZ5vxacfXICdryoTAlGxrbwACvO/ak+OHEYTtkX3OyFM/f8zV0z7Shz/rOSbSvcEKmpQ="
+  global:
+    - ORGNAME="omnia" # the name of the organization
+    - PACKAGENAME="openmmtools" # the name of your package
+    - OPENMM_CPU_THREADS="1" # only use one CPU thread for determinism
+    # encrypted BINSTAR_TOKEN for push of dev package to binstar
+    - secure: "DP5heLvW3wnHvw6d2tinSHcyAxe0EWEsoL4X3lrGC+BSSy3Fd60pb90zSibK/hcxzV7Cb/x4mC4C7KPgGZEXzvVFH/iF7tg2Yy41XgyuZ5vxacfXICdryoTAlGxrbwACvO/ak+OHEYTtkX3OyFM/f8zV0z7Shz/rOSbSvcEKmpQ="
 
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,8 +53,3 @@ after_success:
   - echo "after_success"
   - if [ "$TRAVIS_SECURE_ENV_VARS" == true ]; then source devtools/travis-ci/after_success.sh; fi
 
-branches:
- only:
-  - master
-  - travis-nodev
-

--- a/openmmtools/tests/test_integrators.py
+++ b/openmmtools/tests/test_integrators.py
@@ -306,6 +306,7 @@ def test_external_protocol_work_accumulation():
     integrator.step(25)
     del context, integrator
 
+
 class TestExternalPerturbationLangevinIntegrator(TestCase):
 
     def create_system(self, testsystem, parameter_name, parameter_initial, temperature = 298.0 * unit.kelvin, platform_name='Reference'):
@@ -318,7 +319,14 @@ class TestExternalPerturbationLangevinIntegrator(TestCase):
         # Create the context
         platform = openmm.Platform.getPlatformByName(platform_name)
         if platform_name in ['CPU', 'CUDA']:
-            platform.setPropertyDefaultValue('DeterministicForces', 'true')
+            try:
+                platform.setPropertyDefaultValue('DeterministicForces', 'true')
+            except Exception as e:
+                mm_min_version = '7.2.0'
+                if platform_name == 'CPU' and openmm.version.short_version < mm_min_version:
+                    print("Deterministic CPU forces not present in versions of OpenMM prior to {}".format(mm_min_version))
+                else:
+                    raise e
         context = openmm.Context(system, integrator, platform)
         context.setParameter(parameter_name, parameter_initial)
         context.setPositions(testsystem.positions)


### PR DESCRIPTION
This changes the Travis builds to by default use the normal (not-dev) Omnia channel.
Adds a test which is allowed to fail that pulls down from the Omnia Dev label. Only runs on a single Python version.

@jchodera this changes the default to use the normal omnia channel for all tests and a "allowed to fail" single test on the dev channel. Is this what you had in mind or do you want this reversed so the default is the dev and a single on normal?

cc #270 