### PR TITLE
Add SamplerState interface to OpenMM CustomCVForce

### DIFF
--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -12,22 +12,20 @@ build:
 requirements:
   build:
     - python
-    - cython
-    - numpy
-    - scipy
+#    - cython
+#    - numpy
+#    - scipy
     - setuptools
     - openmm
-    - parmed
-    - mdtraj
-    - netcdf4
-    - pyyaml
+#    - parmed
+#    - mdtraj
+#    - netcdf4
+#    - pyyaml
 
   run:
     - python
-    - cython
     - numpy
     - scipy
-    - setuptools
     - six
     - openmm
     - parmed

--- a/docs/releasehistory.rst
+++ b/docs/releasehistory.rst
@@ -1,6 +1,13 @@
 Release History
 ===============
 
+0.15.1 - Something New This Way Comes [WIP]
+===========================================
+
+New features
+------------
+- Add ability for `SamplerState` to access new `OpenMM Custom CV Force Variables <http://docs.openmm.org/development/api-python/generated/simtk.openmm.openmm.CustomCVForce.html#simtk.openmm.openmm.CustomCVForce>`_
+
 0.15.0 - Restraint forces
 =========================
 - Add radially-symmetric restraint custom forces (`#336 <https://github.com/choderalab/openmmtools/pull/336>`_).

--- a/docs/releasehistory.rst
+++ b/docs/releasehistory.rst
@@ -6,13 +6,14 @@ Release History
 
 New features
 ------------
-- Add ability for `SamplerState` to access new `OpenMM Custom CV Force Variables <http://docs.openmm.org/development/api-python/generated/simtk.openmm.openmm.CustomCVForce.html#simtk.openmm.openmm.CustomCVForce>`_
+- Add ability for ``SamplerState`` to access new `OpenMM Custom CV Force Variables <http://docs.openmm.org/development/api-python/generated/simtk.openmm.openmm.CustomCVForce.html#simtk.openmm.openmm.CustomCVForce>`_
+- ``SamplerState.update_from_context`` now has keywords to support finer grain updating from the Context. This is only recommended for advanced users.
 
 0.15.0 - Restraint forces
 =========================
 - Add radially-symmetric restraint custom forces (`#336 <https://github.com/choderalab/openmmtools/pull/336>`_).
 - Copy Python attributes of integrators on ``deepcopy()`` (`#336 <https://github.com/choderalab/openmmtools/pull/336>`_).
-- Optimization of `states.CompoundThermodynamicState` deserialization (`#338 <https://github.com/choderalab/openmmtools/pull/338>`_).
+- Optimization of ``states.CompoundThermodynamicState`` deserialization (`#338 <https://github.com/choderalab/openmmtools/pull/338>`_).
 - Bugfixes (`#332 <https://github.com/choderalab/openmmtools/pull/332>`_, `#343 <https://github.com/choderalab/openmmtools/pull/343>`_).
 
 

--- a/openmmtools/mcmc.py
+++ b/openmmtools/mcmc.py
@@ -715,7 +715,14 @@ class BaseIntegratorMove(MCMCMove):
 
         # Updated sampler state.
         timer.start("{}: update sampler state".format(move_name))
-        sampler_state.update_from_context(context_state)
+        # This is an optimization around the fact that Collective Variables are not a part of the State,
+        # but are a part of the Context. We do this call twice to minimize duplicating information fetched from
+        # the State.
+        # Update everything but the collective variables from the State object
+        sampler_state.update_from_context(context_state, ignore_collective_variables=True)
+        # Update only the collective variables from the Context
+        sampler_state.update_from_context(context, ignore_positions=True, ignore_velocities=True,
+                                          ignore_collective_variables=False)
         timer.stop("{}: update sampler state".format(move_name))
 
         #timer.report_timing()

--- a/openmmtools/tests/test_integrators.py
+++ b/openmmtools/tests/test_integrators.py
@@ -417,7 +417,7 @@ class TestExternalPerturbationLangevinIntegrator(TestCase):
 
         assert (integrator.get_protocol_work(dimensionless=True) == 0)
         integrator.step(5)
-        assert(integrator.get_protocol_work(dimensionless=True) == 0)
+        assert np.allclose(integrator.get_protocol_work(dimensionless=True), 0)
 
     def test_reset_protocol_work(self):
         """

--- a/setup.py
+++ b/setup.py
@@ -2,12 +2,8 @@
 Various Python tools for OpenMM.
 """
 from __future__ import print_function
-import os
 import sys
-from distutils.core import setup, Extension
-from setuptools import setup, Extension, find_packages
-import numpy
-import glob
+from setuptools import setup
 import os
 from os.path import relpath, join
 import subprocess
@@ -171,8 +167,6 @@ setup(
     packages=['openmmtools', 'openmmtools.tests', 'openmmtools.scripts', 'openmmtools.storage'],
     package_dir={'openmmtools': 'openmmtools'},
     package_data={'openmmtools': find_package_data('openmmtools/data', 'openmmtools')},
-    install_requires=['numpy', 'scipy', 'openmm', 'parmed', 'mdtraj', 'netCDF4', 'pyyaml'],
-    tests_requires=['nose', 'pymbar', 'netCDF4', 'pyyaml'],
     zip_safe=False,
     scripts=[],
     ext_modules=extensions,


### PR DESCRIPTION
This PR gives the `SamplerState` a regular way to access the CustomCVForce variables and values which may appear in a `Context`.

 - [x] Implement feature / fix bug
 - [x] Add [tests](https://github.com/choderalab/openmmtools/tree/master/openmmtools/tests)
 - [x] Update [documentation](https://github.com/choderalab/openmmtools/tree/master/docs) as needed
 - [x] Update [changelog](https://github.com/choderalab/openmmtools/blob/master/docs/releasehistory.rst)