### PR TITLE
Modified MC rotation moves

### DIFF
--- a/openmmtools/mcmc.py
+++ b/openmmtools/mcmc.py
@@ -1782,14 +1782,14 @@ class MCRotationMove(MetropolizedMove):
         super(MCRotationMove, self).__init__(**kwargs)
 
     @classmethod
-    def rotate_positions(cls, positions, indices=None):
+    def rotate_positions(cls, positions, rotation_center_indices=None):
         """Return the positions after applying a random rotation to them.
 
         Parameters
         ----------
         positions : nx3 numpy.ndarray simtk.unit.Quantity
             The positions to rotate.
-        indices : list
+        rotation_center_indices : list
             Indices of a subset of atoms to center the rotation around, None by default.
 
         Returns
@@ -1805,10 +1805,10 @@ class MCRotationMove(MetropolizedMove):
         x_rot_centers = x_initial
 
         # Update coordinates for the center of rotation from the subset defined by indices
-        if indices is not None:
-            if len(indices) < 1 or len(indices) > x_initial.shape[0]:
-                raise IndexError("The length of indicies must be >= % d and <= %d" % (1, x_initial.shape[0]))
-            x_rot_centers = positions[indices, :]
+        if rotation_center_indices is not None:
+            if len(rotation_center_indices) < 1 or len(rotation_center_indices) > x_initial.shape[0]:
+                raise IndexError("Length of rotation center indices must be >= % d and <= %d" % (1, x_initial.shape[0]))
+            x_rot_centers = positions[rotation_center_indices, :]
 
         x_initial_mean = x_rot_centers.mean(0)
 

--- a/openmmtools/mcmc.py
+++ b/openmmtools/mcmc.py
@@ -1782,13 +1782,15 @@ class MCRotationMove(MetropolizedMove):
         super(MCRotationMove, self).__init__(**kwargs)
 
     @classmethod
-    def rotate_positions(cls, positions):
+    def rotate_positions(cls, positions, indices=None):
         """Return the positions after applying a random rotation to them.
 
         Parameters
         ----------
         positions : nx3 numpy.ndarray simtk.unit.Quantity
             The positions to rotate.
+        indices : list
+            Indices of a subset of atoms to center the rotation around, None by default.
 
         Returns
         -------
@@ -1799,8 +1801,16 @@ class MCRotationMove(MetropolizedMove):
         positions_unit = positions.unit
         x_initial = positions / positions_unit
 
-        # Compute center of geometry of atoms to rotate.
-        x_initial_mean = x_initial.mean(0)
+        # Define coordinates for the center of rotation.
+        x_rot_centers = x_initial
+
+        # Update coordinates for the center of rotation from the subset defined by indices
+        if indices is not None:
+            if len(indices) < 1 or len(indices) > x_initial.shape[0]:
+                raise IndexError("The length of indicies must be >= % d and <= %d" % (1, x_initial.shape[0]))
+            x_rot_centers = positions[indices, :]
+
+        x_initial_mean = x_rot_centers.mean(0)
 
         # Generate a random rotation matrix.
         rotation_matrix = cls.generate_random_rotation_matrix()


### PR DESCRIPTION
Potential enhancement: Following up on discussion in #330, I modified the `rotate_positions` method of `MCRotationMove` to allow a subset of atom positions define the geometric center of rotation.  The unit test for metropolized moves wouldn't test for this modification so when running tests locally, everything goes smoothly. I checked the output configurations, as shown in issue thread. Let me know if I should write a unit test for this.