### PR TITLE
Fix argument order for GeodesicBAOABIntegrator 

### DIFF
--- a/openmmtools/integrators.py
+++ b/openmmtools/integrators.py
@@ -2073,7 +2073,7 @@ class BAOABIntegrator(LangevinIntegrator):
 class GeodesicBAOABIntegrator(LangevinIntegrator):
     """Create a geodesic-BAOAB integrator."""
 
-    def __init__(self, K_r=2, *args, **kwargs):
+    def __init__(self, *args, K_r=2, **kwargs):
         """Create a geodesic BAOAB Langevin integrator.
 
         Parameters

--- a/openmmtools/integrators.py
+++ b/openmmtools/integrators.py
@@ -2070,10 +2070,11 @@ class BAOABIntegrator(LangevinIntegrator):
         kwargs['splitting'] = "V R O R V"
         super(BAOABIntegrator, self).__init__(*args, **kwargs)
 
+
 class GeodesicBAOABIntegrator(LangevinIntegrator):
     """Create a geodesic-BAOAB integrator."""
 
-    def __init__(self, *args, K_r=2, **kwargs):
+    def __init__(self, *args, **kwargs):
         """Create a geodesic BAOAB Langevin integrator.
 
         Parameters
@@ -2112,8 +2113,11 @@ class GeodesicBAOABIntegrator(LangevinIntegrator):
         >>> timestep = 1.0 * unit.femtoseconds
         >>> integrator = GeodesicBAOABIntegrator(K_r=3, temperature=temperature, collision_rate=collision_rate, timestep=timestep)
         """
+        # TODO: move this as an explicity keyword argument after dropping Python 2 support.
+        K_r = kwargs.pop('K_r', 2)
         kwargs['splitting'] = " ".join(["V"] + ["R"] * K_r + ["O"] + ["R"] * K_r + ["V"])
         super(GeodesicBAOABIntegrator, self).__init__(*args, **kwargs)
+
 
 class GHMCIntegrator(LangevinIntegrator):
     """Create a generalized hybrid Monte Carlo (GHMC) integrator."""


### PR DESCRIPTION
This fixes a problem with the API of `GeodesicBAOABIntegrator` so it can be used interchangeably with `BAOABIntegrator` and `LangevinIntegrator`.

At some point, we should add a test that makes sure all of our `LangevinIntegrators` can be invoked like:
```python
integrator = integrator_class(temperature, collision_rate, timestep)
```
to catch this issue in the future.