### PR TITLE
Reimplement exact PME to use parameter offset in OpenMM 7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,6 @@ script:
 
 env:
   matrix:
-    - python=2.7 CONDA_PY=27
     - python=3.5 CONDA_PY=35
     - python=3.5 CONDA_PY=35 DEVOMNIA=true
     - python=3.6 CONDA_PY=36

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -13,14 +13,14 @@ requirements:
   build:
     - python
     - setuptools
-    - openmm >=7.2
+    - openmm >=7.3
 
   run:
     - python
     - numpy
     - scipy
     - six
-    - openmm >=7.2
+    - openmm >=7.3
     - parmed
     - mdtraj
     - netcdf4

--- a/docs/gettingstarted.rst
+++ b/docs/gettingstarted.rst
@@ -228,7 +228,7 @@ as a generic variable called ``lambda`` goes from ``1.0`` to ``0.0``.
 .. testcode::
 
     # Enslave lambda_sterics and lambda_electrostatics to a generic lambda variable.
-    alchemical_state.set_alchemical_variable('lambda', 1.0)
+    alchemical_state.set_function_variable('lambda', 1.0)
 
     # The functions here turn off first electrostatic and the steric interactions
     # in sequence as lambda goes from 1.0 to 0.0.
@@ -237,11 +237,11 @@ as a generic variable called ``lambda`` goes from ``1.0`` to ``0.0``.
     alchemical_state.lambda_electrostatics = alchemy.AlchemicalFunction(f_electrostatics)
     alchemical_state.lambda_sterics = alchemy.AlchemicalFunction(f_sterics)
 
-    alchemical_state.set_alchemical_variable('lambda', 0.75)
+    alchemical_state.set_function_variable('lambda', 0.75)
     assert alchemical_state.lambda_electrostatics == 0.5
     assert alchemical_state.lambda_sterics == 1.0
 
-    alchemical_state.set_alchemical_variable('lambda', 0.25)
+    alchemical_state.set_function_variable('lambda', 0.25)
     assert alchemical_state.lambda_electrostatics == 0.0
     assert alchemical_state.lambda_sterics == 0.5
 

--- a/openmmtools/alchemy.py
+++ b/openmmtools/alchemy.py
@@ -198,11 +198,25 @@ class AlchemicalState(states.GlobalParameterState):
     # Lambda properties
     # -------------------------------------------------------------------------
 
-    lambda_sterics = states.GlobalParameterState.GlobalParameter('lambda_sterics', standard_value=1.0)
-    lambda_electrostatics = states.GlobalParameterState.GlobalParameter('lambda_electrostatics', standard_value=1.0)
-    lambda_bonds = states.GlobalParameterState.GlobalParameter('lambda_bonds', standard_value=1.0)
-    lambda_angles = states.GlobalParameterState.GlobalParameter('lambda_angles', standard_value=1.0)
-    lambda_torsions = states.GlobalParameterState.GlobalParameter('lambda_torsions', standard_value=1.0)
+    class _LambdaParameter(states.GlobalParameterState.GlobalParameter):
+        """A global parameter in the interval [0, 1] with standard value 1."""
+
+        def __init__(self, parameter_name):
+            super().__init__(parameter_name, standard_value=1.0, validator=self.lambda_validator)
+
+        @staticmethod
+        def lambda_validator(self, instance, parameter_value):
+            if parameter_value is None:
+                return parameter_value
+            if not (0.0 <= parameter_value <= 1.0):
+                raise ValueError('{} must be between 0 and 1.'.format(self.parameter_name))
+            return float(parameter_value)
+
+    lambda_sterics = _LambdaParameter('lambda_sterics')
+    lambda_electrostatics = _LambdaParameter('lambda_electrostatics')
+    lambda_bonds = _LambdaParameter('lambda_bonds')
+    lambda_angles = _LambdaParameter('lambda_angles')
+    lambda_torsions = _LambdaParameter('lambda_torsions')
 
     @classmethod
     def from_system(cls, system, *args, **kwargs):

--- a/openmmtools/alchemy.py
+++ b/openmmtools/alchemy.py
@@ -205,7 +205,7 @@ class AlchemicalState(states.GlobalParameterState):
     lambda_torsions = states.GlobalParameterState.GlobalParameter('lambda_torsions', standard_value=1.0)
 
     @classmethod
-    def from_system(cls, system, **kwargs):
+    def from_system(cls, system, *args, **kwargs):
         """Constructor reading the state from an alchemical system.
 
         Parameters
@@ -230,7 +230,7 @@ class AlchemicalState(states.GlobalParameterState):
 
         """
         # The function is redefined here only to provide more specific documentation for this method.
-        super().from_system(system, **kwargs)
+        return super().from_system(system, *args, **kwargs)
 
     def set_alchemical_parameters(self, new_value):
         """Set all defined lambda parameters to the given value.
@@ -271,7 +271,7 @@ class AlchemicalState(states.GlobalParameterState):
 
         """
         # The function is redefined here only to provide more specific documentation for this method.
-        super().get_function_variable(variable_name)
+        return super().get_function_variable(variable_name)
 
     def set_function_variable(self, variable_name, new_value):
         """Set the value of the function variable.

--- a/openmmtools/alchemy.py
+++ b/openmmtools/alchemy.py
@@ -305,6 +305,46 @@ class AlchemicalState(states.GlobalParameterState):
         # The function is redefined here only to provide more specific documentation for this method.
         super().set_function_variable(variable_name, new_value)
 
+    def get_alchemical_variable(self, variable_name):
+        """Return the value of the alchemical parameter.
+
+        .. warning:
+            This is deprecated. Use ``get_function_variable`` instead.
+
+        Parameters
+        ----------
+        variable_name : str
+            The name of the alchemical variable.
+
+        Returns
+        -------
+        variable_value : float
+            The value of the alchemical variable.
+        """
+        import warnings
+        warnings.warn('AlchemicalState.get_alchemical_variable is deprecated. '
+                      'Use AlchemicalState.get_function_variable instead.')
+        return super().get_function_variable(variable_name)
+
+    def set_alchemical_variable(self, variable_name, new_value):
+        """Set the value of the alchemical variable.
+
+        .. warning:
+            This is deprecated. Use ``set_function_variable`` instead.
+
+        Parameters
+        ----------
+        variable_name : str
+            The name of the alchemical variable.
+        new_value : float
+            The new value for the variable.
+
+        """
+        import warnings
+        warnings.warn('AlchemicalState.get_alchemical_variable is deprecated. '
+                      'Use AlchemicalState.get_function_variable instead.')
+        super().set_function_variable(variable_name, new_value)
+
     # -------------------------------------------------------------------------
     # IComposableState interface
     # -------------------------------------------------------------------------

--- a/openmmtools/states.py
+++ b/openmmtools/states.py
@@ -2723,7 +2723,7 @@ class CompoundThermodynamicState(ThermodynamicState):
                     self._on_setattr_callback(s, name, old_state)
 
             # No attribute found. This is monkey patching.
-            if old_state is not None:
+            if old_state is None:
                 super(CompoundThermodynamicState, self).__setattr__(name, value)
 
     def __getstate__(self, **kwargs):

--- a/openmmtools/states.py
+++ b/openmmtools/states.py
@@ -3048,7 +3048,7 @@ class GlobalParameterState(object):
 
     # This constant can be overwritten by inheriting classes to
     # raise a custom exception class when an error is encountered.
-     _GLOBAL_PARAMETER_ERROR = GlobalParameterError
+    _GLOBAL_PARAMETER_ERROR = GlobalParameterError
 
     def __init__(self, parameters_name_suffix=None, **kwargs):
         self._initialize(parameters_name_suffix=parameters_name_suffix, **kwargs)

--- a/openmmtools/states.py
+++ b/openmmtools/states.py
@@ -3249,7 +3249,7 @@ class GlobalParameterState(object):
                 suffixed_parameter_name = self.parameter_name + '_' + instance._parameters_name_suffix
                 err_msg = 'This state does not control {} but {}.'.format(
                     self.parameter_name, suffixed_parameter_name)
-                raise instance._GLOBAL_PARAMETER_ERROR(err_msg)
+                raise AttributeError(err_msg)
 
     # -------------------------------------------------------------------------
     # Internal usage: IComposableState interface

--- a/openmmtools/states.py
+++ b/openmmtools/states.py
@@ -3156,6 +3156,10 @@ class GlobalParameterState(object):
             err_msg = ('Cannot have an function variable with the same name '
                        'of the predefined global parameter {}.'.format(variable_name))
             raise self._GLOBAL_PARAMETER_ERROR(err_msg)
+        # Check that the new value is a scalar,
+        if not (np.isreal(new_value) and np.isscalar(new_value)):
+            err_msg = 'Only integers and floats can be assigned to a function variable.'
+            raise self._GLOBAL_PARAMETER_ERROR(err_msg)
         self._function_variables[variable_name] = new_value
 
     # -------------------------------------------------------------------------

--- a/openmmtools/utils.py
+++ b/openmmtools/utils.py
@@ -273,13 +273,14 @@ def math_eval(expression, variables=None, functions=None):
                  }
 
     # Supported functions, not defined in math.
-    stock_functions = {'step': lambda x: 1 * (x >= 0),
+    extra_functions = {'step': lambda x: 1 * (x >= 0),
                        'step_hm': lambda x: 0.5 * (np.sign(x) + 1),
                        'sign': lambda x: np.sign(x)}
-    # Allow overwrite of stock_functions
+
+    # Allow overwrite of extra_functions.
     if functions is not None:
-        stock_functions.update(functions)
-    functions = stock_functions
+        extra_functions.update(functions)
+    functions = extra_functions
 
     def _math_eval(node):
         if isinstance(node, ast.Num):

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ import subprocess
 DOCLINES = __doc__.split("\n")
 
 ########################
-VERSION = "0.16.0"
+VERSION = "0.17.0"
 ISRELEASED = False
 __version__ = VERSION
 ########################


### PR DESCRIPTION
This removes the old implementation of exact PME that used `updateParametersInContext` in favor of using the parameter offset feature offered in OpenMM 7.3.

`AlchemicalState` now is a very short extension of `GlobalParameterState` that provides a general way to implement composable states controlling global parameters. I've also added `GlobalParameterFunction`, which is the general version of `AlchemicalFunction`.

I've also removed support for Python 2 here.