### PR TITLE
Convert RadiallySymmetricRestraint Forces to CV Forces

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,6 +25,7 @@ install:
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
   - conda config --add channels omnia
   - conda config --add channels conda-forge
+  - pip install netcdf4  # This has to be done through pip since Windows NetCF4 has a DLL issue on conda
 
 build: false
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,7 +25,6 @@ install:
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
   - conda config --add channels omnia
   - conda config --add channels conda-forge
-  - pip install netcdf4  # This has to be done through pip since Windows NetCF4 has a DLL issue on conda
 
 build: false
 

--- a/devtools/appveyor/install.ps1
+++ b/devtools/appveyor/install.ps1
@@ -7,11 +7,7 @@ $MINICONDA_URL = "http://repo.continuum.io/miniconda/"
 
 function DownloadMiniconda ($python_version, $platform_suffix) {
     $webclient = New-Object System.Net.WebClient
-    if ($python_version -match "3.4") {
-        $filename = "Miniconda3-3.7.3-Windows-" + $platform_suffix + ".exe"
-    } else {
-        $filename = "Miniconda-3.7.3-Windows-" + $platform_suffix + ".exe"
-    }
+    $filename = "Miniconda3-4.5.4-Windows-" + $platform_suffix + ".exe"
     $url = $MINICONDA_URL + $filename
 
     $basedir = $pwd.Path + "\"

--- a/devtools/appveyor/install.ps1
+++ b/devtools/appveyor/install.ps1
@@ -86,7 +86,6 @@ function UpdateConda ($python_home) {
     Start-Process -FilePath "$conda_path" -ArgumentList $args -Wait -Passthru
 }
 
-
 function main () {
     InstallMiniconda $env:PYTHON_VERSION $env:PYTHON_ARCH $env:PYTHON
     UpdateConda $env:PYTHON

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - numpy
     - scipy
     - six
-    - openmm >= 7.2
+    - openmm >=7.2
     - parmed
     - mdtraj
     - netcdf4

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - numpy
     - scipy
     - six
-    - openmm
+    - openmm >= 7.2
     - parmed
     - mdtraj
     - netcdf4

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -30,7 +30,8 @@ requirements:
     - openmm >=7.2
     - parmed
     - mdtraj
-    - netcdf4
+    # NetCDF4 on windows conda has DLL issues and has for a while, must get from pip
+    - netcdf4 # [not win]
     - pyyaml
 
 

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -30,8 +30,9 @@ requirements:
     - openmm >=7.2
     - parmed
     - mdtraj
-    # NetCDF4 on windows conda has DLL issues and has for a while, must get from pip
-    - netcdf4 # [not win]
+    # NetCDF4 on windows conda has DLL issues, so pin libnetcdf
+    - netcdf4
+    - libnetcdf 4.4.1.1 # [win]
     - pyyaml
 
 

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -32,7 +32,7 @@ requirements:
     - mdtraj
     # NetCDF4 on windows conda has DLL issues, so pin libnetcdf
     - netcdf4
-    - libnetcdf 4.4.1.1 # [win]
+    - libnetcdf ==4.6.1=h183b1a9_3 # [win]
     - pyyaml
 
 

--- a/docs/releasehistory.rst
+++ b/docs/releasehistory.rst
@@ -27,6 +27,18 @@ Deprecated
 - Deprecated ``update_alchemical_charges`` in ``AlchemicalState`` in anticipation of the new implementation of the
   exact PME that will be based on the ``NonbondedForce`` offsets rather than ``updateParametersInContext()``.
 
+Compatibility Warnings
+----------------------
+- ``RadiallySymmetricRestraintForce``'s conversion to ``CustomCVForce``'s break the backwards compatibility with older
+  codes which implement subclasses of it. The largest change is how the Energy Function is implemented, and subclass
+  hierarchy. E.g. All these classes are now ``CustomCVForce``'s instead of ``CustomBondForce`` and
+  ``CustomCentroidBondForce`` objects.
+
+     - This affects ``RadiallySymmetricRestraintForce``,
+       ``RadiallySymmetricCentroidRestraintForce``, ``RadiallySymmetricBondRestraintForce``,
+       ``HarmonicRestraintForceMixIn``, ``HarmonicRestraintForce``, ``HarmonicRestraintBondForce``,
+       ``FlatBottomRestraintForceMixIn``, ``FlatBottomRestraintForce``, and ``FlatBottomRestraintBondForce``.
+
 
 0.15.0 - Restraint forces
 =========================

--- a/docs/releasehistory.rst
+++ b/docs/releasehistory.rst
@@ -15,6 +15,9 @@ New features
   control global variables (`#363 <https://github.com/choderalab/openmmtools/pull/363>`_).
 - Allow restraint force classes to be controlled by a parameter other than ``lambda_restraints``. This will enable
   multi-restraints simulations (`#363 <https://github.com/choderalab/openmmtools/pull/363>`_).
+- ``RadiallySymmetricRestraintForce`` and all subclasses are now a ``CustomCVForce`` subclass wrapping their
+  respective ``CustomBondForce`` and ``CustomCentroidBondForce`` objects. This breaks backwards compatibility, but
+  enables tracking the restraint distances through the new ``SamplerSate`` collective variable features.
 
 Deprecated
 ----------

--- a/openmmtools/forces.py
+++ b/openmmtools/forces.py
@@ -336,6 +336,7 @@ class RadiallySymmetricRestraintForce(utils.RestorableOpenMMObject,
         force : OpenMM.Force
             The force measuring distance to be used as the CV
         """
+        pass
 
     @abc.abstractmethod
     def _create_bond(self, restrained_atom_indices1,

--- a/openmmtools/forces.py
+++ b/openmmtools/forces.py
@@ -21,7 +21,6 @@ import inspect
 import logging
 import math
 import re
-import yaml
 
 import scipy
 import numpy as np

--- a/openmmtools/forces.py
+++ b/openmmtools/forces.py
@@ -228,7 +228,7 @@ def _compute_harmonic_radius(spring_constant, potential_energy):
 # =============================================================================
 
 class RadiallySymmetricRestraintForce(utils.RestorableOpenMMObject,
-                                      openmm.CustomCVForce, abc.ABC):
+                                      openmm.CustomCVForce):
     """Base class for radially-symmetric restraint force.
 
     Provide facility functions to compute the standard state correction
@@ -289,6 +289,8 @@ class RadiallySymmetricRestraintForce(utils.RestorableOpenMMObject,
         assert len(restraint_parameters) == 1 or isinstance(restraint_parameters, collections.OrderedDict)
         assert "Distance" not in restraint_parameters, ('"Distance" cannot be a restraint_parameter as it will ' 
                                                         'clash with the CV Variable"')
+        assert "Distance" in energy_string, ('"Distance" must be in the energy_string as it will be the collective '
+                                             'variable the base CustomCVForce uses.')
 
         # Augment energy_string with parameters
         energy_string += ";"

--- a/openmmtools/forces.py
+++ b/openmmtools/forces.py
@@ -63,7 +63,7 @@ def find_forces(system, force_type, only_one=False, include_subclasses=False):
     ----------
     system : simtk.openmm.System
         The system to search.
-    force_type : str, or type
+    force_type : str or type
         The class of the force to search, or a regular expression that
         is used to match its name. Note that ``re.match()`` is used in
         this case, not ``re.search()``. The ``iter_subclasses`` argument
@@ -227,18 +227,28 @@ def _compute_harmonic_radius(spring_constant, potential_energy):
 # GENERIC CLASSES FOR RADIALLY SYMMETRIC RECEPTOR-LIGAND RESTRAINTS
 # =============================================================================
 
-class RadiallySymmetricRestraintForce(utils.RestorableOpenMMObject):
+class RadiallySymmetricRestraintForce(utils.RestorableOpenMMObject,
+                                      openmm.CustomCVForce, abc.ABC):
     """Base class for radially-symmetric restraint force.
 
     Provide facility functions to compute the standard state correction
     of a receptor-ligand restraint.
+
+    These facilities are implemented through the CustomCVForce around the internal
+    force the restraint.
 
     To create a subclass, implement the properties :func:`restrained_atom_indices1`
     and :func:`restrained_atom_indices2` (with their setters) that return
     the indices of the restrained atoms.
 
     You will also have to implement :func:`_create_bond`, which should add the
-    bond using the correct function/signature.
+    bond using the correct function/signature. This should not do anything with the
+    parameter values as those are handled through the parent CV force
+
+    Finally, you will need to implement the :func:`_create_distance_force`, which returns the
+    Force object that the CustomCVForce will use. This should only create a very
+    simple force which measures the radial distance. This force can be
+    accessed through the property _distance_force available to this class
 
     Optionally, you can implement :func:`distance_at_energy` if an
     analytical expression for distance(potential_energy) exists.
@@ -256,8 +266,14 @@ class RadiallySymmetricRestraintForce(utils.RestorableOpenMMObject):
         The indices of the second group of atoms to restrain.
     controlling_parameter_name : str
         The name of the global parameter controlling the energy function.
+    energy_string : str
+        Energy Expression for the CustomCVForce object. Use the variable
+        "Distance" to reference the internal distance force CV.
+        You should NOT add the value of the parameters in the
+        string, the ``restraint_parameters`` dict will automatically
+        augment this string, overwriting any setting.
     *args, **kwargs
-        Parameters to pass to the super constructor.
+        Additional parameters to pass to the super constructor.
 
     Attributes
     ----------
@@ -267,35 +283,65 @@ class RadiallySymmetricRestraintForce(utils.RestorableOpenMMObject):
 
     def __init__(self, restraint_parameters, restrained_atom_indices1,
                  restrained_atom_indices2, controlling_parameter_name,
+                 energy_string,
                  *args, **kwargs):
+        # Ensure parameter names are in the correct format
+        assert len(restraint_parameters) == 1 or isinstance(restraint_parameters, collections.OrderedDict)
+        assert "Distance" not in restraint_parameters, ('"Distance" cannot be a restraint_parameter as it will ' 
+                                                        'clash with the CV Variable"')
+
+        # Augment energy_string with parameters
+        energy_string += ";"
+        for parameter_name, parameter_value in restraint_parameters.items():
+            # Ensure OpenMM Unit system
+            if isinstance(parameter_value, unit.Quantity):
+                parameter_value = parameter_value.in_unit_system(unit.md_unit_system)
+                restraint_parameters[parameter_name] = parameter_value
+                # Strip unit without overwriting dict entry efficiently
+                # Fetching value is faster than dividing by unit since
+                # we are already in correct unit system
+                parameter_value = parameter_value._value
+            energy_string += "{} = {};".format(parameter_name, parameter_value)
+        # Augment args with the energy string
+        args = (energy_string,) + args
+
+        # Construct
         super(RadiallySymmetricRestraintForce, self).__init__(*args, **kwargs)
         self._controlling_parameter_name = controlling_parameter_name
 
-        # Unzip bond parameters names and values from dict.
-        assert len(restraint_parameters) == 1 or isinstance(restraint_parameters, collections.OrderedDict)
-        parameter_names, parameter_values = zip(*restraint_parameters.items())
+        # Create the distance force used for the CV force wraps
+        distance_force = self._create_distance_force()
+        self.addCollectiveVariable("Distance", distance_force)
 
         # Let the subclass initialize its bond.
-        self._create_bond(parameter_values, restrained_atom_indices1, restrained_atom_indices2)
+        self._create_bond(restrained_atom_indices1, restrained_atom_indices2)
 
         # Add parameters.
         self.addGlobalParameter(self._controlling_parameter_name, 1.0)
-        for parameter in parameter_names:
-            self.addPerBondParameter(parameter)
+        self._restraint_parameters = restraint_parameters
 
     # -------------------------------------------------------------------------
     # Abstract methods.
     # -------------------------------------------------------------------------
 
     @abc.abstractmethod
-    def _create_bond(self, bond_parameter_values, restrained_atom_indices1,
+    def _create_distance_force(self):
+        """
+        Create and return the underlying force object
+
+        Returns
+        -------
+        force : OpenMM.Force
+            The force measuring distance to be used as the CV
+        """
+
+    @abc.abstractmethod
+    def _create_bond(self, restrained_atom_indices1,
                      restrained_atom_indices2):
         """Create the bond modelling the restraint.
 
         Parameters
         ----------
-        bond_parameter_values : list of floats
-            The list of the parameter values of the bond.
         restrained_atom_indices1 : list of int
             The indices of the first group of atoms to restrain.
         restrained_atom_indices2 : list of int
@@ -321,10 +367,7 @@ class RadiallySymmetricRestraintForce(utils.RestorableOpenMMObject):
     @property
     def restraint_parameters(self):
         """OrderedDict: The restraint parameters in dictionary form."""
-        parameter_values = self.getBondParameters(0)[-1]
-        restraint_parameters = [(self.getPerBondParameterName(parameter_idx), parameter_value)
-                                for parameter_idx, parameter_value in enumerate(parameter_values)]
-        return collections.OrderedDict(restraint_parameters)
+        return collections.OrderedDict(self._restraint_parameters)
 
     @property
     def controlling_parameter_name(self):
@@ -520,7 +563,7 @@ class RadiallySymmetricRestraintForce(utils.RestorableOpenMMObject):
         force.restrained_atom_indices1 = [0]
         force.restrained_atom_indices2 = [1]
         # Disable the PBC for this approximation of the analytical solution.
-        force.setUsesPeriodicBoundaryConditions(False)
+        force._distance_force.setUsesPeriodicBoundaryConditions(False)
         system.addForce(force)
 
         # Create a Reference context to evaluate energies on the CPU.
@@ -529,7 +572,7 @@ class RadiallySymmetricRestraintForce(utils.RestorableOpenMMObject):
         context = openmm.Context(system, integrator, platform)
 
         # Set default positions.
-        positions = unit.Quantity(np.zeros([2,3]), distance_unit)
+        positions = unit.Quantity(np.zeros([2, 3]), distance_unit)
         context.setPositions(positions)
 
         # Create a function to compute integrand as a function of interparticle separation.
@@ -656,9 +699,13 @@ class RadiallySymmetricRestraintForce(utils.RestorableOpenMMObject):
         r_max *= distance_unit
         return r_min, r_max, analytical_volume
 
+    @property
+    def _distance_force(self):
+        """Helper to return the correct CV object independent of copy operations"""
+        return self.getCollectiveVariable(0)
 
-class RadiallySymmetricCentroidRestraintForce(RadiallySymmetricRestraintForce,
-                                              openmm.CustomCentroidBondForce):
+
+class RadiallySymmetricCentroidRestraintForce(RadiallySymmetricRestraintForce):
     """Base class for radially-symmetric restraints between the centroids of two groups of atoms.
 
     The restraint is applied between the centers of mass of two groups
@@ -671,7 +718,7 @@ class RadiallySymmetricCentroidRestraintForce(RadiallySymmetricRestraintForce,
     Parameters
     ----------
     energy_function : str
-        The energy function to pass to ``CustomCentroidBondForce``. The
+        The energy function to pass to ``CustomCVForce``. The
         name of the controlling global parameter  will be prepended to
         this expression.
     restraint_parameters : OrderedDict
@@ -701,41 +748,42 @@ class RadiallySymmetricCentroidRestraintForce(RadiallySymmetricRestraintForce,
                  controlling_parameter_name='lambda_restraints'):
         # Initialize CustomCentroidBondForce.
         energy_function = controlling_parameter_name + ' * (' + energy_function + ')'
-        custom_centroid_bond_force_args = [2, energy_function]
         super(RadiallySymmetricCentroidRestraintForce, self).__init__(
             restraint_parameters, restrained_atom_indices1, restrained_atom_indices2,
-            controlling_parameter_name, *custom_centroid_bond_force_args)
+            controlling_parameter_name, energy_function)
 
     @property
     def restrained_atom_indices1(self):
         """The indices of the first group of restrained atoms."""
-        restrained_atom_indices1, weights_group1 = self.getGroupParameters(0)
+        restrained_atom_indices1, weights_group1 = self._distance_force.getGroupParameters(0)
         return list(restrained_atom_indices1)
 
     @restrained_atom_indices1.setter
     def restrained_atom_indices1(self, atom_indices):
-        self.setGroupParameters(0, atom_indices)
+        self._distance_force.setGroupParameters(0, atom_indices)
 
     @property
     def restrained_atom_indices2(self):
         """The indices of the first group of restrained atoms."""
-        restrained_atom_indices2, weights_group2 = self.getGroupParameters(1)
+        restrained_atom_indices2, weights_group2 = self._distance_force.getGroupParameters(1)
         return list(restrained_atom_indices2)
 
     @restrained_atom_indices2.setter
     def restrained_atom_indices2(self, atom_indices):
-        self.setGroupParameters(1, atom_indices)
+        self._distance_force.setGroupParameters(1, atom_indices)
 
-    def _create_bond(self, bond_parameter_values, restrained_atom_indices1,
+    def _create_distance_force(self):
+        return openmm.CustomCentroidBondForce(2, "distance(g1,g2)")
+
+    def _create_bond(self, restrained_atom_indices1,
                      restrained_atom_indices2):
         """Create the bond modelling the restraint."""
-        self.addGroup(restrained_atom_indices1)
-        self.addGroup(restrained_atom_indices2)
-        self.addBond([0, 1], bond_parameter_values)
+        self._distance_force.addGroup(restrained_atom_indices1)
+        self._distance_force.addGroup(restrained_atom_indices2)
+        self._distance_force.addBond([0, 1], [])
 
 
-class RadiallySymmetricBondRestraintForce(RadiallySymmetricRestraintForce,
-                                          openmm.CustomBondForce):
+class RadiallySymmetricBondRestraintForce(RadiallySymmetricRestraintForce):
     """Base class for radially-symmetric restraints between two atoms.
 
     This is a version of ``RadiallySymmetricCentroidRestraintForce`` that can
@@ -748,7 +796,6 @@ class RadiallySymmetricBondRestraintForce(RadiallySymmetricRestraintForce,
                  restrained_atom_index1, restrained_atom_index2,
                  controlling_parameter_name='lambda_restraints'):
         # Initialize CustomBondForce.
-        energy_function = energy_function.replace('distance(g1,g2)', 'r')
         energy_function = controlling_parameter_name + ' * (' + energy_function + ')'
         super(RadiallySymmetricBondRestraintForce, self).__init__(
             restraint_parameters, [restrained_atom_index1], [restrained_atom_index2],
@@ -761,30 +808,33 @@ class RadiallySymmetricBondRestraintForce(RadiallySymmetricRestraintForce,
     @property
     def restrained_atom_indices1(self):
         """The indices of the first group of restrained atoms."""
-        atom1, atom2, parameters = self.getBondParameters(0)
+        atom1, atom2, parameters = self._distance_force.getBondParameters(0)
         return [atom1]
 
     @restrained_atom_indices1.setter
     def restrained_atom_indices1(self, atom_indices):
         assert len(atom_indices) == 1
-        atom1, atom2, parameters = self.getBondParameters(0)
-        self.setBondParameters(0, atom_indices[0], atom2, parameters)
+        atom1, atom2, parameters = self._distance_force.getBondParameters(0)
+        self._distance_force.setBondParameters(0, atom_indices[0], atom2, parameters)
 
     @property
     def restrained_atom_indices2(self):
         """The indices of the first group of restrained atoms."""
-        atom1, atom2, parameters = self.getBondParameters(0)
+        atom1, atom2, parameters = self._distance_force.getBondParameters(0)
         return [atom2]
 
     @restrained_atom_indices2.setter
     def restrained_atom_indices2(self, atom_indices):
         assert len(atom_indices) == 1
-        atom1, atom2, parameters = self.getBondParameters(0)
-        self.setBondParameters(0, atom1, atom_indices[0], parameters)
+        atom1, atom2, parameters = self._distance_force.getBondParameters(0)
+        self._distance_force.setBondParameters(0, atom1, atom_indices[0], parameters)
 
-    def _create_bond(self, bond_parameter_values, restrained_atom_indices1, restrained_atom_indices2):
+    def _create_bond(self, restrained_atom_indices1, restrained_atom_indices2):
         """Create the bond modelling the restraint."""
-        self.addBond(restrained_atom_indices1[0], restrained_atom_indices2[0], bond_parameter_values)
+        self._distance_force.addBond(restrained_atom_indices1[0], restrained_atom_indices2[0], [])
+
+    def _create_distance_force(self):
+        return openmm.CustomBondForce("r")
 
 
 # =============================================================================
@@ -795,7 +845,7 @@ class HarmonicRestraintForceMixIn(object):
     """A mix-in providing the interface for harmonic restraints."""
 
     def __init__(self, spring_constant, *args, **kwargs):
-        energy_function = '(K/2)*distance(g1,g2)^2'
+        energy_function = '(K/2)*Distance^2'
         restraint_parameters = collections.OrderedDict([('K', spring_constant)])
         super(HarmonicRestraintForceMixIn, self).__init__(energy_function, restraint_parameters,
                                                           *args, **kwargs)
@@ -803,9 +853,11 @@ class HarmonicRestraintForceMixIn(object):
     @property
     def spring_constant(self):
         """unit.simtk.Quantity: The spring constant K (units of energy/mole/distance^2)."""
-        # This works for both CustomBondForce and CustomCentroidBondForce.
-        parameters = self.getBondParameters(0)[-1]
-        return parameters[0] * unit.kilojoule_per_mole/unit.nanometers**2
+        k = self._restraint_parameters['K']
+        if not isinstance(k, unit.Quantity):
+            # Ensures return is a unit in case the user passed in unit-stripped value
+            k = k * unit.kilojoule_per_mole / unit.nanometers**2
+        return k
 
     def distance_at_energy(self, potential_energy):
         """Compute the distance at which the potential energy is ``potential_energy``.
@@ -853,9 +905,9 @@ class HarmonicRestraintForce(HarmonicRestraintForceMixIn,
 
     The energy expression of the restraint is given by
 
-       ``E = controlling_parameter * (K/2)*r^2``
+       ``E = controlling_parameter * (K/2)*Distance^2``
 
-    where `K` is the spring constant, `r` is the distance between the
+    where `K` is the spring constant, `Distance` is the distance between the
     two group centroids, and `controlling_parameter` is a scale factor that
     can be used to control the strength of the restraint.
 
@@ -928,7 +980,7 @@ class FlatBottomRestraintForceMixIn(object):
     """A mix-in providing the interface for flat-bottom restraints."""
 
     def __init__(self, spring_constant, well_radius, *args, **kwargs):
-        energy_function = 'step(distance(g1,g2)-r0) * (K/2)*(distance(g1,g2)-r0)^2'
+        energy_function = 'step(Distance-r0) * (K/2)*(Distance-r0)^2'
         restraint_parameters = collections.OrderedDict([
             ('K', spring_constant),
             ('r0', well_radius)
@@ -940,15 +992,21 @@ class FlatBottomRestraintForceMixIn(object):
     def spring_constant(self):
         """unit.simtk.Quantity: The spring constant K (units of energy/mole/length^2)."""
         # This works for both CustomBondForce and CustomCentroidBondForce.
-        parameters = self.getBondParameters(0)[-1]
-        return parameters[0] * unit.kilojoule_per_mole/unit.nanometers**2
+        k = self._restraint_parameters['K']
+        if not isinstance(k, unit.Quantity):
+            # Ensures return is a unit in case the user passed in unit-stripped value
+            k = k * unit.kilojoule_per_mole / unit.nanometers**2
+        return k
 
     @property
     def well_radius(self):
         """unit.simtk.Quantity: The distance at which the harmonic restraint is imposed (units of length)."""
         # This works for both CustomBondForce and CustomCentroidBondForce.
-        parameters = self.getBondParameters(0)[-1]
-        return parameters[1] * unit.nanometers
+        r0 = self._restraint_parameters['r0']
+        if not isinstance(r0, unit.Quantity):
+            # Ensures return is a unit in case the user passed in unit-stripped value
+            r0 = r0 * unit.nanometers
+        return r0
 
     def distance_at_energy(self, potential_energy):
         """Compute the distance at which the potential energy is ``potential_energy``.
@@ -1014,9 +1072,9 @@ class FlatBottomRestraintForce(FlatBottomRestraintForceMixIn,
 
     More precisely, the energy expression of the restraint is given by
 
-        ``E = controlling_parameter * step(r-r0) * (K/2)*(r-r0)^2``
+        ``E = controlling_parameter * step(Distance-r0) * (K/2)*(Distance-r0)^2``
 
-    where ``K`` is the spring constant, ``r`` is the distance between the
+    where ``K`` is the spring constant, ``Distance`` is the distance between the
     restrained atoms, ``r0`` is another parameter defining the distance
     at which the restraint is imposed, and ``controlling_parameter``
     is a scale factor that can be used to control the strength of the

--- a/openmmtools/tests/test_forces.py
+++ b/openmmtools/tests/test_forces.py
@@ -58,6 +58,7 @@ def test_find_forces():
                                                  restrained_atom_index1=2, restrained_atom_index2=5)
     system.addForce(restraint_force)
     system.addForce(openmm.CustomBondForce('0.0'))
+    system.addForce(openmm.CustomCVForce('0.0'))
 
     def assert_forces_equal(found_forces, expected_force_classes):
         # Forces should be ordered by their index.
@@ -70,9 +71,9 @@ def test_find_forces():
     yield assert_forces_equal, found_forces, [(6, openmm.CustomBondForce)]
 
     # Test find force and include subclasses.
-    found_forces = find_forces(system, openmm.CustomBondForce, include_subclasses=True)
+    found_forces = find_forces(system, openmm.CustomCVForce, include_subclasses=True)
     yield assert_forces_equal, found_forces, [(5, HarmonicRestraintBondForce),
-                                              (6, openmm.CustomBondForce)]
+                                              (7, openmm.CustomCVForce)]
     found_forces = find_forces(system, RadiallySymmetricRestraintForce, include_subclasses=True)
     yield assert_forces_equal, found_forces, [(5, HarmonicRestraintBondForce)]
 
@@ -88,16 +89,16 @@ def test_find_forces():
 
     # Find all forces from the name including the subclasses.
     # Test find force and include subclasses.
-    found_forces = find_forces(system, 'CustomBond.*', include_subclasses=True)
+    found_forces = find_forces(system, 'CustomCV.*', include_subclasses=True)
     yield assert_forces_equal, found_forces, [(5, HarmonicRestraintBondForce),
-                                              (6, openmm.CustomBondForce)]
+                                              (7, openmm.CustomCVForce)]
 
     # With check_multiple=True only one force is returned.
     force_idx, force = find_forces(system, openmm.NonbondedForce, only_one=True)
     yield assert_forces_equal, {force_idx: force}, [(3, openmm.NonbondedForce)]
 
     # An exception is raised with "only_one" if multiple forces are found.
-    yield nose.tools.assert_raises, MultipleForcesError, find_forces, system, 'CustomBondForce', True, True
+    yield nose.tools.assert_raises, MultipleForcesError, find_forces, system, 'CustomCVForce', True, True
 
     # An exception is raised with "only_one" if the force wasn't found.
     yield nose.tools.assert_raises, NoForceFoundError, find_forces, system, 'NonExistentForce', True
@@ -116,8 +117,8 @@ class TestRadiallySymmetricRestraints(object):
         cls.spring_constant = 15000.0 * unit.joule/unit.mole/unit.nanometers**2
         cls.restrained_atom_indices1 = [2, 3, 4]
         cls.restrained_atom_indices2 = [10, 11]
-        cls.restrained_atom_index1=12
-        cls.restrained_atom_index2=2
+        cls.restrained_atom_index1 = 12
+        cls.restrained_atom_index2 = 2
         cls.custom_parameter_name = 'restraints_parameter'
 
         cls.restraints = [

--- a/openmmtools/tests/test_forces.py
+++ b/openmmtools/tests/test_forces.py
@@ -143,6 +143,14 @@ class TestRadiallySymmetricRestraints(object):
                                          restrained_atom_index2=cls.restrained_atom_index2,
                                          controlling_parameter_name=cls.custom_parameter_name),
         ]
+        tforce = cls.restraints[0]
+        from openmmtools.utils import deserialize as dese
+        from openmmtools.utils import serialize as se
+        import pdb
+        pdb.set_trace()
+        s = se(tforce)
+        reforce = dese(s)
+        pass
 
     def test_restorable_forces(self):
         """Test that the restraint interface can be restored after serialization."""

--- a/openmmtools/tests/test_forces.py
+++ b/openmmtools/tests/test_forces.py
@@ -143,14 +143,6 @@ class TestRadiallySymmetricRestraints(object):
                                          restrained_atom_index2=cls.restrained_atom_index2,
                                          controlling_parameter_name=cls.custom_parameter_name),
         ]
-        tforce = cls.restraints[0]
-        from openmmtools.utils import deserialize as dese
-        from openmmtools.utils import serialize as se
-        import pdb
-        pdb.set_trace()
-        s = se(tforce)
-        reforce = dese(s)
-        pass
 
     def test_restorable_forces(self):
         """Test that the restraint interface can be restored after serialization."""
@@ -158,6 +150,14 @@ class TestRadiallySymmetricRestraints(object):
             force_serialization = openmm.XmlSerializer.serialize(restorable_force)
             deserialized_force = utils.RestorableOpenMMObject.deserialize_xml(force_serialization)
             yield assert_pickles_equal, restorable_force, deserialized_force
+            # Make sure Python properties are restored correctly
+            yield assert_equal, restorable_force.controlling_parameter_name, \
+                  deserialized_force.controlling_parameter_name
+            if isinstance(restorable_force, FlatBottomRestraintForceMixIn):
+                yield assert_quantity_almost_equal, restorable_force.spring_constant, deserialized_force.spring_constant
+                yield assert_quantity_almost_equal, restorable_force.well_radius, deserialized_force.well_radius
+            elif isinstance(restorable_force, HarmonicRestraintForceMixIn):
+                yield assert_quantity_almost_equal, restorable_force.spring_constant, deserialized_force.spring_constant
 
     def test_restraint_properties(self):
         """Test that properties work as expected."""


### PR DESCRIPTION
This is my implementation of the CV Force conversion of the `RadiallySymmetricRestraintForce` class and subclasses. The call to the parent class is slightly different, the parent class is a `CustomCVForce`, and subclasses are no longer `CustomBond-` or `CustomCentroidBondForce`s.

These tests pass locally but the implementation should still be reviewed. 

While waiting for a review, I will work on the YANK side of things to take advantage of these changes.

 - [x] Implement feature / fix bug
 - [x] Add [tests](https://github.com/choderalab/openmmtools/tree/master/openmmtools/tests)
 - [x] Update [documentation](https://github.com/choderalab/openmmtools/tree/master/docs) as needed
 - [x] Update [changelog](https://github.com/choderalab/openmmtools/blob/master/docs/releasehistory.rst)