### PR TITLE
Fix typo in ndof attribute

### DIFF
--- a/openmmtools/testsystems.py
+++ b/openmmtools/testsystems.py
@@ -1794,7 +1794,7 @@ class WaterCluster(TestSystem):
                                  removeCMMotion=False)
 
         n_atoms = system.getNumParticles()
-        self.ndof = 3 * n_atoms - 3 * constrained
+        self.ndof = 3 * n_atoms - (constrained * n_atoms)
 
         # Add a restraining potential centered at the origin.
         system.addForce(construct_restraining_potential(n_atoms, K))
@@ -2669,7 +2669,8 @@ class WaterBox(TestSystem):
         forces['NonbondedForce'].setUseDispersionCorrection(dispersion_correction)
         forces['NonbondedForce'].setEwaldErrorTolerance(ewaldErrorTolerance)
 
-        self.ndof = 3 * system.getNumParticles() - 3 * constrained
+        n_atoms = system.getNumParticles()
+        self.ndof = 3 * n_atoms - (constrained * n_atoms)
 
         self.topology = m.getTopology()
         self.system = system


### PR DESCRIPTION
In `WaterBox` and `WaterCluster`, the `ndof` attribute was computed incorrectly when `constrained=True` -- only 3 d.o.f. were subtracted from the system, regardless of the number of waters in the system.
```python
>>> WaterBox(constrained=False).ndof
4509
>>> WaterBox(constrained=True).ndof
4506
```

Fix: subtract 3 d.o.f. per water.