### PR TITLE
Exact PME electrostatics treatment and fast computation of reduced potentials

### DIFF
--- a/docs/releasehistory.rst
+++ b/docs/releasehistory.rst
@@ -6,6 +6,9 @@ Development snapshot
 New features
 ------------
 - Add a ``WaterCluster`` testsystem (`#322 <https://github.com/choderalab/openmmtools/pull/322>`_)
+- Add exact treatment of PME electrostatics in `alchemy.AbsoluteAlchemicalFactory`. (`#320 <https://github.com/choderalab/openmmtools/pull/320>`_)
+- Add method in ``ThermodynamicState`` for the efficient computation of the reduced potential at a list of states. (`#320 <https://github.com/choderalab/openmmtools/pull/320>`_)
+- When a ``SamplerState`` is applied to many ``Context``s, the units are stripped only once for optimization. (`#320 <https://github.com/choderalab/openmmtools/pull/320>`_)
 
 
 0.13.4 - Barostat/External Force Bugfix, Restart Robustness

--- a/openmmtools/alchemy.py
+++ b/openmmtools/alchemy.py
@@ -571,15 +571,15 @@ class AlchemicalState(object):
 
         """
         need_changes = False
-        standardize_system = False
 
         # The standard_system changes with update_alchemical_charges
         # if the system uses exact PME treatment.
         if attribute_name == 'update_alchemical_charges':
             original_charges_force = self._find_exact_pme_forces(standard_system, original_charges_only=True)
-            old_update_charge_parameter = bool(original_charges_force.getGlobalParameterDefaultValue(
-                _UPDATE_ALCHEMICAL_CHARGES_PARAMETER_IDX))
-            need_changes = old_update_charge_parameter != self.update_alchemical_charges
+            if original_charges_force is not None:
+                old_update_charge_parameter = bool(original_charges_force.getGlobalParameterDefaultValue(
+                    _UPDATE_ALCHEMICAL_CHARGES_PARAMETER_IDX))
+                need_changes = old_update_charge_parameter != self.update_alchemical_charges
 
         # If we are not allowed to update_alchemical_charges is off and
         # we change lambda_electrostatics we also change the compatibility.

--- a/openmmtools/alchemy.py
+++ b/openmmtools/alchemy.py
@@ -391,7 +391,7 @@ class AlchemicalState(object):
         """Set the state from a dictionary representation."""
         parameters = serialization['parameters']
         alchemical_variables = serialization['alchemical_variables']
-        update_alchemical_charges = serialization['update_alchemical_charges']
+        update_alchemical_charges = serialization.get('update_alchemical_charges', True)
         alchemical_functions = dict()
 
         # Temporarily store alchemical functions.

--- a/openmmtools/alchemy.py
+++ b/openmmtools/alchemy.py
@@ -769,8 +769,8 @@ class AlchemicalState(object):
                         force.getEnergyFunction() == '0.0;' and
                         force.getGlobalParameterName(0) == 'lambda_electrostatics'):
                 if original_charges_only:
+                    original_charges_force = force
                     break
-                original_charges_force = force
                 n_found += 1
             elif isinstance(force, openmm.NonbondedForce):
                 nonbonded_force = force

--- a/openmmtools/alchemy.py
+++ b/openmmtools/alchemy.py
@@ -768,8 +768,8 @@ class AlchemicalState(object):
             if (isinstance(force, openmm.CustomNonbondedForce) and
                         force.getEnergyFunction() == '0.0;' and
                         force.getGlobalParameterName(0) == 'lambda_electrostatics'):
+                original_charges_force = force
                 if original_charges_only:
-                    original_charges_force = force
                     break
                 n_found += 1
             elif isinstance(force, openmm.NonbondedForce):

--- a/openmmtools/states.py
+++ b/openmmtools/states.py
@@ -41,21 +41,27 @@ def group_by_compatibility(thermodynamic_states):
     Returns
     -------
     compatible_groups : list of list of ThermodynamicState
-       The states grouped by compatibility.
+        The states grouped by compatibility.
+    original_indices: list of list of int
+        The indices of the ThermodynamicStates in theoriginal list.
 
     """
     compatible_groups = []
-    for state in thermodynamic_states:
+    original_indices = []
+    for state_idx, state in enumerate(thermodynamic_states):
         # Search for compatible group.
         found_compatible = False
-        for group in compatible_groups:
+        for group, indices in zip(compatible_groups, original_indices):
             if state.is_state_compatible(group[0]):
                 found_compatible = True
                 group.append(state)
+                indices.append(state_idx)
+
         # Create new one.
         if not found_compatible:
             compatible_groups.append([state])
-    return compatible_groups
+            original_indices.append([state_idx])
+    return compatible_groups, original_indices
 
 
 def _box_vectors_volume(box_vectors):

--- a/openmmtools/states.py
+++ b/openmmtools/states.py
@@ -2459,11 +2459,13 @@ class CompoundThermodynamicState(ThermodynamicState):
             assert isinstance(composable_state, IComposableState)
 
         # Copy internal attributes of thermodynamic state.
+        thermodynamic_state = copy.deepcopy(thermodynamic_state)
         self.__dict__ = thermodynamic_state.__dict__
 
         # Setting self._composable_states signals __setattr__ to start
         # searching in composable states as well, so this must be the
         # last new attribute set in the constructor.
+        composable_states = copy.deepcopy(composable_states)
         self._composable_states = composable_states
 
         # This call causes the thermodynamic state standard system

--- a/openmmtools/states.py
+++ b/openmmtools/states.py
@@ -2146,7 +2146,7 @@ class IComposableState(utils.SubhookedABCMeta):
 
     @abc.abstractmethod
     def _on_setattr(self, standard_system, attribute_name):
-        """Update the standard system after a state attribute is set.
+        """Check if standard system needs to be updated after a state attribute is set.
 
         This callback function is called after an attribute is set (i.e.
         after __setattr__ is called on this state) or if an attribute whose
@@ -2162,8 +2162,8 @@ class IComposableState(utils.SubhookedABCMeta):
 
         Returns
         -------
-        updated : bool
-            True if the standard system has been updated, False if no change
+        need_changes : bool
+            True if the standard system has to be updated, False if no change
             occurred.
 
         """
@@ -2493,7 +2493,10 @@ class CompoundThermodynamicState(ThermodynamicState):
     def _on_setattr_callback(self, composable_state, attribute_name):
         """Updates the standard system (and hash) after __setattr__."""
         if composable_state._on_setattr(self._standard_system, attribute_name):
-            self._update_standard_system(self._standard_system)
+            new_standard_system = copy.deepcopy(self._standard_system)
+            composable_state.apply_to_system(new_standard_system)
+            composable_state._standardize_system(new_standard_system)
+            self._update_standard_system(new_standard_system)
 
     def _apply_to_context_in_state(self, context, thermodynamic_state):
         super(CompoundThermodynamicState, self)._apply_to_context_in_state(context, thermodynamic_state)

--- a/openmmtools/tests/test_alchemy.py
+++ b/openmmtools/tests/test_alchemy.py
@@ -1788,7 +1788,7 @@ class TestAlchemicalState(object):
             context = create_context(system, integrator)
 
             # No force group should be updated if we don't move.
-            assert alchemical_state._find_force_groups_to_update(context, alchemical_state2) == set()
+            assert alchemical_state._find_force_groups_to_update(context, alchemical_state2, memo={}) == set()
 
             # Change the lambdas one by one and check that the method
             # recognize that the force group energy must be updated.
@@ -1800,7 +1800,7 @@ class TestAlchemicalState(object):
                 # Change the current state.
                 setattr(alchemical_state2, lambda_name, 0.0)
                 force_group = expected_force_groups[lambda_name]
-                assert alchemical_state._find_force_groups_to_update(context, alchemical_state2) == {force_group}
+                assert alchemical_state._find_force_groups_to_update(context, alchemical_state2, memo={}) == {force_group}
                 setattr(alchemical_state2, lambda_name, 1.0)  # Reset current state.
             del context
 
@@ -1967,7 +1967,8 @@ class TestAlchemicalState(object):
         compound_states = []
         for thermo_state in thermodynamic_states:
             for alchemical_state in alchemical_states:
-                compound_states.append(states.CompoundThermodynamicState(thermo_state, [alchemical_state]))
+                compound_states.append(states.CompoundThermodynamicState(
+                    copy.deepcopy(thermo_state), [copy.deepcopy(alchemical_state)]))
 
         # Group thermodynamic states by compatibility.
         compatible_groups, _ = states.group_by_compatibility(compound_states)

--- a/openmmtools/tests/test_alchemy.py
+++ b/openmmtools/tests/test_alchemy.py
@@ -1649,7 +1649,7 @@ class TestAlchemicalState(object):
                 assert parameter_value == 0.5
         del context
 
-        def compute_electrostatic_energy(lambda_electrostatics):
+        def compute_electrostatic_energy(lambda_electrostatics, context):
             alchemical_state.lambda_electrostatics = lambda_electrostatics
             alchemical_state.apply_to_context(context)
             return context.getState(getEnergy=True).getPotentialEnergy()

--- a/openmmtools/tests/test_alchemy.py
+++ b/openmmtools/tests/test_alchemy.py
@@ -404,7 +404,9 @@ def is_alchemical_pme_treatment_exact(alchemical_system):
     # If exact PME is here, there is a CustomNonbondedForce storing
     # the original charges that does not contribute to the energy.
     for force in alchemical_system.getForces():
-        if isinstance(force, openmm.CustomNonbondedForce) and force.getEnergyFunction() == '0.0;':
+        if (isinstance(force, openmm.CustomNonbondedForce) and
+                    force.getEnergyFunction() == '0.0;' and
+                    force.getGlobalParameterName(0) == 'lambda_electrostatics'):
             return True
     return False
 

--- a/openmmtools/tests/test_alchemy.py
+++ b/openmmtools/tests/test_alchemy.py
@@ -1667,8 +1667,8 @@ class TestAlchemicalState(object):
         positions = self.alanine_test_system.positions
         reference_system = copy.deepcopy(self.alanine_test_system.system)
         context.setPositions(positions)
-        alchemical_energy_1 = compute_electrostatic_energy(1.0)
-        alchemical_energy_0 = compute_electrostatic_energy(0.0)
+        alchemical_energy_1 = compute_electrostatic_energy(1.0, context)
+        alchemical_energy_0 = compute_electrostatic_energy(0.0, context)
         del context
 
         reference_energy_1 = compute_energy(reference_system, positions)

--- a/openmmtools/tests/test_alchemy.py
+++ b/openmmtools/tests/test_alchemy.py
@@ -1973,12 +1973,9 @@ class TestAlchemicalState(object):
         # ----------------------
 
         # Check that changes in lambda_electrostatics are not compatible.
-        alchemical_state_incompatible1 = copy.deepcopy(alchemical_state)
-        alchemical_state_incompatible1.lambda_electrostatics = 0.0
-        compound_state_incompatible1 = states.CompoundThermodynamicState(
-            thermodynamic_state=copy.deepcopy(alanine_state_exact_pme),
-            composable_states=[alchemical_state_incompatible1]
-        )
+        compound_state_incompatible1 = copy.deepcopy(compound_state)
+        compound_state_incompatible1.lambda_electrostatics = 0.0
+
         # States with non-exact PME treatment are incompatible
         # even with same lambda_electrostatics.
         compound_state_incompatible2 = states.CompoundThermodynamicState(
@@ -1996,8 +1993,14 @@ class TestAlchemicalState(object):
         compound_state_incompatible4 = copy.deepcopy(compound_state)
         compound_state_incompatible4.update_alchemical_charges = True
 
+        compound_state_incompatible5 = copy.deepcopy(compound_state)
+        compound_state_incompatible5.update_alchemical_charges = True
+        compound_state_incompatible5.lambda_electrostatics = 0.5
+        compound_state_incompatible5.update_alchemical_charges = False
+
         for incompatible_state in [compound_state_incompatible1, compound_state_incompatible2,
-                                   compound_state_incompatible3, compound_state_incompatible4]:
+                                   compound_state_incompatible3, compound_state_incompatible4,
+                                   compound_state_incompatible5]:
             self._check_compatibility(compound_state, incompatible_state, context, is_compatible=False)
 
         # Test compatibility.

--- a/openmmtools/tests/test_alchemy.py
+++ b/openmmtools/tests/test_alchemy.py
@@ -1303,7 +1303,7 @@ class TestAbsoluteAlchemicalFactory(object):
                 forcefactories.replace_reaction_field(test_system.system, return_copy=False,
                                                       switch_width=factory.switch_width)
 
-    def filter_test_cases(self, condition_func, max_number=None):
+    def filter_cases(self, condition_func, max_number=None):
         """Return the list of test cases that satisfy condition_func(test_case_name)."""
         if max_number is None:
             max_number = len(self.test_cases)
@@ -1319,9 +1319,9 @@ class TestAbsoluteAlchemicalFactory(object):
     def test_split_force_groups(self):
         """Forces having different lambda variables should have a different force group."""
         # Select 1 implicit, 1 explicit, and 1 exact PME explicit test case randomly.
-        test_cases = self.filter_test_cases(lambda x: 'Implicit' in x, max_number=1)
-        test_cases.update(self.filter_test_cases(lambda x: 'Explicit ' in x and 'exact PME' in x, max_number=1))
-        test_cases.update(self.filter_test_cases(lambda x: 'Explicit ' in x and 'exact PME' not in x, max_number=1))
+        test_cases = self.filter_cases(lambda x: 'Implicit' in x, max_number=1)
+        test_cases.update(self.filter_cases(lambda x: 'Explicit ' in x and 'exact PME' in x, max_number=1))
+        test_cases.update(self.filter_cases(lambda x: 'Explicit ' in x and 'exact PME' not in x, max_number=1))
         for test_name, (test_system, alchemical_system, alchemical_region) in test_cases.items():
             f = partial(check_split_force_groups, alchemical_system)
             f.description = "Testing force splitting among groups of {}".format(test_name)
@@ -1348,7 +1348,7 @@ class TestAbsoluteAlchemicalFactory(object):
         """Test interacting state energy by force component."""
         # This is a very expensive but very informative test. We can
         # run this locally when test_fully_interacting_energies() fails.
-        test_cases = self.filter_test_cases(lambda x: 'Explicit' in x)
+        test_cases = self.filter_cases(lambda x: 'Explicit' in x)
         for test_name, (test_system, alchemical_system, alchemical_region) in test_cases.items():
             f = partial(check_interacting_energy_components, test_system.system, alchemical_system,
                         alchemical_region, test_system.positions)
@@ -1970,7 +1970,7 @@ class TestAlchemicalState(object):
                 compound_states.append(states.CompoundThermodynamicState(thermo_state, [alchemical_state]))
 
         # Group thermodynamic states by compatibility.
-        compatible_groups = states.group_by_compatibility(compound_states)
+        compatible_groups, _ = states.group_by_compatibility(compound_states)
         assert len(compatible_groups) == 2
 
         # Compute the reduced potentials.

--- a/openmmtools/tests/test_states.py
+++ b/openmmtools/tests/test_states.py
@@ -725,14 +725,15 @@ class TestThermodynamicState(object):
         thermodynamic_states = [
             ThermodynamicState(self.alanine_explicit, temperature=300*unit.kelvin,
                                pressure=1.0*unit.atmosphere),
+            ThermodynamicState(self.toluene_implicit, temperature=200*unit.kelvin),
             ThermodynamicState(self.alanine_explicit, temperature=250*unit.kelvin,
-                               pressure=1.2*unit.atmosphere),
-            ThermodynamicState(self.toluene_implicit, temperature=200*unit.kelvin)
+                               pressure=1.2*unit.atmosphere)
         ]
 
         # Group thermodynamic states by compatibility.
-        compatible_groups = group_by_compatibility(thermodynamic_states)
+        compatible_groups, original_indices = group_by_compatibility(thermodynamic_states)
         assert len(compatible_groups) == 2
+        assert original_indices == [[0, 2], [1]]
 
         # Compute the reduced potentials.
         expected_energies = []

--- a/openmmtools/tests/test_states.py
+++ b/openmmtools/tests/test_states.py
@@ -853,11 +853,12 @@ class TestSamplerState(object):
             sampler_state.positions = copy.deepcopy(positions)
             assert sampler_state._unitless_positions_cache is None
 
-            if isinstance(sampler_state._positions._value, np.ndarray):
-                old_unitless_positions = copy.deepcopy(sampler_state._unitless_positions)
-                sampler_state.positions[5:8] = [[2.0, 2.0, 2.0], [2.0, 2.0, 2.0], [2.0, 2.0, 2.0]] * pos_unit
-                assert sampler_state.positions.has_changed
-                assert np.all(old_unitless_positions[5:8] != sampler_state._unitless_positions[5:8])
+            # TODO reactivate this test once OpenMM 7.2 is released with bugfix for #1940
+            # if isinstance(sampler_state._positions._value, np.ndarray):
+            #     old_unitless_positions = copy.deepcopy(sampler_state._unitless_positions)
+            #     sampler_state.positions[5:8] = [[2.0, 2.0, 2.0], [2.0, 2.0, 2.0], [2.0, 2.0, 2.0]] * pos_unit
+            #     assert sampler_state.positions.has_changed
+            #     assert np.all(old_unitless_positions[5:8] != sampler_state._unitless_positions[5:8])
 
             if sampler_state.velocities is not None:
                 old_unitless_velocities = copy.deepcopy(sampler_state._unitless_velocities)
@@ -867,11 +868,12 @@ class TestSamplerState(object):
                 sampler_state.velocities = copy.deepcopy(sampler_state.velocities)
                 assert sampler_state._unitless_velocities_cache is None
 
-                if isinstance(sampler_state._velocities._value, np.ndarray):
-                    old_unitless_velocities = copy.deepcopy(sampler_state._unitless_velocities)
-                    sampler_state.velocities[5:8] = [[2.0, 2.0, 2.0], [2.0, 2.0, 2.0], [2.0, 2.0, 2.0]] * vel_unit
-                    assert sampler_state.velocities.has_changed
-                    assert np.all(old_unitless_velocities[5:8] != sampler_state._unitless_velocities[5:8])
+                # TODO reactivate this test once OpenMM 7.2 is released with bugfix for #1940
+                # if isinstance(sampler_state._velocities._value, np.ndarray):
+                #     old_unitless_velocities = copy.deepcopy(sampler_state._unitless_velocities)
+                #     sampler_state.velocities[5:8] = [[2.0, 2.0, 2.0], [2.0, 2.0, 2.0], [2.0, 2.0, 2.0]] * vel_unit
+                #     assert sampler_state.velocities.has_changed
+                #     assert np.all(old_unitless_velocities[5:8] != sampler_state._unitless_velocities[5:8])
             else:
                 assert sampler_state._unitless_velocities is None
 

--- a/openmmtools/tests/test_states.py
+++ b/openmmtools/tests/test_states.py
@@ -50,7 +50,9 @@ class TestThermodynamicState(object):
         cls.alanine_positions = alanine_explicit.positions
         cls.alanine_no_thermostat = alanine_explicit.system
 
-        cls.toluene_implicit = testsystems.TolueneImplicit().system
+        toluene_implicit = testsystems.TolueneImplicit()
+        cls.toluene_positions = toluene_implicit.positions
+        cls.toluene_implicit = toluene_implicit.system
         cls.toluene_vacuum = testsystems.TolueneVacuum().system
         thermostat = openmm.AndersenThermostat(cls.std_temperature,
                                                1.0/unit.picosecond)
@@ -260,7 +262,6 @@ class TestThermodynamicState(object):
 
         # Correctly reads and set system pressures
         periodic_testcases = [self.alanine_explicit]
-        print('ON IT!')
         for system in periodic_testcases:
             state = ThermodynamicState(system, self.std_temperature)
             assert state.pressure is None
@@ -714,6 +715,46 @@ class TestThermodynamicState(object):
             state.reduced_potential(incompatible_sampler_state)
         assert cm.exception.code == ThermodynamicsError.INCOMPATIBLE_SAMPLER_STATE
 
+    def test_method_reduced_potential_at_states(self):
+        """ThermodynamicState.reduced_potential_at_states() method.
+
+        Computing the reduced potential singularly and with the class
+        method should give the same result.
+        """
+        # Build a mixed collection of compatible and incompatible thermodynamic states.
+        thermodynamic_states = [
+            ThermodynamicState(self.alanine_explicit, temperature=300*unit.kelvin,
+                               pressure=1.0*unit.atmosphere),
+            ThermodynamicState(self.alanine_explicit, temperature=250*unit.kelvin,
+                               pressure=1.2*unit.atmosphere),
+            ThermodynamicState(self.toluene_implicit, temperature=200*unit.kelvin)
+        ]
+
+        # Group thermodynamic states by compatibility.
+        compatible_groups = group_by_compatibility(thermodynamic_states)
+        assert len(compatible_groups) == 2
+
+        # Compute the reduced potentials.
+        expected_energies = []
+        obtained_energies = []
+        for compatible_group in compatible_groups:
+            # Create context.
+            integrator = openmm.VerletIntegrator(2.0*unit.femtoseconds)
+            context = compatible_group[0].create_context(integrator)
+            if len(compatible_group) == 2:
+                context.setPositions(self.alanine_positions)
+            else:
+                context.setPositions(self.toluene_positions)
+
+            # Compute with single-state method.
+            for state in compatible_group:
+                state.apply_to_context(context)
+                expected_energies.append(state.reduced_potential(context))
+
+            # Compute with multi-state method.
+            obtained_energies.extend(ThermodynamicState.reduced_potential_at_states(context, compatible_group))
+        assert np.allclose(np.array(expected_energies), np.array(obtained_energies))
+
 
 # =============================================================================
 # TEST SAMPLER STATE
@@ -933,11 +974,19 @@ class TestCompoundThermodynamicState(object):
         def apply_to_context(self, context):
             context.setParameter('dummy_parameter', self.dummy_parameter)
 
+        def _find_force_groups_to_update(self, context, current_context_state):
+            if current_context_state.dummy_parameter == self.dummy_parameter:
+                return {}
+            force, _ = self._find_dummy_force(context.getSystem())
+            return {force.getForceGroup()}
+
         @classmethod
         def add_dummy_parameter(cls, system):
             """Add to system a CustomBondForce with a dummy parameter."""
             force = openmm.CustomBondForce('dummy_parameter')
             force.addGlobalParameter('dummy_parameter', cls.standard_dummy_parameter)
+            max_force_group = cls._find_max_force_group(system)
+            force.setForceGroup(max_force_group + 1)
             system.addForce(force)
 
         @staticmethod
@@ -953,6 +1002,14 @@ class TestCompoundThermodynamicState(object):
         def set_dummy_parameter(cls, system, value):
             force, parameter_id = cls._find_dummy_force(system)
             force.setGlobalParameterDefaultValue(parameter_id, value)
+
+        @staticmethod
+        def _find_max_force_group(system):
+            max_force_group = 0
+            for force in system.getForces():
+                if max_force_group < force.getForceGroup():
+                    max_force_group = force.getForceGroup()
+            return max_force_group
 
     @classmethod
     def get_dummy_parameter(cls, system):
@@ -1071,7 +1128,7 @@ class TestCompoundThermodynamicState(object):
         assert not compound_state.is_context_compatible(context)
 
     def test_method_apply_to_context(self):
-        """CompoundThermodynamicState.apply_to_context() method."""
+        """Test CompoundThermodynamicState.apply_to_context() method."""
         dummy_parameter = self.DummyState.standard_dummy_parameter
         thermodynamic_state = ThermodynamicState(self.alanine_explicit, self.std_temperature)
         thermodynamic_state.pressure = self.std_pressure
@@ -1089,6 +1146,22 @@ class TestCompoundThermodynamicState(object):
         compound_state.apply_to_context(context)
         assert context.getParameter('dummy_parameter') == self.dummy_parameter
         assert context.getParameter(barostat.Pressure()) == new_pressure / unit.bar
+
+    def test_method_find_force_groups_to_update(self):
+        """Test CompoundThermodynamicState._find_force_groups_to_update() method."""
+        alanine_explicit = copy.deepcopy(self.alanine_explicit)
+        thermodynamic_state = ThermodynamicState(alanine_explicit, self.std_temperature)
+        compound_state = CompoundThermodynamicState(thermodynamic_state, [self.dummy_state])
+        context = compound_state.create_context(openmm.VerletIntegrator(2.0*unit.femtoseconds))
+
+        # No force group should be updated if the two states are identical.
+        assert compound_state._find_force_groups_to_update(context, compound_state) == set()
+
+        # If the dummy parameter changes, there should be 1 force group to update.
+        compound_state2 = copy.deepcopy(compound_state)
+        compound_state2.dummy_parameter -= 0.5
+        group = self.DummyState._find_max_force_group(context.getSystem())
+        assert compound_state._find_force_groups_to_update(context, compound_state2) == {group}
 
 
 # =============================================================================

--- a/openmmtools/tests/test_states.py
+++ b/openmmtools/tests/test_states.py
@@ -940,10 +940,9 @@ class TestCompoundThermodynamicState(object):
         def dummy_parameter(self, value):
             self._dummy_parameter = value
 
-        @classmethod
-        def _standardize_system(cls, system):
+        def _standardize_system(self, system):
             try:
-                cls.set_dummy_parameter(system, cls.standard_dummy_parameter)
+                self.set_dummy_parameter(system, self.standard_dummy_parameter)
             except TypeError:  # No parameter to set.
                 raise ComposableStateError()
 
@@ -965,6 +964,9 @@ class TestCompoundThermodynamicState(object):
 
         def apply_to_context(self, context):
             context.setParameter('dummy_parameter', self.dummy_parameter)
+
+        def _on_setattr(self, standard_system, attribute_name):
+            return False
 
         def _find_force_groups_to_update(self, context, current_context_state, memo):
             if current_context_state.dummy_parameter == self.dummy_parameter:

--- a/openmmtools/tests/test_utils.py
+++ b/openmmtools/tests/test_utils.py
@@ -78,8 +78,11 @@ def test_is_quantity_close():
                   (300.0*unit.kelvin, 300.00000004*unit.kelvin, False),
                   (1.01325*unit.bar, 1.01325000006*unit.bar, True),
                   (1.01325*unit.bar, 1.0132500006*unit.bar, False)]
+
+    err_msg = 'obtained: {}, expected: {} (quantity1: {}, quantity2: {})'
     for quantity1, quantity2, test_result in test_cases:
-        assert is_quantity_close(quantity1, quantity2) is test_result
+        result = is_quantity_close(quantity1, quantity2)
+        assert result is test_result, err_msg.format(result, test_result, quantity1, quantity2)
 
     # Passing quantities with different units raise an exception.
     with nose.tools.assert_raises(TypeError):

--- a/openmmtools/tests/test_utils.py
+++ b/openmmtools/tests/test_utils.py
@@ -82,7 +82,7 @@ def test_is_quantity_close():
     err_msg = 'obtained: {}, expected: {} (quantity1: {}, quantity2: {})'
     for quantity1, quantity2, test_result in test_cases:
         result = is_quantity_close(quantity1, quantity2)
-        assert result is test_result, err_msg.format(result, test_result, quantity1, quantity2)
+        assert result == test_result, err_msg.format(result, test_result, quantity1, quantity2)
 
     # Passing quantities with different units raise an exception.
     with nose.tools.assert_raises(TypeError):

--- a/openmmtools/tests/test_utils.py
+++ b/openmmtools/tests/test_utils.py
@@ -71,6 +71,67 @@ def test_math_eval():
 # TEST QUANTITY UTILITIES
 # =============================================================================
 
+def test_tracked_quantity():
+    """Test TrackedQuantity objects."""
+    def reset(q):
+        assert tracked_quantity.has_changed is True
+        tracked_quantity.has_changed = False
+
+    test_cases = [
+        np.array([10.0, 20.0, 30.0]) * unit.kelvin,
+        [1.0, 2.0, 3.0] * unit.nanometers,
+    ]
+    for quantity in test_cases:
+        tracked_quantity = TrackedQuantity(quantity)
+        u = tracked_quantity.unit
+        assert tracked_quantity.has_changed is False
+
+        tracked_quantity[0] = 5.0 * u
+        assert tracked_quantity[0] == 5.0 * u
+        reset(tracked_quantity)
+
+        tracked_quantity[0:2] = [5.0, 6.0] * u
+        assert np.all(tracked_quantity[0:2] == [5.0, 6.0] * u)
+        reset(tracked_quantity)
+
+        if isinstance(tracked_quantity._value, list):
+            del tracked_quantity[0]
+            assert len(tracked_quantity) == 2
+            reset(tracked_quantity)
+
+            tracked_quantity.append(10.0*u)
+            assert len(tracked_quantity) == 3
+            reset(tracked_quantity)
+
+            tracked_quantity.extend([11.0, 12.0]*u)
+            assert len(tracked_quantity) == 5
+            reset(tracked_quantity)
+
+            element = 15.0*u
+            tracked_quantity.insert(1, element)
+            assert len(tracked_quantity) == 6
+            reset(tracked_quantity)
+
+            tracked_quantity.remove(element.value_in_unit(u))
+            assert len(tracked_quantity) == 5
+            reset(tracked_quantity)
+
+            assert tracked_quantity.pop().unit == u
+            assert len(tracked_quantity) == 4
+            reset(tracked_quantity)
+        else:
+            # Check that numpy views are handled correctly.
+            view = tracked_quantity[:3]
+            view[0] = 20.0*u
+            assert tracked_quantity[0] == 20.0*u
+            reset(tracked_quantity)
+
+            view2 = view[1:]
+            view2[0] = 30.0*u
+            assert tracked_quantity[1] == 30.0*u
+            reset(tracked_quantity)
+
+
 def test_is_quantity_close():
     """Test is_quantity_close method."""
     # (quantity1, quantity2, test_result)

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ import subprocess
 DOCLINES = __doc__.split("\n")
 
 ########################
-VERSION = "0.13.5"
+VERSION = "0.14.0"
 ISRELEASED = False
 __version__ = VERSION
 ########################


### PR DESCRIPTION
Fix #319.

I've run some `timeit` tests, and reading the charges from the `CustomNonbondedForce` is actually pretty fast so I don't think implementing the caching system for the charges is worth it. With
```python
import timeit

def read_charges(system):
    original_charges_force = None
    for force in system.getForces():
        if (isinstance(force, openmm.CustomNonbondedForce) and
                    force.getEnergyFunction() == '0.0;'):
            original_charges_force = force

    # Set alchemical atoms charges.
    _, alchemical_atoms = original_charges_force.getInteractionGroupParameters(0)
    for atom_idx in alchemical_atoms:
        original_charge = original_charges_force.getParticleParameters(atom_idx)[0]

test_system = testsystems.SrcExplicit()
factory = AbsoluteAlchemicalFactory(alchemical_pme_treatment='exact')

# Alchemically modify first 150 atoms of Src.
alchemical_region = AlchemicalRegion(alchemical_atoms=range(150))
alchemical_system = factory.create_alchemical_system(test_system.system, alchemical_region)
globals = {
    'read_charges': read_charges,
    'alchemical_system': alchemical_system,
}
number = 1000
tot_time = timeit.timeit('read_charges(alchemical_system)', globals=globals, number=number)
print('read_charges: time for {} executions: {} s (time per execution {} s)'.format(number, tot_time, tot_time / number))
```
I got on the cluster (CUDA platform)
```
read_charges: time for 1000 executions: 0.13602294865995646 s (time per execution 0.00013602294865995646 s)
```