### PR TITLE
Extend default compatibility of integrators

### DIFF
--- a/docs/releasehistory.rst
+++ b/docs/releasehistory.rst
@@ -1,13 +1,20 @@
 Release History
 ===============
 
-0.15.1 - Something New This Way Comes [WIP]
-===========================================
+0.15.1 - Development
+====================
 
 New features
 ------------
-- Add ability for ``SamplerState`` to access new `OpenMM Custom CV Force Variables <http://docs.openmm.org/development/api-python/generated/simtk.openmm.openmm.CustomCVForce.html#simtk.openmm.openmm.CustomCVForce>`_
-- ``SamplerState.update_from_context`` now has keywords to support finer grain updating from the Context. This is only recommended for advanced users.
+- Add ability for ``SamplerState`` to access new `OpenMM Custom CV Force Variables
+  <http://docs.openmm.org/development/api-python/generated/simtk.openmm.openmm.CustomCVForce.html#simtk.openmm.openmm.CustomCVForce>`_ 
+  (`#362 <https://github.com/choderalab/openmmtools/pull/362>`_).
+- ``SamplerState.update_from_context`` now has keywords to support finer grain updating from the Context. This is only
+  recommended for advanced users (`#362 <https://github.com/choderalab/openmmtools/pull/362>`_).
+
+Enhancements
+------------
+- Global variables of integrators are now automatically copied over the integrator returned by ``ContextCache.get_context``. It is possible to specify exception through ``ContextCache.INCOMPATIBLE_INTEGRATOR_ATTRIBUTES`` (`#364 <https://github.com/choderalab/openmmtools/pull/364>`_).
 
 0.15.0 - Restraint forces
 =========================

--- a/docs/releasehistory.rst
+++ b/docs/releasehistory.rst
@@ -14,7 +14,13 @@ New features
 
 Enhancements
 ------------
-- Global variables of integrators are now automatically copied over the integrator returned by ``ContextCache.get_context``. It is possible to specify exception through ``ContextCache.INCOMPATIBLE_INTEGRATOR_ATTRIBUTES`` (`#364 <https://github.com/choderalab/openmmtools/pull/364>`_).
+- Global variables of integrators are now automatically copied over the integrator returned by ``ContextCache.get_context``.
+  It is possible to specify exception through ``ContextCache.INCOMPATIBLE_INTEGRATOR_ATTRIBUTES`` (`#364 <https://github.com/choderalab/openmmtools/pull/364>`_).
+
+Others
+------
+- Integrator ``MCMCMove``s now attempt to recover from NaN automatically by default (with ``n_restart_attempts`` set to
+  4) (`#364 <https://github.com/choderalab/openmmtools/pull/364>`_).
 
 0.15.0 - Restraint forces
 =========================

--- a/openmmtools/cache.py
+++ b/openmmtools/cache.py
@@ -537,12 +537,6 @@ class ContextCache(object):
         # Copy all compatible global variables.
         cls._set_integrator_compatible_variables(integrator, copied_integrator)
 
-        # Copy the Python attributes (except for the SWIG pointer).
-        # TODO: Remove Python attributes
-        # python_attributes = {k: v for k, v in copied_integrator.__dict__.items()
-        #                      if k != 'this' and k not in cls.INCOMPATIBLE_INTEGRATOR_ATTRIBUTES}
-        # integrator.__dict__.update(copy.deepcopy(python_attributes))
-
         # Copy other compatible attributes through getters/setters.
         for attribute in cls.COMPATIBLE_INTEGRATOR_ATTRIBUTES:
             try:  # getter/setter

--- a/openmmtools/mcmc.py
+++ b/openmmtools/mcmc.py
@@ -614,7 +614,7 @@ class BaseIntegratorMove(MCMCMove):
     """
 
     def __init__(self, n_steps, context_cache=None,
-                 reassign_velocities=False, n_restart_attempts=0):
+                 reassign_velocities=False, n_restart_attempts=4):
         self.n_steps = n_steps
         self.context_cache = context_cache
         self.reassign_velocities = reassign_velocities

--- a/openmmtools/tests/test_cache.py
+++ b/openmmtools/tests/test_cache.py
@@ -205,9 +205,6 @@ class TestContextCache(object):
              integrators.LangevinIntegrator(temperature=270*unit.kelvin,
                                             collision_rate=180/unit.picoseconds)],
         ]
-        # Add a fake Python attribute to the last two integrators to test those as well.
-        test_cases[1][0].fake_attribute = 1
-        test_cases[1][1].fake_attribute = 2
 
         for integrator1, integrator2 in copy.deepcopy(test_cases):
             assert integrator1.__getstate__() != integrator2.__getstate__()
@@ -224,10 +221,8 @@ class TestContextCache(object):
                 except:
                     return integrator.getGlobalVariableByName(attribute_name)
 
-        test_cases.append(copy.deepcopy(test_cases[1]))
         test_cases[0].append('Temperature')  # Getter/setter.
-        test_cases[1].append('fake_attribute')  # Python attribute.
-        test_cases[2].append('a')  # Global variable.
+        test_cases[1].append('a')  # Global variable.
 
         for integrator1, integrator2, incompatible_attribute in test_cases:
             ContextCache.INCOMPATIBLE_INTEGRATOR_ATTRIBUTES.add(incompatible_attribute)


### PR DESCRIPTION
This adds the optimization discussed in #352. The state of the integrator was always consistent even before this change, but now the compatibility of the integrator has been extended by default to all global variables, so new `Context` objects are created less often.

This also adds a blacklist `ContextCache.INCOMPATIBLE_INTEGRATOR_ATTRIBUTES` that can be used to exclude some integrator parameters from the copy when requesting the cached context.