### PR TITLE
Removed dynamic typing mechanism in CompoundState to fix pickling.

### DIFF
--- a/openmmtools/tests/test_alchemy.py
+++ b/openmmtools/tests/test_alchemy.py
@@ -1738,13 +1738,7 @@ class TestAlchemicalState(object):
 
         # The object is deserialized correctly.
         deserialized_state = utils.deserialize(serialization)
-        original_system_pickle = pickle.dumps(compound_state.system)
-        original_alchemical_state_pickle = pickle.dumps(compound_state._composable_states[0])
-        deserialized_system_pickle = pickle.dumps(deserialized_state.system)
-        deserialized_alchemical_state_pickle = pickle.dumps(deserialized_state._composable_states[0])
-        assert original_system_pickle == deserialized_system_pickle
-        assert original_alchemical_state_pickle == deserialized_alchemical_state_pickle
-
+        assert pickle.dumps(compound_state) == pickle.dumps(deserialized_state)
 
 
 # =============================================================================

--- a/openmmtools/tests/test_states.py
+++ b/openmmtools/tests/test_states.py
@@ -533,7 +533,7 @@ class TestThermodynamicState(object):
         check_barostat_thermostat(npt_system, operator.ne)
 
         # Standardize system sets pressure and temperature to standard.
-        ThermodynamicState._standardize_system(npt_system)
+        npt_state._standardize_system(npt_system)
         check_barostat_thermostat(npt_system, operator.eq)
 
     def test_method_create_context(self):


### PR DESCRIPTION
Should be ready for review as soon as tests pass.

I had to convert the `ThermodynamicState._standardize_system()` method from class to instance method to make the change. All state classes are now tested for pickling.