### PR TITLE
GlobalParameterState and changes for multi-restraint calculations

### DIFF
--- a/devtools/appveyor/install.ps1
+++ b/devtools/appveyor/install.ps1
@@ -7,7 +7,11 @@ $MINICONDA_URL = "http://repo.continuum.io/miniconda/"
 
 function DownloadMiniconda ($python_version, $platform_suffix) {
     $webclient = New-Object System.Net.WebClient
-    $filename = "Miniconda3-4.5.4-Windows-" + $platform_suffix + ".exe"
+    if ($python_version -match "3.4") {
+        $filename = "Miniconda3-3.7.3-Windows-" + $platform_suffix + ".exe"
+    } else {
+        $filename = "Miniconda-3.7.3-Windows-" + $platform_suffix + ".exe"
+    }
     $url = $MINICONDA_URL + $filename
 
     $basedir = $pwd.Path + "\"
@@ -81,6 +85,7 @@ function UpdateConda ($python_home) {
     Write-Host $conda_path $args
     Start-Process -FilePath "$conda_path" -ArgumentList $args -Wait -Passthru
 }
+
 
 function main () {
     InstallMiniconda $env:PYTHON_VERSION $env:PYTHON_ARCH $env:PYTHON

--- a/devtools/appveyor/install.ps1
+++ b/devtools/appveyor/install.ps1
@@ -7,11 +7,7 @@ $MINICONDA_URL = "http://repo.continuum.io/miniconda/"
 
 function DownloadMiniconda ($python_version, $platform_suffix) {
     $webclient = New-Object System.Net.WebClient
-    if ($python_version -match "3.4") {
-        $filename = "Miniconda3-3.7.3-Windows-" + $platform_suffix + ".exe"
-    } else {
-        $filename = "Miniconda-3.7.3-Windows-" + $platform_suffix + ".exe"
-    }
+    $filename = "Miniconda3-4.5.4-Windows-" + $platform_suffix + ".exe"
     $url = $MINICONDA_URL + $filename
 
     $basedir = $pwd.Path + "\"
@@ -85,7 +81,6 @@ function UpdateConda ($python_home) {
     Write-Host $conda_path $args
     Start-Process -FilePath "$conda_path" -ArgumentList $args -Wait -Passthru
 }
-
 
 function main () {
     InstallMiniconda $env:PYTHON_VERSION $env:PYTHON_ARCH $env:PYTHON

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -32,7 +32,7 @@ requirements:
     - mdtraj
     # NetCDF4 on windows conda has DLL issues, so pin libnetcdf. Remove this later
     - netcdf4 # [not win]
-    - netcdf4 ==1.4.0=0 # [win]
+    - netcdf4 ==1.4.0=py*_0 # [win]
     - libnetcdf ==4.6.1=vc14_2 # [win]
     - pyyaml
 

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -30,9 +30,10 @@ requirements:
     - openmm >=7.2
     - parmed
     - mdtraj
-    # NetCDF4 on windows conda has DLL issues, so pin libnetcdf
-    - netcdf4
-    - libnetcdf ==4.6.1=h183b1a9_3 # [win]
+    # NetCDF4 on windows conda has DLL issues, so pin libnetcdf. Remove this later
+    - netcdf4 # [not win]
+    - netcdf4 ==1.4.0=0 # [win]
+    - libnetcdf ==4.6.1=vc14_2 # [win]
     - pyyaml
 
 

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -36,6 +36,7 @@ requirements:
     - netcdf4 ==1.4.0=py*_0 # [win]
     - libnetcdf ==4.6.1=vc14_2 # [win]
     - hdf5 ==1.10.1=vc14_2 # [win]
+    - blosc ==1.14.0=h6538335_1 # [win]
 
 
 test:

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -36,7 +36,7 @@ requirements:
     - netcdf4 ==1.4.0=py*_0 # [win]
     - libnetcdf ==4.6.1=vc14_2 # [win]
     - hdf5 ==1.10.1=vc14_2 # [win]
-    - blosc ==1.14.0=h6538335_1 # [win]
+    - blosc ==1.14.0=h6538335* # [win]
 
 
 test:

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - numpy
     - scipy
     - six
-    - openmm
+    - openmm >=7.2
     - parmed
     - mdtraj
     - netcdf4
@@ -38,8 +38,9 @@ test:
   requires:
     - nose
     - pymbar
-  imports:
-    - openmmtools
+# Until the NetCDF issues are resolved, actual test runs are subject to run_test.[bat,sh] (9/16/2018)
+#  imports:
+#    - openmmtools
 
 about:
   home: https://github.com/choderalab/openmmtools

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -27,26 +27,19 @@ requirements:
     - numpy
     - scipy
     - six
-    - openmm >=7.2
+    - openmm
     - parmed
     - mdtraj
-    - pyyaml
-    # NetCDF4 on windows conda has DLL issues, so pin libnetcdf. Remove this later
     - netcdf4
-#    - netcdf4 # [not win]
-#    - netcdf4 ==1.4.0=py*_0 # [win]
-#    - libnetcdf ==4.6.1=vc14_2 # [win]
-#    - hdf5 ==1.10.1=vc14_2 # [win]
-#    - blosc ==1.14.0=h6538335* # [win]
+    - pyyaml
 
 
 test:
   requires:
     - nose
     - pymbar
-# Until the NetCDF issues are resolved, actual test runs are subject to run_test.[bat,sh]
-#  imports:
-#    - openmmtools
+  imports:
+    - openmmtools
 
 about:
   home: https://github.com/choderalab/openmmtools

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -30,11 +30,12 @@ requirements:
     - openmm >=7.2
     - parmed
     - mdtraj
+    - pyyaml
     # NetCDF4 on windows conda has DLL issues, so pin libnetcdf. Remove this later
     - netcdf4 # [not win]
     - netcdf4 ==1.4.0=py*_0 # [win]
     - libnetcdf ==4.6.1=vc14_2 # [win]
-    - pyyaml
+    - hdf5 ==1.10.1=vc14_2 # [win]
 
 
 test:

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -32,19 +32,21 @@ requirements:
     - mdtraj
     - pyyaml
     # NetCDF4 on windows conda has DLL issues, so pin libnetcdf. Remove this later
-    - netcdf4 # [not win]
-    - netcdf4 ==1.4.0=py*_0 # [win]
-    - libnetcdf ==4.6.1=vc14_2 # [win]
-    - hdf5 ==1.10.1=vc14_2 # [win]
-    - blosc ==1.14.0=h6538335* # [win]
+    - netcdf4
+#    - netcdf4 # [not win]
+#    - netcdf4 ==1.4.0=py*_0 # [win]
+#    - libnetcdf ==4.6.1=vc14_2 # [win]
+#    - hdf5 ==1.10.1=vc14_2 # [win]
+#    - blosc ==1.14.0=h6538335* # [win]
 
 
 test:
   requires:
     - nose
     - pymbar
-  imports:
-    - openmmtools
+# Until the NetCDF issues are resolved, actual test runs are subject to run_test.[bat,sh]
+#  imports:
+#    - openmmtools
 
 about:
   home: https://github.com/choderalab/openmmtools

--- a/devtools/conda-recipe/run_test.bat
+++ b/devtools/conda-recipe/run_test.bat
@@ -1,0 +1,3 @@
+conda uninstall --force --yes netcdf4
+pip install netCDF4
+python -c "import openmmtools"

--- a/devtools/conda-recipe/run_test.sh
+++ b/devtools/conda-recipe/run_test.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+python -c "import openmmtools"

--- a/docs/releasehistory.rst
+++ b/docs/releasehistory.rst
@@ -1,11 +1,29 @@
 Release History
 ===============
 
+0.16.0 - GlobalParameterState class
+===================================
+
+New features
+------------
+- Added the new class ``states.GlobalParameterState`` designed to simplify the implementation of composable states that
+  control global variables (`#363 <https://github.com/choderalab/openmmtools/pull/363>`_).
+- Allow restraint force classes to be controlled by a parameter other than ``lambda_restraints``. This will enable
+  multi-restraints simulations (`#363 <https://github.com/choderalab/openmmtools/pull/363>`_).
+
+Deprecated
+----------
+- Python2 is officially deprecated. Support will be dropped in future versions.
+- Deprecated the signature of ``IComposableState._on_setattr`` to fix a bug where the objects were temporarily left in
+  an inconsistent state when an exception was raised and caught.
+- Deprecated ``update_alchemical_charges`` in ``AlchemicalState`` in anticipation of the new implementation of the
+  exact PME that will be based on the ``NonbondedForce`` offsets rather than ``updateParametersInContext()``.
+
 0.15.0 - Restraint forces
 =========================
 - Add radially-symmetric restraint custom forces (`#336 <https://github.com/choderalab/openmmtools/pull/336>`_).
 - Copy Python attributes of integrators on ``deepcopy()`` (`#336 <https://github.com/choderalab/openmmtools/pull/336>`_).
-- Optimization of `states.CompoundThermodynamicState` deserialization (`#338 <https://github.com/choderalab/openmmtools/pull/338>`_).
+- Optimization of ``states.CompoundThermodynamicState`` deserialization (`#338 <https://github.com/choderalab/openmmtools/pull/338>`_).
 - Bugfixes (`#332 <https://github.com/choderalab/openmmtools/pull/332>`_, `#343 <https://github.com/choderalab/openmmtools/pull/343>`_).
 
 

--- a/docs/releasehistory.rst
+++ b/docs/releasehistory.rst
@@ -15,9 +15,6 @@ New features
   control global variables (`#363 <https://github.com/choderalab/openmmtools/pull/363>`_).
 - Allow restraint force classes to be controlled by a parameter other than ``lambda_restraints``. This will enable
   multi-restraints simulations (`#363 <https://github.com/choderalab/openmmtools/pull/363>`_).
-- ``RadiallySymmetricRestraintForce`` and all subclasses are now a ``CustomCVForce`` subclass wrapping their
-  respective ``CustomBondForce`` and ``CustomCentroidBondForce`` objects. This breaks backwards compatibility, but
-  enables tracking the restraint distances through the new ``SamplerSate`` collective variable features.
 
 Deprecated
 ----------
@@ -26,18 +23,6 @@ Deprecated
   an inconsistent state when an exception was raised and caught.
 - Deprecated ``update_alchemical_charges`` in ``AlchemicalState`` in anticipation of the new implementation of the
   exact PME that will be based on the ``NonbondedForce`` offsets rather than ``updateParametersInContext()``.
-
-Compatibility Warnings
-----------------------
-- ``RadiallySymmetricRestraintForce``'s conversion to ``CustomCVForce``'s break the backwards compatibility with older
-  codes which implement subclasses of it. The largest change is how the Energy Function is implemented, and subclass
-  hierarchy. E.g. All these classes are now ``CustomCVForce``'s instead of ``CustomBondForce`` and
-  ``CustomCentroidBondForce`` objects.
-
-     - This affects ``RadiallySymmetricRestraintForce``,
-       ``RadiallySymmetricCentroidRestraintForce``, ``RadiallySymmetricBondRestraintForce``,
-       ``HarmonicRestraintForceMixIn``, ``HarmonicRestraintForce``, ``HarmonicRestraintBondForce``,
-       ``FlatBottomRestraintForceMixIn``, ``FlatBottomRestraintForce``, and ``FlatBottomRestraintBondForce``.
 
 
 0.15.0 - Restraint forces

--- a/docs/states.rst
+++ b/docs/states.rst
@@ -8,6 +8,7 @@ The module :mod:`openmmtools.states` contains classes to maintain a consistent s
  - :class:`ThermodynamicState`: Represent and manipulate the thermodynamic state of OpenMM `System <http://docs.openmm.org/7.1.0/api-python/generated/simtk.openmm.openmm.System.html>`_ and `Context <http://docs.openmm.org/7.1.0/api-python/generated/simtk.openmm.openmm.Context.html>`_ objects.
  - :class:`SamplerState`: Represent and cache the state of the simulation that changes when the `System <http://docs.openmm.org/7.1.0/api-python/generated/simtk.openmm.openmm.System.html>`_ is integrated.
  - :class:`CompoundThermodynamicState`: Extend the :class:`ThermodynamicState` to handle parameters other than temperature and pressure through the implementations of the :class:`IComposableState` abstract class.
+ - :class:`GlobalParameterState`: An implementation of :class:`IComposableState` specialized to control OpenMM forces' global parameters.
 
 States
 ------
@@ -21,3 +22,4 @@ States
     SamplerState
     CompoundThermodynamicState
     IComposableState
+    GlobalParameterState

--- a/openmmtools/alchemy.py
+++ b/openmmtools/alchemy.py
@@ -554,7 +554,7 @@ class AlchemicalState(object):
         # states with different settings must be incompatible.
         alchemical_state._apply_to_system(system, set_update_charges_flag=False)
 
-    def _on_setattr(self, standard_system, attribute_name):
+    def _on_setattr(self, standard_system, attribute_name, old_attribute_value):
         """Check if the standard system needs changes after a state attribute is set.
 
         Parameters
@@ -563,6 +563,8 @@ class AlchemicalState(object):
             The standard system before setting the attribute.
         attribute_name : str
             The name of the attribute that has just been set or retrieved.
+        old_attribute_value : float
+            The value of the attribute retrieved before being set.
 
         Returns
         -------

--- a/openmmtools/alchemy.py
+++ b/openmmtools/alchemy.py
@@ -211,6 +211,12 @@ class AlchemicalState(object):
     # -------------------------------------------------------------------------
 
     def __init__(self, **kwargs):
+        if 'update_alchemical_charges' in kwargs:
+            # TODO Drop support for the parameter and remove deprecation warning from 0.17 on
+            # TODO after implementing new way for exact PME based on the NonbondedForce offsets.
+            import warnings
+            warnings.warn('The update_alchemical_charges in AlchemicalState.__init__ has been '
+                          'deprecated, and future versions of openmmtools may not support it.')
         self._initialize(**kwargs)
 
     @classmethod

--- a/openmmtools/forcefactories.py
+++ b/openmmtools/forcefactories.py
@@ -50,7 +50,7 @@ def replace_reaction_field(reference_system, switch_width=1.0*unit.angstrom,
         Setting it to `False` speeds up the function execution but modifies
         the `reference_system` object.
     shifted : bool, optional, default=False
-        If `True`, a shited reaction-field will be used.
+        If `True`, a shifted reaction-field will be used.
 
     Returns
     -------

--- a/openmmtools/forces.py
+++ b/openmmtools/forces.py
@@ -700,7 +700,7 @@ class RadiallySymmetricCentroidRestraintForce(RadiallySymmetricRestraintForce,
                  restrained_atom_indices1, restrained_atom_indices2,
                  controlling_parameter_name='lambda_restraints'):
         # Initialize CustomCentroidBondForce.
-        energy_function = controlling_parameter_name + ' * ' + energy_function
+        energy_function = controlling_parameter_name + ' * (' + energy_function + ')'
         custom_centroid_bond_force_args = [2, energy_function]
         super(RadiallySymmetricCentroidRestraintForce, self).__init__(
             restraint_parameters, restrained_atom_indices1, restrained_atom_indices2,
@@ -749,7 +749,7 @@ class RadiallySymmetricBondRestraintForce(RadiallySymmetricRestraintForce,
                  controlling_parameter_name='lambda_restraints'):
         # Initialize CustomBondForce.
         energy_function = energy_function.replace('distance(g1,g2)', 'r')
-        energy_function = controlling_parameter_name + ' * ' + energy_function
+        energy_function = controlling_parameter_name + ' * (' + energy_function + ')'
         super(RadiallySymmetricBondRestraintForce, self).__init__(
             restraint_parameters, [restrained_atom_index1], [restrained_atom_index2],
             controlling_parameter_name, energy_function)

--- a/openmmtools/forces.py
+++ b/openmmtools/forces.py
@@ -63,7 +63,7 @@ def find_forces(system, force_type, only_one=False, include_subclasses=False):
     ----------
     system : simtk.openmm.System
         The system to search.
-    force_type : str or type
+    force_type : str, or type
         The class of the force to search, or a regular expression that
         is used to match its name. Note that ``re.match()`` is used in
         this case, not ``re.search()``. The ``iter_subclasses`` argument
@@ -227,43 +227,21 @@ def _compute_harmonic_radius(spring_constant, potential_energy):
 # GENERIC CLASSES FOR RADIALLY SYMMETRIC RECEPTOR-LIGAND RESTRAINTS
 # =============================================================================
 
-class RadiallySymmetricRestraintForce(utils.RestorableOpenMMObject,
-                                      openmm.CustomCVForce):
+class RadiallySymmetricRestraintForce(utils.RestorableOpenMMObject):
     """Base class for radially-symmetric restraint force.
 
     Provide facility functions to compute the standard state correction
     of a receptor-ligand restraint.
-
-    These facilities are implemented through the CustomCVForce around the internal
-    force the restraint.
 
     To create a subclass, implement the properties :func:`restrained_atom_indices1`
     and :func:`restrained_atom_indices2` (with their setters) that return
     the indices of the restrained atoms.
 
     You will also have to implement :func:`_create_bond`, which should add the
-    bond using the correct function/signature. This should not do anything with the
-    parameter values as those are handled through the parent CV force
-
-    Finally, you will need to implement the :func:`_create_distance_force`, which returns the
-    Force object that the CustomCVForce will use. This should only create a very
-    simple force which measures the radial distance. This force can be
-    accessed through the property _distance_force available to this class
+    bond using the correct function/signature.
 
     Optionally, you can implement :func:`distance_at_energy` if an
     analytical expression for distance(potential_energy) exists.
-
-    If you want to access any of the restraint parameters, concrete class
-    implementations must infer them from the energy function, including
-    if they should bear units or not. A helper function exists in
-    this parent class called :func:``_get_parameter_in_energy_function``
-    which accepts a single arg of a string of the parameter name
-    (case sensitive) and returns the int or float value that is the
-    parameter.
-
-    If you subclass this, and plan on adding additional
-    global parameters, you need to invoke this class super().__init__ first as the
-    ``controlling_parameter_name`` must be the first global variable.
 
     Parameters
     ----------
@@ -271,27 +249,15 @@ class RadiallySymmetricRestraintForce(utils.RestorableOpenMMObject,
         An ordered dictionary containing the bond parameters in the form
         parameter_name: parameter_value. The order is important to make
         sure that parameters can be retrieved from the bond force with
-        the correct force index. If these are unit bearing quantities,
-        these will be converted to the OpenMM MD Unit system before
-        being stripped and assigned to the Force
+        the correct force index.
     restrained_atom_indices1 : iterable of int
         The indices of the first group of atoms to restrain.
     restrained_atom_indices2 : iterable of int
         The indices of the second group of atoms to restrain.
     controlling_parameter_name : str
         The name of the global parameter controlling the energy function.
-    energy_function : str
-        Energy Expression for the CustomCVForce object. Use the variable
-        "symmetric_restraint_distance" to reference the internal distance force CV.
-        You should NOT add the value of the parameters in the
-        string, the ``restraint_parameters`` dict will automatically
-        augment this string.
-
-        If you were to accidentally include the values, then
-        the restraint_parameters key is effectively ignored, and
-        could lead to unintended behavior
     *args, **kwargs
-        Additional parameters to pass to the super constructor.
+        Parameters to pass to the super constructor.
 
     Attributes
     ----------
@@ -301,76 +267,35 @@ class RadiallySymmetricRestraintForce(utils.RestorableOpenMMObject,
 
     def __init__(self, restraint_parameters, restrained_atom_indices1,
                  restrained_atom_indices2, controlling_parameter_name,
-                 energy_function,
                  *args, **kwargs):
-        # Ensure parameter names are in the correct format
-        assert len(restraint_parameters) == 1 or isinstance(restraint_parameters, collections.OrderedDict)
-        assert "symmetric_restraint_distance" not in restraint_parameters, \
-            '"symmetric_restraint_distance" cannot be a restraint_parameter as it will clash with the CV Variable"'
-        assert "symmetric_restraint_distance" in energy_function, \
-            ('"symmetric_restraint_distance" must be in the energy_function as it will be the collective ' 
-             'variable the base CustomCVForce uses.')
-
-        # Augment energy_function with parameters
-        energy_function += ";"
-        for parameter_name, parameter_value in restraint_parameters.items():
-            # Ensure OpenMM Unit system
-            if isinstance(parameter_value, unit.Quantity):
-                parameter_value = parameter_value.in_unit_system(unit.md_unit_system)
-                restraint_parameters[parameter_name] = parameter_value
-                # Strip unit without overwriting dict entry efficiently
-                # Fetching value is faster than dividing by unit since
-                # we are already in correct unit system
-                parameter_value = parameter_value._value
-            energy_function += "{} = {};".format(parameter_name, parameter_value)
-        # Augment args with the energy string
-        args = (energy_function,) + args
-
-        # Construct
         super(RadiallySymmetricRestraintForce, self).__init__(*args, **kwargs)
         self._controlling_parameter_name = controlling_parameter_name
 
-        # Create the distance force used for the CV force wraps
-        distance_force = self._create_distance_force()
-        self.addCollectiveVariable("symmetric_restraint_distance", distance_force)
+        # Unzip bond parameters names and values from dict.
+        assert len(restraint_parameters) == 1 or isinstance(restraint_parameters, collections.OrderedDict)
+        parameter_names, parameter_values = zip(*restraint_parameters.items())
 
         # Let the subclass initialize its bond.
-        self._create_bond(restrained_atom_indices1, restrained_atom_indices2)
+        self._create_bond(parameter_values, restrained_atom_indices1, restrained_atom_indices2)
 
         # Add parameters.
-        # First global parameter is _restorable_force__class_hash from the RestorableOpenMMObject class
-        assert self.getNumGlobalParameters() == 1, ("The first global parameter after _restorable_force__class_hash "
-                                                    "(from parent) is expected to be the "
-                                                    "controlling_parameter_name, but there are additional global "
-                                                    "parameters before it. This is likely because the subclass "
-                                                    "called addGlobalParameter before calling super()__init__ to "
-                                                    "the parent class.")
         self.addGlobalParameter(self._controlling_parameter_name, 1.0)
-        self._restraint_parameters = restraint_parameters
+        for parameter in parameter_names:
+            self.addPerBondParameter(parameter)
 
     # -------------------------------------------------------------------------
     # Abstract methods.
     # -------------------------------------------------------------------------
 
     @abc.abstractmethod
-    def _create_distance_force(self):
-        """
-        Create and return the underlying force object
-
-        Returns
-        -------
-        force : OpenMM.Force
-            The force measuring distance to be used as the CV
-        """
-        pass
-
-    @abc.abstractmethod
-    def _create_bond(self, restrained_atom_indices1,
+    def _create_bond(self, bond_parameter_values, restrained_atom_indices1,
                      restrained_atom_indices2):
         """Create the bond modelling the restraint.
 
         Parameters
         ----------
+        bond_parameter_values : list of floats
+            The list of the parameter values of the bond.
         restrained_atom_indices1 : list of int
             The indices of the first group of atoms to restrain.
         restrained_atom_indices2 : list of int
@@ -394,9 +319,17 @@ class RadiallySymmetricRestraintForce(utils.RestorableOpenMMObject,
         pass
 
     @property
+    def restraint_parameters(self):
+        """OrderedDict: The restraint parameters in dictionary form."""
+        parameter_values = self.getBondParameters(0)[-1]
+        restraint_parameters = [(self.getPerBondParameterName(parameter_idx), parameter_value)
+                                for parameter_idx, parameter_value in enumerate(parameter_values)]
+        return collections.OrderedDict(restraint_parameters)
+
+    @property
     def controlling_parameter_name(self):
         """str: The name of the global parameter controlling the energy function (read-only)."""
-        return self.getGlobalParameterName(1)
+        return self._controlling_parameter_name
 
     def distance_at_energy(self, potential_energy):
         """Compute the distance at which the potential energy is ``potential_energy``.
@@ -587,7 +520,7 @@ class RadiallySymmetricRestraintForce(utils.RestorableOpenMMObject,
         force.restrained_atom_indices1 = [0]
         force.restrained_atom_indices2 = [1]
         # Disable the PBC for this approximation of the analytical solution.
-        force._distance_force.setUsesPeriodicBoundaryConditions(False)
+        force.setUsesPeriodicBoundaryConditions(False)
         system.addForce(force)
 
         # Create a Reference context to evaluate energies on the CPU.
@@ -596,7 +529,7 @@ class RadiallySymmetricRestraintForce(utils.RestorableOpenMMObject,
         context = openmm.Context(system, integrator, platform)
 
         # Set default positions.
-        positions = unit.Quantity(np.zeros([2, 3]), distance_unit)
+        positions = unit.Quantity(np.zeros([2,3]), distance_unit)
         context.setPositions(positions)
 
         # Create a function to compute integrand as a function of interparticle separation.
@@ -723,48 +656,9 @@ class RadiallySymmetricRestraintForce(utils.RestorableOpenMMObject,
         r_max *= distance_unit
         return r_min, r_max, analytical_volume
 
-    @property
-    def _distance_force(self):
-        """Helper to return the correct CV object independent of copy operations"""
-        return self.getCollectiveVariable(0)
 
-    def _get_parameter_in_energy_function(self, parameter):
-        """
-        Helper function to parse a restraint_parameter from the energy function
-
-        Parameters
-        ----------
-        parameter : str
-            Case-sensitive parameter to regex from the energy string
-
-        Returns
-        -------
-        value : int or float
-            Value of the parameter in the string. Checks if value
-            is an integer (+-{digits}, no trailing decimal) to
-            return int, otherwise returns float
-        """
-        energy_function = self.getEnergyFunction()
-        # This compile will find the *first* entry, and therefore the
-        # one OpenMM uses as its value in implementation.
-        # There are some ambiguous energy function corner cases users could write,
-        # but that is then their error.
-        # Should catch int, float, +-, sci. notation
-        re_search = re.compile(r';{} = ([-+\d\.eE]+);'.format(parameter))
-        try:
-            value = re_search.search(energy_function).group(1)
-        except AttributeError:
-            # Trap the match returning None (bad parameter)
-            raise ValueError("Parameter {} not found in energy function!".format(parameter))
-        # An efficient check if string is safe to be cast to int, or if it should be float
-        # https://stackoverflow.com/questions/1265665
-        # This is a slightly more restrictive check than the example to favor floats over ints
-        if value == '0' or (value if value.find('..') > -1 else value.lstrip('-+')).isdigit():
-            return int(value)
-        return float(value)
-
-
-class RadiallySymmetricCentroidRestraintForce(RadiallySymmetricRestraintForce):
+class RadiallySymmetricCentroidRestraintForce(RadiallySymmetricRestraintForce,
+                                              openmm.CustomCentroidBondForce):
     """Base class for radially-symmetric restraints between the centroids of two groups of atoms.
 
     The restraint is applied between the centers of mass of two groups
@@ -777,10 +671,9 @@ class RadiallySymmetricCentroidRestraintForce(RadiallySymmetricRestraintForce):
     Parameters
     ----------
     energy_function : str
-        The energy function to pass to ``CustomCVForce``. The
+        The energy function to pass to ``CustomCentroidBondForce``. The
         name of the controlling global parameter  will be prepended to
-        this expression. The radially symmetric distance in this expression
-        can is the variable ``symmetric_restraint_distance``.
+        this expression.
     restraint_parameters : OrderedDict
         An ordered dictionary containing the bond parameters in the form
         parameter_name: parameter_value. The order is important to make
@@ -796,6 +689,7 @@ class RadiallySymmetricCentroidRestraintForce(RadiallySymmetricRestraintForce):
 
     Attributes
     ----------
+    restraint_parameters
     restrained_atom_indices1
     restrained_atom_indices2
     controlling_parameter_name
@@ -807,42 +701,41 @@ class RadiallySymmetricCentroidRestraintForce(RadiallySymmetricRestraintForce):
                  controlling_parameter_name='lambda_restraints'):
         # Initialize CustomCentroidBondForce.
         energy_function = controlling_parameter_name + ' * (' + energy_function + ')'
+        custom_centroid_bond_force_args = [2, energy_function]
         super(RadiallySymmetricCentroidRestraintForce, self).__init__(
             restraint_parameters, restrained_atom_indices1, restrained_atom_indices2,
-            controlling_parameter_name, energy_function)
+            controlling_parameter_name, *custom_centroid_bond_force_args)
 
     @property
     def restrained_atom_indices1(self):
         """The indices of the first group of restrained atoms."""
-        restrained_atom_indices1, weights_group1 = self._distance_force.getGroupParameters(0)
+        restrained_atom_indices1, weights_group1 = self.getGroupParameters(0)
         return list(restrained_atom_indices1)
 
     @restrained_atom_indices1.setter
     def restrained_atom_indices1(self, atom_indices):
-        self._distance_force.setGroupParameters(0, atom_indices)
+        self.setGroupParameters(0, atom_indices)
 
     @property
     def restrained_atom_indices2(self):
         """The indices of the first group of restrained atoms."""
-        restrained_atom_indices2, weights_group2 = self._distance_force.getGroupParameters(1)
+        restrained_atom_indices2, weights_group2 = self.getGroupParameters(1)
         return list(restrained_atom_indices2)
 
     @restrained_atom_indices2.setter
     def restrained_atom_indices2(self, atom_indices):
-        self._distance_force.setGroupParameters(1, atom_indices)
+        self.setGroupParameters(1, atom_indices)
 
-    def _create_distance_force(self):
-        return openmm.CustomCentroidBondForce(2, "distance(g1,g2)")
-
-    def _create_bond(self, restrained_atom_indices1,
+    def _create_bond(self, bond_parameter_values, restrained_atom_indices1,
                      restrained_atom_indices2):
         """Create the bond modelling the restraint."""
-        self._distance_force.addGroup(restrained_atom_indices1)
-        self._distance_force.addGroup(restrained_atom_indices2)
-        self._distance_force.addBond([0, 1], [])
+        self.addGroup(restrained_atom_indices1)
+        self.addGroup(restrained_atom_indices2)
+        self.addBond([0, 1], bond_parameter_values)
 
 
-class RadiallySymmetricBondRestraintForce(RadiallySymmetricRestraintForce):
+class RadiallySymmetricBondRestraintForce(RadiallySymmetricRestraintForce,
+                                          openmm.CustomBondForce):
     """Base class for radially-symmetric restraints between two atoms.
 
     This is a version of ``RadiallySymmetricCentroidRestraintForce`` that can
@@ -855,6 +748,7 @@ class RadiallySymmetricBondRestraintForce(RadiallySymmetricRestraintForce):
                  restrained_atom_index1, restrained_atom_index2,
                  controlling_parameter_name='lambda_restraints'):
         # Initialize CustomBondForce.
+        energy_function = energy_function.replace('distance(g1,g2)', 'r')
         energy_function = controlling_parameter_name + ' * (' + energy_function + ')'
         super(RadiallySymmetricBondRestraintForce, self).__init__(
             restraint_parameters, [restrained_atom_index1], [restrained_atom_index2],
@@ -867,33 +761,30 @@ class RadiallySymmetricBondRestraintForce(RadiallySymmetricRestraintForce):
     @property
     def restrained_atom_indices1(self):
         """The indices of the first group of restrained atoms."""
-        atom1, atom2, parameters = self._distance_force.getBondParameters(0)
+        atom1, atom2, parameters = self.getBondParameters(0)
         return [atom1]
 
     @restrained_atom_indices1.setter
     def restrained_atom_indices1(self, atom_indices):
         assert len(atom_indices) == 1
-        atom1, atom2, parameters = self._distance_force.getBondParameters(0)
-        self._distance_force.setBondParameters(0, atom_indices[0], atom2, parameters)
+        atom1, atom2, parameters = self.getBondParameters(0)
+        self.setBondParameters(0, atom_indices[0], atom2, parameters)
 
     @property
     def restrained_atom_indices2(self):
         """The indices of the first group of restrained atoms."""
-        atom1, atom2, parameters = self._distance_force.getBondParameters(0)
+        atom1, atom2, parameters = self.getBondParameters(0)
         return [atom2]
 
     @restrained_atom_indices2.setter
     def restrained_atom_indices2(self, atom_indices):
         assert len(atom_indices) == 1
-        atom1, atom2, parameters = self._distance_force.getBondParameters(0)
-        self._distance_force.setBondParameters(0, atom1, atom_indices[0], parameters)
+        atom1, atom2, parameters = self.getBondParameters(0)
+        self.setBondParameters(0, atom1, atom_indices[0], parameters)
 
-    def _create_bond(self, restrained_atom_indices1, restrained_atom_indices2):
+    def _create_bond(self, bond_parameter_values, restrained_atom_indices1, restrained_atom_indices2):
         """Create the bond modelling the restraint."""
-        self._distance_force.addBond(restrained_atom_indices1[0], restrained_atom_indices2[0], [])
-
-    def _create_distance_force(self):
-        return openmm.CustomBondForce("r")
+        self.addBond(restrained_atom_indices1[0], restrained_atom_indices2[0], bond_parameter_values)
 
 
 # =============================================================================
@@ -904,7 +795,7 @@ class HarmonicRestraintForceMixIn(object):
     """A mix-in providing the interface for harmonic restraints."""
 
     def __init__(self, spring_constant, *args, **kwargs):
-        energy_function = '(K/2)*symmetric_restraint_distance^2'
+        energy_function = '(K/2)*distance(g1,g2)^2'
         restraint_parameters = collections.OrderedDict([('K', spring_constant)])
         super(HarmonicRestraintForceMixIn, self).__init__(energy_function, restraint_parameters,
                                                           *args, **kwargs)
@@ -912,8 +803,9 @@ class HarmonicRestraintForceMixIn(object):
     @property
     def spring_constant(self):
         """unit.simtk.Quantity: The spring constant K (units of energy/mole/distance^2)."""
-        k = self._get_parameter_in_energy_function('K')
-        return k * unit.kilojoule_per_mole / unit.nanometers**2
+        # This works for both CustomBondForce and CustomCentroidBondForce.
+        parameters = self.getBondParameters(0)[-1]
+        return parameters[0] * unit.kilojoule_per_mole/unit.nanometers**2
 
     def distance_at_energy(self, potential_energy):
         """Compute the distance at which the potential energy is ``potential_energy``.
@@ -961,9 +853,9 @@ class HarmonicRestraintForce(HarmonicRestraintForceMixIn,
 
     The energy expression of the restraint is given by
 
-       ``E = controlling_parameter * (K/2)*symmetric_restraint_distance^2``
+       ``E = controlling_parameter * (K/2)*r^2``
 
-    where `K` is the spring constant, `Distance` is the distance between the
+    where `K` is the spring constant, `r` is the distance between the
     two group centroids, and `controlling_parameter` is a scale factor that
     can be used to control the strength of the restraint.
 
@@ -987,6 +879,7 @@ class HarmonicRestraintForce(HarmonicRestraintForceMixIn,
     spring_constant
     restrained_atom_indices1
     restrained_atom_indices2
+    restraint_parameters
     controlling_parameter_name
 
     """
@@ -1019,6 +912,7 @@ class HarmonicRestraintBondForce(HarmonicRestraintForceMixIn,
     spring_constant
     restrained_atom_indices1
     restrained_atom_indices2
+    restraint_parameters
     controlling_parameter_name
 
     """
@@ -1034,7 +928,7 @@ class FlatBottomRestraintForceMixIn(object):
     """A mix-in providing the interface for flat-bottom restraints."""
 
     def __init__(self, spring_constant, well_radius, *args, **kwargs):
-        energy_function = 'step(symmetric_restraint_distance-r0) * (K/2)*(symmetric_restraint_distance-r0)^2'
+        energy_function = 'step(distance(g1,g2)-r0) * (K/2)*(distance(g1,g2)-r0)^2'
         restraint_parameters = collections.OrderedDict([
             ('K', spring_constant),
             ('r0', well_radius)
@@ -1046,15 +940,15 @@ class FlatBottomRestraintForceMixIn(object):
     def spring_constant(self):
         """unit.simtk.Quantity: The spring constant K (units of energy/mole/length^2)."""
         # This works for both CustomBondForce and CustomCentroidBondForce.
-        k = self._get_parameter_in_energy_function('K')
-        return k * unit.kilojoule_per_mole / unit.nanometers**2
+        parameters = self.getBondParameters(0)[-1]
+        return parameters[0] * unit.kilojoule_per_mole/unit.nanometers**2
 
     @property
     def well_radius(self):
         """unit.simtk.Quantity: The distance at which the harmonic restraint is imposed (units of length)."""
         # This works for both CustomBondForce and CustomCentroidBondForce.
-        r0 = self._get_parameter_in_energy_function('r0')
-        return r0 * unit.nanometers
+        parameters = self.getBondParameters(0)[-1]
+        return parameters[1] * unit.nanometers
 
     def distance_at_energy(self, potential_energy):
         """Compute the distance at which the potential energy is ``potential_energy``.
@@ -1120,9 +1014,9 @@ class FlatBottomRestraintForce(FlatBottomRestraintForceMixIn,
 
     More precisely, the energy expression of the restraint is given by
 
-        ``E = controlling_parameter * step(symmetric_restraint_distance-r0) * (K/2)*(symmetric_restraint_distance-r0)^2``
+        ``E = controlling_parameter * step(r-r0) * (K/2)*(r-r0)^2``
 
-    where ``K`` is the spring constant, ``symmetric_restraint_distance`` is the distance between the
+    where ``K`` is the spring constant, ``r`` is the distance between the
     restrained atoms, ``r0`` is another parameter defining the distance
     at which the restraint is imposed, and ``controlling_parameter``
     is a scale factor that can be used to control the strength of the
@@ -1152,6 +1046,7 @@ class FlatBottomRestraintForce(FlatBottomRestraintForceMixIn,
     well_radius
     restrained_atom_indices1
     restrained_atom_indices2
+    restraint_parameters
     controlling_parameter_name
 
     """
@@ -1188,6 +1083,7 @@ class FlatBottomRestraintBondForce(FlatBottomRestraintForceMixIn,
     well_radius
     restrained_atom_indices1
     restrained_atom_indices2
+    restraint_parameters
     controlling_parameter_name
 
     """

--- a/openmmtools/states.py
+++ b/openmmtools/states.py
@@ -3190,8 +3190,11 @@ class GlobalParameterState(object):
             suffix = ''
         else:
             suffix = '_' + parameters_name_suffix
-        # inspect.getmembers() resolves automatically the MRO.
-        controlled_parameters = {name + suffix: descriptor for name, descriptor in inspect.getmembers(cls)
+        # TODO just use inspect.getmembers when dropping Python 2 which automatically resolves the MRO.
+        # controlled_parameters = {name + suffix: descriptor for name, descriptor in inspect.getmembers(cls)
+        #                          if isinstance(descriptor, cls.GlobalParameter)}
+        controlled_parameters = {name + suffix: descriptor for c in inspect.getmro(cls)
+                                 for name, descriptor in c.__dict__.items()
                                  if isinstance(descriptor, cls.GlobalParameter)}
         return controlled_parameters
 
@@ -3203,7 +3206,7 @@ class GlobalParameterState(object):
             parameter_value = self._parameters[key]
         except KeyError:
             # Parameter not found, fall back to normal behavior.
-            parameter_value = super().__getattribute__(key)
+            parameter_value = super(GlobalParameterState, self).__getattribute__(key)
         return parameter_value
 
     def __setattr__(self, key, value):

--- a/openmmtools/states.py
+++ b/openmmtools/states.py
@@ -2692,6 +2692,15 @@ class GlobalParameterState(object):
         The value of the parameters controlled by this state. Parameters
         that are not passed here are left undefined.
 
+    Notes
+    -----
+    The class automatically implement the static constructor ``from_system``
+    that reads and create a state object from an OpenMM ``System``. The function
+    calls ``__init__`` and passes the parameter name suffix string as the
+    first positional argument, so it is possible to overwrite ``__init__``
+    and rename ``parameters_name_suffix`` as long as it is the first parameter
+    of the constructor.
+
     Examples
     --------
 
@@ -2861,7 +2870,7 @@ class GlobalParameterState(object):
         # Create and return the GlobalParameterState. The constructor of
         # GlobalParameterState takes the parameters without the suffix so
         # we left them undefined in the constructor and assign the attributes.
-        state = cls(parameters_name_suffix=parameters_name_suffix)
+        state = cls(parameters_name_suffix)
         for parameter_name, parameter_value in state_parameters.items():
             setattr(state, parameter_name, parameter_value)
         return state

--- a/openmmtools/tests/test_forces.py
+++ b/openmmtools/tests/test_forces.py
@@ -58,7 +58,6 @@ def test_find_forces():
                                                  restrained_atom_index1=2, restrained_atom_index2=5)
     system.addForce(restraint_force)
     system.addForce(openmm.CustomBondForce('0.0'))
-    system.addForce(openmm.CustomCVForce('0.0'))
 
     def assert_forces_equal(found_forces, expected_force_classes):
         # Forces should be ordered by their index.
@@ -71,9 +70,9 @@ def test_find_forces():
     yield assert_forces_equal, found_forces, [(6, openmm.CustomBondForce)]
 
     # Test find force and include subclasses.
-    found_forces = find_forces(system, openmm.CustomCVForce, include_subclasses=True)
+    found_forces = find_forces(system, openmm.CustomBondForce, include_subclasses=True)
     yield assert_forces_equal, found_forces, [(5, HarmonicRestraintBondForce),
-                                              (7, openmm.CustomCVForce)]
+                                              (6, openmm.CustomBondForce)]
     found_forces = find_forces(system, RadiallySymmetricRestraintForce, include_subclasses=True)
     yield assert_forces_equal, found_forces, [(5, HarmonicRestraintBondForce)]
 
@@ -89,16 +88,16 @@ def test_find_forces():
 
     # Find all forces from the name including the subclasses.
     # Test find force and include subclasses.
-    found_forces = find_forces(system, 'CustomCV.*', include_subclasses=True)
+    found_forces = find_forces(system, 'CustomBond.*', include_subclasses=True)
     yield assert_forces_equal, found_forces, [(5, HarmonicRestraintBondForce),
-                                              (7, openmm.CustomCVForce)]
+                                              (6, openmm.CustomBondForce)]
 
     # With check_multiple=True only one force is returned.
     force_idx, force = find_forces(system, openmm.NonbondedForce, only_one=True)
     yield assert_forces_equal, {force_idx: force}, [(3, openmm.NonbondedForce)]
 
     # An exception is raised with "only_one" if multiple forces are found.
-    yield nose.tools.assert_raises, MultipleForcesError, find_forces, system, 'CustomCVForce', True, True
+    yield nose.tools.assert_raises, MultipleForcesError, find_forces, system, 'CustomBondForce', True, True
 
     # An exception is raised with "only_one" if the force wasn't found.
     yield nose.tools.assert_raises, NoForceFoundError, find_forces, system, 'NonExistentForce', True
@@ -117,8 +116,8 @@ class TestRadiallySymmetricRestraints(object):
         cls.spring_constant = 15000.0 * unit.joule/unit.mole/unit.nanometers**2
         cls.restrained_atom_indices1 = [2, 3, 4]
         cls.restrained_atom_indices2 = [10, 11]
-        cls.restrained_atom_index1 = 12
-        cls.restrained_atom_index2 = 2
+        cls.restrained_atom_index1=12
+        cls.restrained_atom_index2=2
         cls.custom_parameter_name = 'restraints_parameter'
 
         cls.restraints = [
@@ -150,14 +149,6 @@ class TestRadiallySymmetricRestraints(object):
             force_serialization = openmm.XmlSerializer.serialize(restorable_force)
             deserialized_force = utils.RestorableOpenMMObject.deserialize_xml(force_serialization)
             yield assert_pickles_equal, restorable_force, deserialized_force
-            # Make sure Python properties are restored correctly
-            yield assert_equal, restorable_force.controlling_parameter_name, \
-                  deserialized_force.controlling_parameter_name
-            if isinstance(restorable_force, FlatBottomRestraintForceMixIn):
-                yield assert_quantity_almost_equal, restorable_force.spring_constant, deserialized_force.spring_constant
-                yield assert_quantity_almost_equal, restorable_force.well_radius, deserialized_force.well_radius
-            elif isinstance(restorable_force, HarmonicRestraintForceMixIn):
-                yield assert_quantity_almost_equal, restorable_force.spring_constant, deserialized_force.spring_constant
 
     def test_restraint_properties(self):
         """Test that properties work as expected."""

--- a/openmmtools/tests/test_states.py
+++ b/openmmtools/tests/test_states.py
@@ -964,10 +964,7 @@ class TestSamplerState(object):
         assert sliced_sampler_state.potential_energy is None
 
     def test_collective_variable(self):
-        """Test that CV calculation is working (If on OpenMM >=7.3)"""
-        # TODO: Remove the if statement and require OpenMM 7.3 once 7.3 is actually released
-        if not hasattr(openmm, "CustomCVForce"):
-            return
+        """Test that CV calculation is working"""
         # Setup the CV tests if we have a late enough OpenMM
         # alanine_explicit_cv = copy.deepcopy(self.alanine_explicit)
         system_cv = self.alanine_explicit_state.system

--- a/openmmtools/tests/test_states.py
+++ b/openmmtools/tests/test_states.py
@@ -1552,7 +1552,7 @@ class TestGlobalParameterState(object):
 
         # Raise an error if an extra parameter is defined in the state.
         state_suffix.gamma_mysuffix = 2.0
-        err_msg = 'Could not find parameter gamma_mysuffix in the system.'
+        err_msg = 'Could not find global parameter gamma_mysuffix in the system.'
         with nose.tools.assert_raises_regexp(GlobalParameterError, err_msg):
             state_suffix.apply_to_system(system)
 
@@ -1703,7 +1703,7 @@ class TestGlobalParameterState(object):
 
         # Trying to set in the constructor undefined global parameters raise an exception.
         composable_states[1].gamma_mysuffix = 2.0
-        err_msg = 'Could not find parameter gamma_mysuffix in the system.'
+        err_msg = 'Could not find global parameter gamma_mysuffix in the system.'
         with nose.tools.assert_raises_regexp(GlobalParameterError, err_msg):
             CompoundThermodynamicState(self.diatomic_molecule_ts, composable_states)
 

--- a/openmmtools/tests/test_states.py
+++ b/openmmtools/tests/test_states.py
@@ -1264,3 +1264,578 @@ def test_uncompressed_thermodynamic_state_serialization():
     ThermodynamicState._standard_system_cache = {}
     deserialized_state = utils.deserialize(uncompressed_serialization)
     assert are_pickle_equal(state, deserialized_state)
+
+
+# =============================================================================
+# TEST GLOBAL PARAMETER STATE
+# =============================================================================
+
+_GLOBAL_PARAMETER_STANDARD_VALUE = 1.0
+
+
+class ParameterStateExample(GlobalParameterState):
+    standard_value = _GLOBAL_PARAMETER_STANDARD_VALUE
+    lambda_bonds = GlobalParameterState.GlobalParameter('lambda_bonds', standard_value)
+    gamma = GlobalParameterState.GlobalParameter('gamma', standard_value)
+
+    def set_defined_parameters(self, value):
+        for parameter_name, parameter_value in self._parameters.items():
+            if parameter_value is not None:
+                self._parameters[parameter_name] = value
+
+
+class TestGlobalParameterState(object):
+    """Test GlobalParameterState stand-alone functionality.
+
+    The compatibility with CompoundThermodynamicState is tested in the next
+    test suite.
+    """
+
+    @classmethod
+    def setup_class(cls):
+        """Create test systems and shared objects."""
+        # Define a diatomic molecule System with two custom forces
+        # using the simple version and the suffix'ed version.
+        r0 = 0.15*unit.nanometers
+
+        # Make sure that there is a force without defining a parameter.
+        cls.parameters_default_values = {
+            'lambda_bonds': 1.0,
+            'gamma': 2.0,
+            'lambda_bonds_mysuffix': 0.5,
+            'gamma_mysuffix': None,
+        }
+
+        r0_nanometers = r0.value_in_unit(unit.nanometers)  # Shortcut in OpenMM units.
+        system = openmm.System()
+        system.addParticle(40.0*unit.amu)
+        system.addParticle(40.0*unit.amu)
+        custom_force = openmm.CustomBondForce('lambda_bonds^gamma*60000*(r-{})^2;'.format(r0_nanometers))
+        custom_force.addGlobalParameter('lambda_bonds', cls.parameters_default_values['lambda_bonds'])
+        custom_force.addGlobalParameter('gamma', cls.parameters_default_values['gamma'])
+        custom_force.addBond(0, 1, [])
+        system.addForce(custom_force)
+        custom_force_suffix = openmm.CustomBondForce('lambda_bonds_mysuffix*20000*(r-{})^2;'.format(r0_nanometers))
+        custom_force_suffix.addGlobalParameter('lambda_bonds_mysuffix', cls.parameters_default_values['lambda_bonds_mysuffix'])
+        custom_force_suffix.addBond(0, 1, [])
+        system.addForce(custom_force_suffix)
+
+        # Create a thermodynamic and sampler states.
+        cls.diatomic_molecule_ts = ThermodynamicState(system, temperature=300.0*unit.kelvin)
+        pos1 = [0.0, 0.0, 0.0]
+        pos2 = [0.0, 0.0, r0_nanometers]
+        cls.diatomic_molecule_ss = SamplerState(positions=np.array([pos1, pos2]) * unit.nanometers)
+
+        # Create few incompatible systems for testing. An incompatible state
+        # has a different set of defined global parameters.
+        cls.incompatible_systems = [system]
+
+        # System without suffixed or non-suffixed parameters.
+        for i in range(2):
+            cls.incompatible_systems.append(copy.deepcopy(system))
+            cls.incompatible_systems[i+1].removeForce(i)
+
+        # System with both lambda_bonds_suffix and gamma_bond_suffix defined (instead of only the former).
+        cls.incompatible_systems.append(copy.deepcopy(system))
+        custom_force = copy.deepcopy(cls.incompatible_systems[-1].getForce(1))
+        energy_function = custom_force.getEnergyFunction()
+        energy_function = energy_function.replace('lambda_bonds_mysuffix', 'lambda_bonds_mysuffix^gamma_mysuffix')
+        custom_force.setEnergyFunction(energy_function)
+        custom_force.addGlobalParameter('gamma_mysuffix', cls.parameters_default_values['gamma'])
+        cls.incompatible_systems[-1].addForce(custom_force)
+
+    def read_system_state(self, system):
+        states = []
+        for suffix in [None, 'mysuffix']:
+            try:
+                states.append(ParameterStateExample.from_system(system, parameters_name_suffix=suffix))
+            except GlobalParameterError:
+                continue
+        return states
+
+    @staticmethod
+    def test_constructor_parameters():
+        """Test GlobalParameterState constructor behave as expected."""
+        class MyState(GlobalParameterState):
+            lambda_angles = GlobalParameterState.GlobalParameter('lambda_angles', standard_value=1.0)
+            lambda_sterics = GlobalParameterState.GlobalParameter('lambda_sterics', standard_value=1.0)
+
+        # Raise an exception if parameter is not recognized.
+        with nose.tools.assert_raises_regexp(GlobalParameterError, 'Unknown parameters'):
+            MyState(lambda_steric=1.0)  # Typo.
+
+        # Properties are initialized correctly.
+        test_cases = [{},
+                      {'lambda_angles': 1.0},
+                      {'lambda_sterics': 0.5, 'lambda_angles': 0.5},
+                      {'parameters_name_suffix': 'suffix'},
+                      {'parameters_name_suffix': 'suffix', 'lambda_angles': 1.0},
+                      {'parameters_name_suffix': 'suffix', 'lambda_sterics': 0.5, 'lambda_angles': 0.5}]
+
+        for test_kwargs in test_cases:
+            state = MyState(**test_kwargs)
+
+            # Check which parameters are defined/undefined in the constructed state.
+            for parameter in MyState._get_controlled_parameters():
+                # Store whether parameter is defined before appending the suffix.
+                is_defined = parameter in test_kwargs
+
+                # The "unsuffixed" parameter should not be controlled by the state.
+                if 'parameters_name_suffix' in test_kwargs:
+                    with nose.tools.assert_raises_regexp(AttributeError, 'state does not control'):
+                        getattr(state, parameter)
+                    # The state exposes a "suffixed" version of the parameter.
+                    state_attribute = parameter + '_' + test_kwargs['parameters_name_suffix']
+                else:
+                    state_attribute = parameter
+
+                # Check if parameter should is defined or undefined (i.e. set to None) as expected.
+                err_msg = 'Parameter: {} (Test case: {})'.format(parameter, test_kwargs)
+                if is_defined:
+                    assert getattr(state, state_attribute) == test_kwargs[parameter], err_msg
+                else:
+                    assert getattr(state, state_attribute) is None, err_msg
+
+    def test_from_system_constructor(self):
+        """Test GlobalParameterState.from_system constructor."""
+        # A system exposing no global parameters controlled by the state raises an error.
+        with nose.tools.assert_raises_regexp(GlobalParameterError, 'no global parameters'):
+            GlobalParameterState.from_system(openmm.System())
+
+        system = self.diatomic_molecule_ts.system
+        state = ParameterStateExample.from_system(system)
+        state_suffix = ParameterStateExample.from_system(system, parameters_name_suffix='mysuffix')
+
+        for parameter_name, parameter_value in self.parameters_default_values.items():
+            if 'suffix' in parameter_name:
+                controlling_state = state_suffix
+                noncontrolling_state = state
+            else:
+                controlling_state = state
+                noncontrolling_state = state_suffix
+
+            err_msg = '{}: {}'.format(parameter_name, parameter_value)
+            assert getattr(controlling_state, parameter_name) == parameter_value, err_msg
+            with nose.tools.assert_raises(AttributeError):
+                getattr(noncontrolling_state, parameter_name), parameter_name
+
+    def test_parameter_validator(self):
+        """Test GlobalParameterState constructor behave as expected."""
+
+        class MyState(GlobalParameterState):
+            lambda_bonds = GlobalParameterState.GlobalParameter('lambda_bonds', standard_value=1.0)
+
+            @lambda_bonds.validator
+            def lambda_bonds(self, instance, new_value):
+                if not (0.0 <= new_value <= 1.0):
+                    raise ValueError('lambda_bonds must be between 0.0 and 1.0')
+                return new_value
+
+        # Create system with incorrect initial parameter.
+        system = self.diatomic_molecule_ts.system
+        system.getForce(0).setGlobalParameterDefaultValue(0, 2.0)  # lambda_bonds
+        system.getForce(1).setGlobalParameterDefaultValue(0, -1.0)  # lambda_bonds_mysuffix
+
+        for suffix in [None, 'mysuffix']:
+            # Raise an exception on init.
+            with nose.tools.assert_raises_regexp(ValueError, 'must be between'):
+                MyState(parameters_name_suffix=suffix, lambda_bonds=-1.0)
+            with nose.tools.assert_raises_regexp(ValueError, 'must be between'):
+                MyState.from_system(system, parameters_name_suffix=suffix)
+
+            # Raise an exception when properties are set.
+            state = MyState(parameters_name_suffix=suffix, lambda_bonds=1.0)
+            parameter_name = 'lambda_bonds' if suffix is None else 'lambda_bonds_' + suffix
+            with nose.tools.assert_raises_regexp(ValueError, 'must be between'):
+                setattr(state, parameter_name, 5.0)
+
+    def test_equality_operator(self):
+        """Test equality operator between GlobalParameterStates."""
+        state1 = ParameterStateExample(lambda_bonds=1.0)
+        state2 = ParameterStateExample(lambda_bonds=1.0)
+        state3 = ParameterStateExample(lambda_bonds=0.9)
+        state4 = ParameterStateExample(lambda_bonds=0.9, gamma=1.0)
+        state5 = ParameterStateExample(lambda_bonds=0.9, parameters_name_suffix='suffix')
+        state6 = ParameterStateExample(parameters_name_suffix='suffix', lambda_bonds=0.9, gamma=1.0)
+        assert state1 == state2
+        assert state2 != state3
+        assert state3 != state4
+        assert state3 != state5
+        assert state4 != state6
+        assert state5 != state6
+        assert state6 == state6
+
+        # States that control more variables are not equal.
+        class MyState(ParameterStateExample):
+            extra_parameter = GlobalParameterState.GlobalParameter('extra_parameter', standard_value=1.0)
+        state7 = MyState(lambda_bonds=0.9)
+        assert state3 != state7
+
+    def test_apply_to_system(self):
+        """Test method GlobalParameterState.apply_to_system()."""
+        system = self.diatomic_molecule_ts.system
+        state = ParameterStateExample.from_system(system)
+        state_suffix = ParameterStateExample.from_system(system, parameters_name_suffix='mysuffix')
+
+        expected_system_values = copy.deepcopy(self.parameters_default_values)
+
+        def check_system_values():
+            state, state_suffix = self.read_system_state(system)
+            for parameter_name, parameter_value in expected_system_values.items():
+                err_msg = 'parameter: {}, expected_value: {}'.format(parameter_name, parameter_value)
+                if 'suffix' in parameter_name:
+                    assert getattr(state_suffix, parameter_name) == parameter_value, err_msg
+                else:
+                    assert getattr(state, parameter_name) == parameter_value, err_msg
+
+        # Test precondition: all parameters have the expected default value.
+        check_system_values()
+
+        # apply_to_system() modifies the state.
+        state.lambda_bonds /= 2
+        expected_system_values['lambda_bonds'] /= 2
+        state_suffix.lambda_bonds_mysuffix /= 2
+        expected_system_values['lambda_bonds_mysuffix'] /= 2
+        for s in [state, state_suffix]:
+            s.apply_to_system(system)
+        check_system_values()
+
+        # Raise an error if an extra parameter is defined in the system.
+        state.gamma = None
+        err_msg = 'The system parameter gamma is not defined in this state.'
+        with nose.tools.assert_raises_regexp(GlobalParameterError, err_msg):
+            state.apply_to_system(system)
+
+        # Raise an error if an extra parameter is defined in the state.
+        state_suffix.gamma_mysuffix = 2.0
+        err_msg = 'Could not find parameter gamma_mysuffix in the system.'
+        with nose.tools.assert_raises_regexp(GlobalParameterError, err_msg):
+            state_suffix.apply_to_system(system)
+
+    def test_check_system_consistency(self):
+        """Test method GlobalParameterState.check_system_consistency()."""
+        system = self.diatomic_molecule_ts.get_system(remove_thermostat=True)
+
+        def check_not_consistency(states):
+            for s in states:
+                with nose.tools.assert_raises_regexp(GlobalParameterError, 'Consistency check failed'):
+                    s.check_system_consistency(system)
+
+        # A system is consistent with itself.
+        state, state_suffix = self.read_system_state(system)
+        for s in [state, state_suffix]:
+            s.check_system_consistency(system)
+
+        # Raise error if System defines global parameters that are undefined in the state.
+        state, state_suffix = self.read_system_state(system)
+        state.gamma = None
+        state_suffix.lambda_bonds_mysuffix = None
+        check_not_consistency([state, state_suffix])
+
+        # Raise error if state defines global parameters that are undefined in the System.
+        state, state_suffix = self.read_system_state(system)
+        state_suffix.gamma_mysuffix = 1.0
+        check_not_consistency([state_suffix])
+
+        # Raise error if system has different lambda values.
+        state, state_suffix = self.read_system_state(system)
+        state.lambda_bonds /= 2
+        state_suffix.lambda_bonds_mysuffix /=2
+        check_not_consistency([state, state_suffix])
+
+    def test_apply_to_context(self):
+        """Test method GlobalParameterState.apply_to_context."""
+        system = self.diatomic_molecule_ts.system
+        integrator = openmm.VerletIntegrator(1.0*unit.femtosecond)
+        context = self.diatomic_molecule_ts.create_context(integrator)
+
+        def check_not_applicable(states, error):
+            for s in states:
+                with nose.tools.assert_raises_regexp(GlobalParameterError, error):
+                    s.apply_to_context(context)
+
+        # Raise error if the Context defines global parameters that are undefined in the state.
+        state, state_suffix = self.read_system_state(system)
+        state.lambda_bonds = None
+        state_suffix.lambda_bonds_mysuffix = None
+        check_not_applicable([state, state_suffix], 'undefined in this state')
+
+        # Raise error if the state defines global parameters that are undefined in the Context.
+        state, state_suffix = self.read_system_state(system)
+        state_suffix.gamma_mysuffix = 2.0
+        check_not_applicable([state_suffix], 'Could not find parameter')
+
+        # Test-precondition: Context parameters are different than the value we'll test.
+        tested_value = 0.2
+        for parameter_value in context.getParameters().values():
+            assert parameter_value != tested_value
+
+        # Correctly sets Context's parameters.
+        state, state_suffix = self.read_system_state(system)
+        state.lambda_bonds = tested_value
+        state.gamma = tested_value
+        state_suffix.lambda_bonds_mysuffix = tested_value
+        for s in [state, state_suffix]:
+            s.apply_to_context(context)
+            for parameter_name, parameter_value in context.getParameters().items():
+                if parameter_name in s._parameters:
+                    assert parameter_value == tested_value
+        del context
+
+    def test_standardize_system(self):
+        """Test method GlobalParameterState.standardize_system."""
+        system = self.diatomic_molecule_ts.system
+        standard_value = _GLOBAL_PARAMETER_STANDARD_VALUE  # Shortcut.
+
+        def check_is_standard(states, is_standard):
+            for s in states:
+                for parameter_name in s._get_controlled_parameters(s._parameters_name_suffix):
+                    parameter_value = getattr(s, parameter_name)
+                    err_msg = 'Parameter: {}; Value: {};'.format(parameter_name, parameter_value)
+                    if parameter_value is not None:
+                        assert (parameter_value  == standard_value) is is_standard, err_msg
+
+        # Test pre-condition: The system is not in the standard state.
+        system.getForce(0).setGlobalParameterDefaultValue(0, 0.9)
+        states = self.read_system_state(system)
+        check_is_standard(states, is_standard=False)
+
+        # Check that _standardize_system() sets all parameters to the standard value.
+        for state in states:
+            state._standardize_system(system)
+        states_standard = self.read_system_state(system)
+        check_is_standard(states_standard, is_standard=True)
+
+    def test_find_force_groups_to_update(self):
+        """Test method GlobalParameterState._find_force_groups_to_update."""
+        system = self.diatomic_molecule_ts.system
+        integrator = openmm.VerletIntegrator(2.0*unit.femtoseconds)
+        # Test cases are (force_group, force_group_suffix)
+        test_cases = [(0, 0), (1, 5), (9, 4)]
+
+        for force_groups in test_cases:
+            for i, force_group in enumerate(force_groups):
+                system.getForce(i).setForceGroup(force_group)
+            states = self.read_system_state(system)
+            context = openmm.Context(system, copy.deepcopy(integrator))
+
+            # No force group should be updated if we don't change the global parameter.
+            for state, force_group in zip(states, force_groups):
+                assert state._find_force_groups_to_update(context, state, memo={}) == set()
+
+                # Change the lambdas one by one and check that the method
+                # recognizes that the force group energy must be updated.
+                current_state = copy.deepcopy(state)
+                for parameter_name in state._get_controlled_parameters(state._parameters_name_suffix):
+                    # Check that the system defines the global variable.
+                    parameter_value = getattr(state, parameter_name)
+                    if parameter_value is None:
+                        continue
+
+                    # Change the current state.
+                    setattr(current_state, parameter_name, parameter_value / 2)
+                    assert state._find_force_groups_to_update(context, current_state, memo={}) == {force_group}
+                    setattr(current_state, parameter_name, parameter_value)  # Reset current state.
+            del context
+
+    # ---------------------------------------------------
+    # Integration tests with CompoundThermodynamicStates
+    # ---------------------------------------------------
+
+    def test_constructor_compound_state(self):
+        """The GlobalParameterState is set on construction of the CompoundState."""
+        system = self.diatomic_molecule_ts.system
+
+        # Create a system state different than the initial.
+        composable_states = self.read_system_state(system)
+        for state in composable_states:
+            state.set_defined_parameters(0.222)
+
+        # CompoundThermodynamicState set the system state in the constructor.
+        compound_state = CompoundThermodynamicState(self.diatomic_molecule_ts, composable_states)
+        new_system_states = self.read_system_state(compound_state.system)
+        for state, new_state in zip(composable_states, new_system_states):
+            assert state == new_state
+
+        # Trying to set in the constructor undefined global parameters raise an exception.
+        composable_states[1].gamma_mysuffix = 2.0
+        err_msg = 'Could not find parameter gamma_mysuffix in the system.'
+        with nose.tools.assert_raises_regexp(GlobalParameterError, err_msg):
+            CompoundThermodynamicState(self.diatomic_molecule_ts, composable_states)
+
+    def test_global_parameters_compound_state(self):
+        """Global parameters setters/getters work in the CompoundState system."""
+        composable_states = self.read_system_state(self.diatomic_molecule_ts.system)
+        for state in composable_states:
+            state.set_defined_parameters(0.222)
+        compound_state = CompoundThermodynamicState(self.diatomic_molecule_ts, composable_states)
+
+        # Defined properties can be assigned and read, unless they are undefined.
+        for parameter_name, default_value in self.parameters_default_values.items():
+            if default_value is None:
+                assert getattr(compound_state, parameter_name) is None
+                # If undefined, setting the property should raise an error.
+                err_msg = 'Cannot set the parameter gamma_mysuffix in the system'
+                with nose.tools.assert_raises_regexp(GlobalParameterError, err_msg):
+                    setattr(compound_state, parameter_name, 2.0)
+                continue
+
+            # Defined parameters should be gettable and settables.
+            assert getattr(compound_state, parameter_name) == 0.222
+            setattr(compound_state, parameter_name, 0.5)
+            assert getattr(compound_state, parameter_name) == 0.5
+
+        # System global variables are updated correctly
+        system_states = self.read_system_state(compound_state.system)
+        for state in system_states:
+            for parameter_name in state._parameters:
+                assert getattr(state, parameter_name) == getattr(compound_state, parameter_name)
+
+    def test_set_system_compound_state(self):
+        """Setting inconsistent system in compound state raise errors."""
+        system = self.diatomic_molecule_ts.system
+        composable_states = self.read_system_state(system)
+        compound_state = CompoundThermodynamicState(self.diatomic_molecule_ts, composable_states)
+
+        for parameter_name, default_value in self.parameters_default_values.items():
+            if default_value is None:
+                continue
+            elif 'suffix' in parameter_name:
+                original_state = composable_states[1]
+            else:
+                original_state = composable_states[0]
+
+            # We create an incompatible state with the parameter set to a different value.
+            incompatible_state = copy.deepcopy(original_state)
+            original_value = getattr(incompatible_state, parameter_name)
+            setattr(incompatible_state, parameter_name, original_value/2)
+            incompatible_state.apply_to_system(system)
+
+            # Setting an inconsistent system raise an error.
+            with nose.tools.assert_raises_regexp(GlobalParameterError, parameter_name):
+                compound_state.system = system
+
+            # Same for set_system when called with default arguments.
+            with nose.tools.assert_raises_regexp(GlobalParameterError, parameter_name):
+                compound_state.set_system(system)
+
+            # This doesn't happen if we fix the state.
+            compound_state.set_system(system, fix_state=True)
+            new_state = incompatible_state.from_system(compound_state.system, original_state._parameters_name_suffix)
+            assert new_state == original_state, (str(new_state), str(incompatible_state))
+
+            # Restore old value in system, and test next parameter.
+            original_state.apply_to_system(system)
+
+    def test_compatibility_compound_state(self):
+        """Compatibility between states is handled correctly in compound state."""
+        incompatible_systems = copy.deepcopy(self.incompatible_systems)
+
+        # Build all compound states.
+        compound_states = []
+        for system in incompatible_systems:
+            thermodynamic_state = ThermodynamicState(system, temperature=300*unit.kelvin)
+            composable_states = self.read_system_state(system)
+            compound_states.append(CompoundThermodynamicState(thermodynamic_state, composable_states))
+
+        # Build all contexts for testing.
+        integrator = openmm.VerletIntegrator(2.0*unit.femtoseconds)
+        contexts = [s.create_context(copy.deepcopy(integrator)) for s in compound_states]
+
+        for state_idx, (compound_state, context) in enumerate(zip(compound_states, contexts)):
+            # The state is compatible with itself.
+            assert compound_state.is_state_compatible(compound_state)
+            assert compound_state.is_context_compatible(context)
+
+            # Changing the values of the parameters do not affect
+            # compatibility (only defined/undefined parameters do).
+            altered_compound_state = copy.deepcopy(compound_state)
+            for parameter_name in ['gamma', 'lambda_bonds_mysuffix']:
+                try:
+                    new_value = getattr(compound_state, parameter_name) / 2
+                    setattr(altered_compound_state, parameter_name, new_value)
+                except AttributeError:
+                    continue
+            assert altered_compound_state.is_state_compatible(compound_state)
+            assert altered_compound_state.is_context_compatible(context)
+
+            # All other states are incompatible. Test only those that we
+            # haven't tested yet, but test transitivity.
+            for incompatible_state_idx in range(state_idx+1, len(compound_states)):
+                print(state_idx, incompatible_state_idx)
+                incompatible_state = compound_states[incompatible_state_idx]
+                incompatible_context = contexts[incompatible_state_idx]
+                assert not compound_state.is_state_compatible(incompatible_state)
+                assert not incompatible_state.is_state_compatible(compound_state)
+                assert not compound_state.is_context_compatible(incompatible_context)
+                assert not incompatible_state.is_context_compatible(context)
+
+    def test_reduced_potential_compound_state(self):
+        """Test CompoundThermodynamicState.reduced_potential_at_states() method.
+
+        Computing the reduced potential singularly and with the class
+        method should give the same result.
+        """
+        positions = copy.deepcopy(self.diatomic_molecule_ss.positions)
+        # Build a mixed collection of compatible and incompatible thermodynamic states.
+        thermodynamic_states = [
+            ThermodynamicState(self.incompatible_systems[0], temperature=300*unit.kelvin),
+            ThermodynamicState(self.incompatible_systems[-1], temperature=300*unit.kelvin)
+        ]
+
+        compound_states = []
+        for ts_idx, ts in enumerate(thermodynamic_states):
+            compound_state = CompoundThermodynamicState(ts, self.read_system_state(ts.system))
+            for state in [dict(lambda_bonds=1.0, gamma=1.0, lambda_bonds_mysuffix=1.0, gamma_mysuffix=1.0),
+                          dict(lambda_bonds=0.5, gamma=1.0, lambda_bonds_mysuffix=1.0, gamma_mysuffix=1.0),
+                          dict(lambda_bonds=0.5, gamma=1.0, lambda_bonds_mysuffix=1.0, gamma_mysuffix=0.5),
+                          dict(lambda_bonds=0.1, gamma=0.5, lambda_bonds_mysuffix=0.2, gamma_mysuffix=0.5)]:
+                for parameter_name, parameter_value in state.items():
+                    try:
+                        setattr(compound_state, parameter_name, parameter_value)
+                    except GlobalParameterError:
+                        continue
+                compound_states.append(copy.deepcopy(compound_state))
+
+        # Group thermodynamic states by compatibility.
+        compatible_groups, _ = group_by_compatibility(compound_states)
+        assert len(compatible_groups) == 2
+
+        # Compute the reduced potentials.
+        expected_energies = []
+        obtained_energies = []
+        for compatible_group in compatible_groups:
+            # Create context.
+            integrator = openmm.VerletIntegrator(2.0*unit.femtoseconds)
+            context = compatible_group[0].create_context(integrator)
+            context.setPositions(positions)
+
+            # Compute with single-state method.
+            for state in compatible_group:
+                state.apply_to_context(context)
+                expected_energies.append(state.reduced_potential(context))
+
+            # Compute with multi-state method.
+            compatible_energies = ThermodynamicState.reduced_potential_at_states(context, compatible_group)
+
+            # The first and the last state must be equal.
+            assert np.isclose(compatible_energies[0], compatible_energies[-1])
+            obtained_energies.extend(compatible_energies)
+
+        assert np.allclose(np.array(expected_energies), np.array(obtained_energies))
+
+    def test_serialization(self):
+        """Test GlobalParameterState serialization alone and in a compound state."""
+        composable_states = self.read_system_state(self.diatomic_molecule_ts.system)
+
+        # Test serialization/deserialization of GlobalParameterState.
+        for state in composable_states:
+            serialization = utils.serialize(state)
+            deserialized_state = utils.deserialize(serialization)
+            are_pickle_equal(state, deserialized_state)
+
+        # Test serialization/deserialization of GlobalParameterState in CompoundState.
+        compound_state = CompoundThermodynamicState(self.diatomic_molecule_ts, composable_states)
+        serialization = utils.serialize(compound_state)
+        deserialized_state = utils.deserialize(serialization)
+        are_pickle_equal(compound_state, deserialized_state)

--- a/openmmtools/tests/test_states.py
+++ b/openmmtools/tests/test_states.py
@@ -1593,7 +1593,7 @@ class TestGlobalParameterState(object):
         integrator = openmm.VerletIntegrator(1.0*unit.femtosecond)
         context = self.diatomic_molecule_ts.create_context(integrator)
 
-        def check_not_applicable(states, error):
+        def check_not_applicable(states, error, context):
             for s in states:
                 with nose.tools.assert_raises_regexp(GlobalParameterError, error):
                     s.apply_to_context(context)
@@ -1602,12 +1602,12 @@ class TestGlobalParameterState(object):
         state, state_suffix = self.read_system_state(system)
         state.lambda_bonds = None
         state_suffix.lambda_bonds_mysuffix = None
-        check_not_applicable([state, state_suffix], 'undefined in this state')
+        check_not_applicable([state, state_suffix], 'undefined in this state', context)
 
         # Raise error if the state defines global parameters that are undefined in the Context.
         state, state_suffix = self.read_system_state(system)
         state_suffix.gamma_mysuffix = 2.0
-        check_not_applicable([state_suffix], 'Could not find parameter')
+        check_not_applicable([state_suffix], 'Could not find parameter', context)
 
         # Test-precondition: Context parameters are different than the value we'll test.
         tested_value = 0.2

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ import subprocess
 DOCLINES = __doc__.split("\n")
 
 ########################
-VERSION = "0.15.1"
+VERSION = "0.16.0"
 ISRELEASED = False
 __version__ = VERSION
 ########################


### PR DESCRIPTION
- Deprecated the signature of `IComposableState._on_setattr` to fix a bug where the objects were temporarily left in an inconsistent state when an exception was raised and caught.
- Deprecated `update_alchemical_charges` in `AlchemicalState` in anticipation of the new implementation of the exact PME that will be based on the `NonbondedForce` offsets rather than `updateParametersInContext()`.
- Allow restraint force classes to be controlled by a parameter other than `'lambda_restraints'`. This will enable multi-restraints simulations.
- Implemented `states.GlobalParametersState`. This more or less generalize the logic of `AlchemicalState` and implement the "suffix" mechanism that we'll be able to use in multi-restraint calculations to control parameters such as `lambda_restraints_restraint1`, `lambda_restraints_restraint2` and, in the future, in multiple alchemical region calculations. With this, the new `RestraintState` class in YANK can be simplified to:
 ```python
class RestraintState(GlobalParameterState):
    lambda_restraints = GlobalParameterState.GlobalParameter('lambda_restraints', standard_value=1.0)

    @lambda_restraints.validator
    def lambda_restraints(self, instance, new_value):
        if not (0.0 <= new_value <= 1.0):
            raise ValueError('lambda_restraints must be between 0.0 and 1.0')
        return new_value

    # A constructor just to give parameters_name_suffix a more meaningful name.
    def __init__(restraint_name=None, **kwargs):
        super().__init__(parameters_name_suffix=restraint_name, **kwargs)
```
`AlchemicalState` will be similarly simplified, but we'll have to wait to do it until the new exact PME implementation will be in.