### PR TITLE
[WIP] Extra-chance GHMC

### DIFF
--- a/openmmtools/integrators.py
+++ b/openmmtools/integrators.py
@@ -42,6 +42,7 @@ import simtk.openmm as mm
 
 from openmmtools.constants import kB
 from openmmtools import respa, utils
+import pandas as pd
 
 logger = logging.getLogger(__name__)
 
@@ -2045,6 +2046,161 @@ class GHMCIntegrator(LangevinIntegrator):
         """
         kwargs['splitting'] = "O { V R V } O"
         super(GHMCIntegrator, self).__init__(*args, **kwargs)
+
+class XCGHMCIntegrator(GHMCIntegrator):
+    """Extra Chance generalized hybrid Monte Carlo (XCGHMC) integrator.
+        Parameters
+        ----------
+        temperature : numpy.unit.Quantity compatible with kelvin, default: 298*simtk.unit.kelvin
+            The temperature.
+        steps_per_hmc : int, default: 10
+            The number of velocity Verlet steps to take per round of hamiltonian dynamics
+        timestep : numpy.unit.Quantity compatible with femtoseconds, default: 1*simtk.unit.femtoseconds
+            The integration timestep.  The total time taken per iteration
+            will equal timestep * steps_per_hmc
+        extra_chances : int, optional, default=2
+            The number of extra chances.  If the initial move is rejected, up to
+            `extra_chances` rounds of additional moves will be attempted to find
+            an accepted proposal.  `extra_chances=0` correponds to vanilla (G)HMC.
+        steps_per_extra_hmc : int, optional, default=1
+            During each extra chance, do this many steps of hamiltonian dynamics.
+        collision_rate : numpy.unit.Quantity compatible with 1 / femtoseconds, default: None
+           The collision rate for the velocity corruption (GHMC).  If None,
+           velocities information will be discarded after each round (HMC).
+
+    Notes
+    -----
+    This integrator attempts to circumvent rejections by propagating up to
+    `extra_chances` steps of additional dynamics.
+
+    References
+    ----------
+    C. M. Campos, J. M. Sanz-Serna, J. Comp. Phys. 281, (2015)
+    J. Sohl-Dickstein, M. Mudigonda, M. DeWeese.  ICML (2014)
+
+    Author
+    ------
+    Kyle A. Beauchamp
+    """
+
+    def __init__(self, temperature=298.0 * u.kelvin, steps_per_hmc=10, timestep=1 * u.femtoseconds, extra_chances=2, steps_per_extra_hmc=1, collision_rate=None):
+        mm.CustomIntegrator.__init__(self, timestep)
+
+        self.temperature = temperature
+        self.steps_per_hmc = steps_per_hmc
+        self.steps_per_extra_hmc = steps_per_extra_hmc
+        self.timestep = timestep
+        self.extra_chances = extra_chances
+        self.collision_rate = collision_rate
+
+        self.add_compute_steps()
+
+    @property
+    def all_counts(self):
+        """Return a pandas series of moves accepted after step 0, 1, . extra_chances - 1, and flip"""
+        d = {}
+        for i in range(1 + self.extra_chances):
+            d[i] = self.getGlobalVariableByName("n%d" % i)
+
+        d["flip"] = self.n_flip
+
+        return pd.Series(d)
+
+    @property
+    def all_probs(self):
+        """Return a pandas series of probabilities of moves accepted after step 0, 1,  extra_chances - 1, and flip"""
+        d = self.all_counts
+        return d / d.sum()
+
+    @property
+    def n_flip(self):
+        """The total number of momentum flips."""
+        return self.getGlobalVariableByName("nflip")
+
+    def add_compute_steps(self):
+        """The key flow control logic for XCHMC."""
+        self.initialize_variables()
+        self.add_draw_velocities_step()
+        self.add_cache_variables_step()
+        for i in range(1 + self.extra_chances):
+            self.beginIfBlock("uni > mu1")
+            self.add_hmc_iterations()
+            self.addComputeSum("ke", "0.5*m*v*v")
+            self.nan_to_inf("Enew", "ke + energy")
+            self.addComputeGlobal("r", "exp(-(Enew - Eold) / kT)")
+            self.addComputeGlobal("mu", "min(1, r)")  # XCGHMC paper version
+            self.addComputeGlobal("mu1", "max(mu1, mu)")
+            self.addComputeGlobal("terminal_chance", "%d" % i)
+            self.addComputeGlobal("n%d" % i, "n%d + step(mu1 - uni)" % (i))
+            self.addComputeGlobal("steps_taken", "steps_taken + 1")
+            self.endBlock()
+
+        self.beginIfBlock("uni > mu1")
+        self.addComputePerDof("x", "xold")
+        if self.is_GHMC:
+            self.addComputePerDof("v", "-1 * vold")
+        else:
+            self.addComputePerDof("v", "vold")
+        self.addComputeGlobal("nflip", "nflip + 1")
+        self.endBlock()
+
+        self.beginIfBlock("uni <= mu1")
+        self.addComputeGlobal("steps_accepted", "steps_accepted + terminal_chance + 1")
+        self.endBlock()
+
+
+
+    def initialize_variables(self):
+
+        self.addGlobalVariable("accept", 1.0)  # accept or reject
+        self.addGlobalVariable("r", 0.0)  # Metropolis ratio: ratio probabilities
+
+        self.addGlobalVariable("extra_chances", self.extra_chances)  # Maximum number of rounds of dynamics
+
+        self.addGlobalVariable("mu", 0.0)  #
+        self.addGlobalVariable("mu1", 0.0)  # XCGHMC Fig. 3 O1
+
+        for i in range(1 + self.extra_chances):
+            self.addGlobalVariable("n%d" % i, 0.0)  # Number of times accepted when k = i
+
+        self.addGlobalVariable("nflip", 0)  # number of momentum flips (e.g. complete rejections)
+        self.addGlobalVariable("nrounds", 0)  # number of "rounds" of XHMC, e.g. the number of times k = 0
+
+        # Below this point is possible base class material
+
+        self.addGlobalVariable("kT", self.kT)  # thermal energy
+        self.addPerDofVariable("sigma", 0)
+        self.addGlobalVariable("ke", 0)  # kinetic energy
+        self.addPerDofVariable("xold", 0)  # old positions
+        self.addPerDofVariable("vold", 0)  # old velocities
+        self.addGlobalVariable("Eold", 0)  # old energy
+        self.addGlobalVariable("Enew", 0)  # new energy
+        self.addGlobalVariable("terminal_chance", 0)
+
+        self.addPerDofVariable("x1", 0)  # for constraints
+
+        self.addGlobalVariable("steps_accepted", 0)  # Number of productive hamiltonian steps
+        self.addGlobalVariable("steps_taken", 0)  # Number of total hamiltonian steps
+
+        self.addGlobalVariable("uni", 0)  # Uniform random number draw in XCHMC
+        self.addComputePerDof("sigma", "sqrt(kT/m)")
+
+
+        if self.is_GHMC:
+            self.addGlobalVariable("b", self.b)  # velocity mixing parameter
+
+        self.addUpdateContextState()
+
+    def add_cache_variables_step(self):
+        """Store old positions and energies."""
+
+        self.addComputeSum("ke", "0.5*m*v*v")
+        self.addComputeGlobal("Eold", "ke + energy")
+        self.addComputePerDof("xold", "x")
+        self.addComputePerDof("vold", "v")
+
+        self.addComputeGlobal("mu1", "0.0")  # XCGHMC Fig. 3 O1
+        self.addComputeGlobal("uni", "uniform")  # XCGHMC Fig. 3 O1
 
 if __name__ == '__main__':
     import doctest

--- a/openmmtools/integrators.py
+++ b/openmmtools/integrators.py
@@ -2084,7 +2084,7 @@ class XCGHMCIntegrator(GHMCIntegrator):
     Kyle A. Beauchamp (https://github.com/kyleabeauchamp/openmmtools/tree/mjhmc2/openmmtools/hmc_integrators)
     """
 
-    def __init__(self, temperature=298.0 * u.kelvin, steps_per_hmc=10, timestep=1 * u.femtoseconds, extra_chances=2, steps_per_extra_hmc=1, collision_rate=None):
+    def __init__(self, temperature=298.0 * unit.kelvin, steps_per_hmc=10, timestep=1 * unit.femtoseconds, extra_chances=2, steps_per_extra_hmc=1, collision_rate=None):
         mm.CustomIntegrator.__init__(self, timestep)
 
         self.temperature = temperature

--- a/openmmtools/integrators.py
+++ b/openmmtools/integrators.py
@@ -2049,6 +2049,7 @@ class GHMCIntegrator(LangevinIntegrator):
 
 class XCGHMCIntegrator(GHMCIntegrator):
     """Extra Chance generalized hybrid Monte Carlo (XCGHMC) integrator.
+
         Parameters
         ----------
         temperature : numpy.unit.Quantity compatible with kelvin, default: 298*simtk.unit.kelvin
@@ -2080,7 +2081,7 @@ class XCGHMCIntegrator(GHMCIntegrator):
 
     Author
     ------
-    Kyle A. Beauchamp
+    Kyle A. Beauchamp (https://github.com/kyleabeauchamp/openmmtools/tree/mjhmc2/openmmtools/hmc_integrators)
     """
 
     def __init__(self, temperature=298.0 * u.kelvin, steps_per_hmc=10, timestep=1 * u.femtoseconds, extra_chances=2, steps_per_extra_hmc=1, collision_rate=None):

--- a/openmmtools/integrators.py
+++ b/openmmtools/integrators.py
@@ -2047,6 +2047,7 @@ class GHMCIntegrator(LangevinIntegrator):
         kwargs['splitting'] = "O { V R V } O"
         super(GHMCIntegrator, self).__init__(*args, **kwargs)
 
+
 class XCGHMCIntegrator(ThermostatedIntegrator):
     """Extra Chance generalized hybrid Monte Carlo (XCGHMC) integrator.
 

--- a/openmmtools/tests/test_integrators.py
+++ b/openmmtools/tests/test_integrators.py
@@ -25,7 +25,7 @@ from simtk import openmm
 
 from openmmtools import integrators, testsystems
 from openmmtools.integrators import (ThermostatedIntegrator, AlchemicalNonequilibriumLangevinIntegrator,
-                                     GHMCIntegrator, NoseHooverChainVelocityVerletIntegrator)
+                                     GHMCIntegrator, NoseHooverChainVelocityVerletIntegrator, XCGHMCIntegrator)
 
 
 #=============================================================================================
@@ -766,6 +766,31 @@ def test_alchemical_langevin_integrator():
     for splitting in ["O { V R H R V } O", "O V R H R V O", "H R V O V R H"]:
         for nsteps in [0, 1, 10]:
             run_alchemical_langevin_integrator(nsteps=nsteps, splitting=splitting)
+
+def test_xcghmc_integrator_stability():
+    """Loop over the various extra-chance parameters to test stability"""
+
+    test_case = testsystems.AlanineDipeptideVacuum()
+    test_name = test_case.__class__.__name__
+
+    for extra_chances in [0, 1, 2]:
+        for steps_per_hmc in [1, 2]:
+            for steps_per_extra_hmc in [1, 2]:
+
+                integrator = XCGHMCIntegrator(extra_chances=extra_chances,
+                                              steps_per_hmc=steps_per_hmc,
+                                              steps_per_extra_hmc=steps_per_extra_hmc
+                                              )
+
+                check_stability.description = ("Testing XCGHMC (extra_chances={}, "
+                                               "steps_per_hmc={}, "
+                                               "steps_per_extra_hmc={}) "
+                                               "for stability over a short number of "
+                                               "integration steps of {}.").format(
+                    extra_chances, steps_per_hmc, steps_per_extra_hmc, test_name)
+
+                yield check_stability, integrator, test_case
+
 
 if __name__=="__main__":
     test_alchemical_langevin_integrator()

--- a/openmmtools/tests/test_integrators.py
+++ b/openmmtools/tests/test_integrators.py
@@ -765,7 +765,7 @@ def run_nonequilibrium_switching(init_x, alchemical_integrator, nsteps, alchemic
 def test_alchemical_langevin_integrator():
     for splitting in ["O { V R H R V } O", "O V R H R V O", "H R V O V R H"]:
         for nsteps in [0, 1, 10]:
-            run_alchemical_langevin_integrator(nsteps=nsteps)
+            run_alchemical_langevin_integrator(nsteps=nsteps, splitting=splitting)
 
 if __name__=="__main__":
     test_alchemical_langevin_integrator()


### PR DESCRIPTION
 - [x] Implement feature / fix bug
 - [x] Add [tests](https://github.com/choderalab/openmmtools/tree/master/openmmtools/tests)
 - [ ] Update [documentation](https://github.com/choderalab/openmmtools/tree/master/docs) as needed
 - [ ] Update [changelog](https://github.com/choderalab/openmmtools/blob/master/docs/releasehistory.rst)

This PR adapts the Extra-Chance GHMC integrator @kyleabeauchamp had implemented in https://github.com/kyleabeauchamp/openmmtools/tree/mjhmc2/openmmtools/hmc_integrators . When (G)HMC would normally encounter a rejection, this integrator will try again up to `n_extra_chances` times to extend the trajectory subject to a suitably modified accept-reject test. This can reduce the influence of "momentum-flipping" and appears to be much more efficient than standard GHMC in some cases.

I copy-pasted Kyle's code and modified it slightly, but it occurs to me now I could probably open a PR directly from Kyle's fork to preserve the early commit history if preferable. If so, let me know and I'll close this PR and attempt that.

(Also [fixes a small bug](https://github.com/choderalab/openmmtools/commit/db2a22f66645adf22436585c3c4908b24050d262) I noticed in the tests.)

In addition to updating the documentation and changelog, my remaining to-do's are:
- [ ] Add warnings that this is experimental
- [ ] Resolve question about correctness if `n_steps_hmc != steps_per_extra_hmc`
- [ ] Make tests pass