### PR TITLE
Fix readthedocs

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -9,6 +9,7 @@ dependencies:
     - scipy
     - six
     - parmed
+    - mdtraj
     - numpydoc
     - netCDF4
     - pyyaml

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -6,5 +6,5 @@ conda:
 requirements_file: null
 
 python:
-    version: 3.6
+    version: 3.5
     setup_py_install: true

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -6,5 +6,5 @@ conda:
 requirements_file: null
 
 python:
-    version: 3.5
+    version: 3.6
     setup_py_install: true


### PR DESCRIPTION
This PR fixes the `docs/environment.yml` to ensure the readthedocs build works.

Here is a build of the [fixed branch](https://openmmtools.readthedocs.io/en/fix-docs/).