### PR TITLE
Bugfix in Nose-Hoover chain integrator

### DIFF
--- a/openmmtools/integrators.py
+++ b/openmmtools/integrators.py
@@ -585,6 +585,7 @@ class NoseHooverChainVelocityVerletIntegrator(ThermostatedIntegrator):
 
     Create a velocity Verlet integrator with Nosé-Hoover chain thermostat.
 
+    >>> from openmmtools import testsystems
     >>> waterbox = testsystems.WaterBox()
     >>> system = waterbox.system
     >>> timestep = 1.0 * unit.femtoseconds

--- a/openmmtools/integrators.py
+++ b/openmmtools/integrators.py
@@ -585,6 +585,7 @@ class NoseHooverChainVelocityVerletIntegrator(ThermostatedIntegrator):
 
     Create a velocity Verlet integrator with Nosé-Hoover chain thermostat.
 
+    >>> system = testsystems.WaterBox()
     >>> timestep = 1.0 * unit.femtoseconds
     >>> temperature = 300 * unit.kelvin
     >>> chain_length = 10
@@ -592,7 +593,7 @@ class NoseHooverChainVelocityVerletIntegrator(ThermostatedIntegrator):
     >>> num_mts = 5
     >>> num_yoshidasuzuki = 5
 
-    >>> integrator = NoseHooverChainVelocityVerletIntegrator(temperature, collision_frequency, timestep, chain_length, num_mts, num_yoshidasuzuki)
+    >>> integrator = NoseHooverChainVelocityVerletIntegrator(system, temperature, collision_frequency, timestep, chain_length, num_mts, num_yoshidasuzuki)
 
     Notes
     ------
@@ -601,7 +602,8 @@ class NoseHooverChainVelocityVerletIntegrator(ThermostatedIntegrator):
 
     Useful tests of the NHC integrator can be performed by monitoring the instantaneous temperature during the simulation and confirming that conserved energy is constant to about 1 part in 10^5.  The instantanous temperature and particle kinetic and potential energies can already be extracted from a snapshot, for example see the OpenMM StateDataReporter implementation for more details.  This integrator also provides heat bath energies (kJ/mol) through the following mechanism:
 
-    >>> integrator = NoseHooverChainVelocityVerletIntegrator()
+    >>> system = testsystems.WaterBox()
+    >>> integrator = NoseHooverChainVelocityVerletIntegrator(system)
     >>> heat_bath_kinetic_energy = integrator.getGlobalVariableByName('bathKE')
     >>> heat_bath_potential_energy = integrator.getGlobalVariableByName('bathPE')
 
@@ -616,13 +618,16 @@ class NoseHooverChainVelocityVerletIntegrator(ThermostatedIntegrator):
         5 : [ 0.2967324292201065,  0.2967324292201065, -0.1869297168804260, 0.2967324292201065, 0.2967324292201065 ]
     }
 
-    def __init__(self, temperature=298*unit.kelvin, collision_frequency=50/unit.picoseconds,
+    def __init__(self, system, temperature=298*unit.kelvin, collision_frequency=50/unit.picoseconds,
                  timestep=0.001*unit.picoseconds, chain_length=5, num_mts=5, num_yoshidasuzuki=5):
         """ Construct a velocity Verlet integrator with Nosé-Hoover chain thermostat implemented with massive collisions.
 
         Parameters:
         -----------
 
+        system: openmm.app.System instance
+            Only required to extract the system's number of degrees of freedom.
+                 
         temperature: unit.Quantity compatible with kelvin, default=298*unit.kelvin
             The target temperature for the thermostat.
 
@@ -674,10 +679,20 @@ class NoseHooverChainVelocityVerletIntegrator(ThermostatedIntegrator):
         frequency = collision_frequency.value_in_unit(unit.picoseconds**-1)
         Q = kT/frequency**2
 
+        # Compute the number of degrees of freedom.
+        # same as in openmm.app.StateDataReporter._initializeConstants
+        dof = 0
+        for i in range(system.getNumParticles()):
+            if system.getParticleMass(i) > 0*unit.dalton:
+                dof += 3
+        dof -= system.getNumConstraints()
+        if any(type(system.getForce(i)) == mm.CMMotionRemover for i in range(system.getNumForces())):
+            dof -= 3
+
         #
         # Define global variables
         #
-        self.addGlobalVariable("ndf", 0)      # number of degrees of freedom
+        self.addGlobalVariable("ndf", dof)      # number of degrees of freedom
         self.addGlobalVariable("bathKE", 0.0) # Thermostat bath kinetic energy
         self.addGlobalVariable("bathPE", 0.0) # Thermostat bath potential energy
         self.addGlobalVariable("KE2", 0.0)    # Twice the kinetic energy
@@ -698,9 +713,7 @@ class NoseHooverChainVelocityVerletIntegrator(ThermostatedIntegrator):
             self.addGlobalVariable("Q{}".format(i), 0)             # Thermostat "masses" in ps^2 kJ/mol
         # The masses need the number of degrees of freedom, which is approximated here.  Need a
         # better solution eventually, to properly account for constraints, translations, etc.
-        self.addPerDofVariable("ones", 1.0)
         self.addPerDofVariable("x1", 0);
-        self.addComputeSum("ndf", "ones")
         if self.M:
             self.addComputeGlobal("Q0", "ndf*Q")
             for i in range(1, self.M):
@@ -720,6 +733,7 @@ class NoseHooverChainVelocityVerletIntegrator(ThermostatedIntegrator):
         if self.M: self.propagateNHC()
         # Compute heat bath energies
         self.computeEnergies()
+
 
     def propagateNHC(self):
         """ Propagate the Nosé-Hoover chain """

--- a/openmmtools/tests/test_integrators.py
+++ b/openmmtools/tests/test_integrators.py
@@ -161,6 +161,8 @@ def test_stabilities():
     for test_name, test in test_cases.items():
         for integrator_name, integrator_class in custom_integrators:
             integrator = integrator_class()
+            # NoseHooverChainVelocityVerletIntegrator will print a severe warning here,
+            # because it is being initialized without a system. That's OK.
             integrator.__doc__ = integrator_name
             check_stability.description = ("Testing {} for stability over a short number of "
                                            "integration steps of a {}.").format(integrator_name, test_name)
@@ -232,8 +234,10 @@ def test_pretty_formatting():
     """
     custom_integrators = get_all_custom_integrators()
     for integrator_name, integrator_class in custom_integrators:
-        # The NonequilibriumLangevinIntegrator requires an alchemical function.
+
         integrator = integrator_class()
+        # NoseHooverChainVelocityVerletIntegrator will print a severe warning here,
+        # because it is being initialized without a system. That's OK.
 
         if hasattr(integrator, 'pretty_format'):
             # Check formatting as text
@@ -251,8 +255,11 @@ def test_update_context_state_calls():
     """
     custom_integrators = get_all_custom_integrators()
     for integrator_name, integrator_class in custom_integrators:
-        # The NonequilibriumLangevinIntegrator requires an alchemical function.
+
         integrator = integrator_class()
+        # NoseHooverChainVelocityVerletIntegrator will print a severe warning here,
+        # because it is being initialized without a system. That's OK.
+
         num_force_update = 0
         for i in range(integrator.getNumComputations()):
             step_type, target, expr = integrator.getComputationStep(i)
@@ -616,6 +623,8 @@ def test_temperature_getter_setter():
         # If this is not a ThermostatedIntegrator, the interface should not be added.
         if integrator_name not in thermostated_integrators:
             integrator = integrator_class()
+            # NoseHooverChainVelocityVerletIntegrator will print a severe warning here,
+            # because it is being initialized without a system. That's OK.
             assert ThermostatedIntegrator.is_thermostated(integrator) is False
             assert ThermostatedIntegrator.restore_interface(integrator) is False
             assert not hasattr(integrator, 'getTemperature')
@@ -625,6 +634,8 @@ def test_temperature_getter_setter():
         check_integrator_temperature_getter_setter.description = ('Test temperature setter and '
                                                                   'getter of {}').format(integrator_name)
         integrator = integrator_class(temperature=temperature)
+        # NoseHooverChainVelocityVerletIntegrator will print a severe warning here,
+        # because it is being initialized without a system. That's OK.
         context = openmm.Context(test.system, integrator)
         context.setPositions(test.positions)
 
@@ -637,6 +648,8 @@ def test_temperature_getter_setter():
         check_integrator_temperature_getter_setter.description = ('Test temperature wrapper '
                                                                   'of {}').format(integrator_name)
         integrator = integrator_class()
+        # NoseHooverChainVelocityVerletIntegrator will print a severe warning here,
+        # because it is being initialized without a system. That's OK.
         context = openmm.Context(test.system, integrator)
         context.setPositions(test.positions)
         integrator = context.getIntegrator()
@@ -654,6 +667,8 @@ def test_restorable_integrator_copy():
     thermostated_integrators = get_all_custom_integrators(only_thermostated=True)
     for integrator_name, integrator_class in thermostated_integrators:
         integrator = integrator_class()
+        # NoseHooverChainVelocityVerletIntegrator will print a severe warning here,
+        # because it is being initialized without a system. That's OK.
         integrator_copied = copy.deepcopy(integrator)
         assert isinstance(integrator_copied, integrator_class)
         assert set(integrator_copied.__dict__.keys()) == set(integrator.__dict__.keys())

--- a/openmmtools/tests/test_integrators_and_testsystems.py
+++ b/openmmtools/tests/test_integrators_and_testsystems.py
@@ -91,7 +91,14 @@ def test_integrators_and_testsystems():
             continue
 
         for integrator_name, integrator_class in custom_integrators:
-            integrator = integrator_class()
+            if integrator_name == "NoseHooverChainVelocityVerletIntegrator":
+                # The system should be passed to the NoseHooverChainVelocityVerletIntegrator
+                # to extract the correct number of degrees of freedom from the system.
+                integrator = integrator_class(testsystem.system)
+            else:
+                integrator = integrator_class()
+
+            # because it is being initialized without a system. That's OK.
 
             # Create test.
             f = partial(check_combination, integrator, testsystem, platform)


### PR DESCRIPTION
@andysim and I realized that constraints had not been taken into account when calculating the number of degrees of freedom in the `NoseHooverChainVelocityVerletIntegrator`. 
As a result, the system temperature did not converge to the target value for systems with constraints.

I added a test to make sure that the target temperature is now matched.

The fix changes the API of the constructor: It requires the system to be passed as an argument (only in order to extract the correct number of constraints; the integrator then forgets about the system).

Cheers,
Andreas Krämer

 - [x] Implement feature / fix bug
 - [x] Add [tests](https://github.com/choderalab/openmmtools/tree/master/openmmtools/tests)
 - [ ] Update [documentation](https://github.com/choderalab/openmmtools/tree/master/docs) as needed
 - [ ] Update [changelog](https://github.com/choderalab/openmmtools/blob/master/docs/releasehistory.rst)