### PR TITLE
Update context box vectors before positions in SamplerState.apply_to_context()

### DIFF
--- a/openmmtools/states.py
+++ b/openmmtools/states.py
@@ -1714,11 +1714,12 @@ class SamplerState(object):
             Context only to compute energies.
 
         """
+        # NOTE: Box vectors MUST be updated before positions are set.
+        if self.box_vectors is not None:
+            context.setPeriodicBoxVectors(*self.box_vectors)
         context.setPositions(self._positions)
         if self._velocities is not None and not ignore_velocities:
             context.setVelocities(self._velocities)
-        if self.box_vectors is not None:
-            context.setPeriodicBoxVectors(*self.box_vectors)
 
     def has_nan(self):
         """Check that energies and positions are finite.


### PR DESCRIPTION
Fixes #305.

Without this fix, explicit solvent simulations are likely to sample incorrect distributions or experience `nan`s when a barostat is in use.

Tagging some folks that may have noticed problems with this issue:
* @andrrizzi @Lnaden in YANK
* @maxentile in MCMC-based sample cache generation (if using `SamplerState.apply_to_context`)
* @pgrinaway in perses