### PR TITLE
Add logical and bitwise operators for math_eval

### DIFF
--- a/openmmtools/tests/test_utils.py
+++ b/openmmtools/tests/test_utils.py
@@ -57,7 +57,10 @@ def test_math_eval():
                   ('(x + lambda) / z * 4', {'x': 1, 'lambda': 2, 'z': 3}, 4.0),
                   ('-((x + y) / z * 4)**2', {'x': 1, 'y': 2, 'z': 3}, -16.0),
                   ('ceil(0.8) + acos(x) + step(0.5 - x) + step(0.5)', {'x': 1}, 2),
-                  ('step_hm(x)', {'x': 0}, 0.5)]
+                  ('step_hm(x)', {'x': 0}, 0.5),
+                  ('{1,2,3} & {2,3,4}', None, {2, 3}),
+                  ('myset or {2,3,4}', {'myset': {1, 2, 3}}, {1, 2, 3, 4}),
+                  ('(myset or my2set) & {2, 3}', {'myset': {1, 2}, 'my2set': {3, 4}}, {2, 3})]
     for expression, variables, result in test_cases:
         evaluated_expression = math_eval(expression, variables)
         assert evaluated_expression == result, '{}, {}, {}'.format(

--- a/openmmtools/tests/test_utils.py
+++ b/openmmtools/tests/test_utils.py
@@ -58,9 +58,9 @@ def test_math_eval():
                   ('-((x + y) / z * 4)**2', {'x': 1, 'y': 2, 'z': 3}, -16.0),
                   ('ceil(0.8) + acos(x) + step(0.5 - x) + step(0.5)', {'x': 1}, 2),
                   ('step_hm(x)', {'x': 0}, 0.5),
-                  ('{1,2,3} & {2,3,4}', None, {2, 3}),
-                  ('myset or {2,3,4}', {'myset': {1, 2, 3}}, {1, 2, 3, 4}),
-                  ('(myset or my2set) & {2, 3}', {'myset': {1, 2}, 'my2set': {3, 4}}, {2, 3})]
+                  ('myset & myset2', {'myset': {1,2,3}, 'myset2': {2,3,4}}, {2, 3}),
+                  ('myset or myset2', {'myset': {1,2,3}, 'myset2': {2,3,4}}, {1, 2, 3, 4}),
+                  ('(myset or my2set) & myset3', {'myset': {1, 2}, 'my2set': {3, 4}, 'myset3': {2, 3}}, {2, 3})]
     for expression, variables, result in test_cases:
         evaluated_expression = math_eval(expression, variables)
         assert evaluated_expression == result, '{}, {}, {}'.format(

--- a/openmmtools/utils.py
+++ b/openmmtools/utils.py
@@ -233,6 +233,9 @@ def math_eval(expression, variables=None, functions=None):
     - step_hm(x) : Heaviside step function with half-maximum convention.
     - sign(x) : sign function (0.0 for x=0.0)
 
+    Available operators are `+`, `-`, `*`, `/`, `**`, `-x` (negative),
+    `&`, `and`, `|`, and `or`
+
     Parameters
     ----------
     expression : str
@@ -287,7 +290,7 @@ def math_eval(expression, variables=None, functions=None):
                 return operators[type(node.op)](*values)
             # Pre-processes all nodes,
             # This does remove the small "A and B" operation which skips evaluating B if A is False
-            processed_values = [*map(_math_eval, node.values)]
+            processed_values = list(map(_math_eval, node.values))
             # Run through each value and apply the pairwise operations
             while len(processed_values) > 1:
                 replacement_value = common_operator(processed_values[:2])

--- a/openmmtools/utils.py
+++ b/openmmtools/utils.py
@@ -233,8 +233,11 @@ def math_eval(expression, variables=None, functions=None):
     - step_hm(x) : Heaviside step function with half-maximum convention.
     - sign(x) : sign function (0.0 for x=0.0)
 
-    Available operators are `+`, `-`, `*`, `/`, `**`, `-x` (negative),
-    `&`, `and`, `|`, and `or`
+    Available operators are ``+``, ``-``, ``*``, ``/``, ``**``, ``-x`` (negative),
+    ``&``, ``and``, ``|``, and ``or``
+
+    **The operators ``and`` and ``or`` operate BITWISE and behave the same as ``&`` and ``|`` respectively as this
+    function is not designed to handle logical operations.**
 
     Parameters
     ----------
@@ -248,7 +251,7 @@ def math_eval(expression, variables=None, functions=None):
 
     Returns
     -------
-    float
+    result
         The result of the evaluated expression.
 
     Examples

--- a/openmmtools/utils.py
+++ b/openmmtools/utils.py
@@ -237,7 +237,7 @@ def math_eval(expression, variables=None, functions=None):
     ``&``, ``and``, ``|``, and ``or``
 
     **The operators ``and`` and ``or`` operate BITWISE and behave the same as ``&`` and ``|`` respectively as this
-    function is not designed to handle logical operations.**
+    function is not designed to handle logical operations.** If you provide sets, they must be as variables.
 
     Parameters
     ----------

--- a/openmmtools/utils.py
+++ b/openmmtools/utils.py
@@ -288,18 +288,14 @@ def math_eval(expression, variables=None, functions=None):
             return operators[type(node.op)](_math_eval(node.left),
                                             _math_eval(node.right))
         elif isinstance(node, ast.BoolOp):
-            # Handle Ternary Boolean Operator which has no operator equivalent
-            def common_operator(values):
-                return operators[type(node.op)](*values)
-            # Pre-processes all nodes,
-            # This does remove the small "A and B" operation which skips evaluating B if A is False
-            processed_values = list(map(_math_eval, node.values))
-            # Run through each value and apply the pairwise operations
-            while len(processed_values) > 1:
-                replacement_value = common_operator(processed_values[:2])
-                processed_values.pop(0)
-                processed_values[0] = replacement_value
-            return processed_values[0]
+            # Parse ternary operator
+            if len(node.values) > 2:
+                # Left-to-right precedence.
+                left_value = copy.deepcopy(node)
+                left_value.values.pop(-1)
+            else:
+                left_value = node.values[0]
+            return operators[type(node.op)](_math_eval(left_value), _math_eval(node.values[-1]))
         elif isinstance(node, ast.Name):
             try:
                 return variables[node.id]


### PR DESCRIPTION
Adds the ability to provide additional operators to the math_eval function. Only adds the `and`, `&`, `or`, and `|` operators.

This is a feature needed in an upcoming version of YANK