### PR TITLE
Fix bug when computing reduced potential in multiple states

### DIFF
--- a/docs/releasehistory.rst
+++ b/docs/releasehistory.rst
@@ -16,9 +16,17 @@ considerable speed improvement over the previous implementation (`#380 <https://
 - It is now possible to have multiple composable states exposing the same attributes/getter/setter in a
 ``CompoundThermodynamicState`` (`#380 <https://github.com/choderalab/openmmtools/pull/380>`_).
 
+Bug fixes
+---------
+- Fixed a bug involving the ``NoseHooverChainVelocityVerletIntegrator`` with ``System`` with constraints. The constraints
+were not taken into account when calculating the number of degrees of freedom resulting in the temperature not converging
+to the target value. (`#384 <https://github.com/choderalab/openmmtools/pull/384>`_)
+- Fixed a bug affecting ``reduced_potential_at_states`` when computing the reduced potential of systems in different
+``AlchemicalState``s when the same alchemical parameter appeared in force objects split in different force groups. (`#385 <https://github.com/choderalab/openmmtools/pull/385>`_)
+
 Deprecated and API breaks
 -------------------------
-- Python 2, which was deprecated in 0.16.0, is now unsupported.
+- Python 2 is not supported anymore.
 - The ``update_alchemical_charges`` attribute of ``AlchemicalState`, which was deprecated in 0.16.0, has now been removed
 since it doesn't make sense with the new parameter offset implementation.
 - The methods ``AlchemicalState.get_alchemical_variable`` and ``AlchemicalState.set_alchemical_variable`` have been

--- a/openmmtools/integrators.py
+++ b/openmmtools/integrators.py
@@ -630,8 +630,9 @@ class NoseHooverChainVelocityVerletIntegrator(ThermostatedIntegrator):
 
         system: openmm.app.System instance
             Required to extract the system's number of degrees of freedom.
-            If the system is not passed to the constructor,
-            the temperature will converge to the wrong value.
+            If the system is not passed to the constructor and has constraints
+            or a ``CMMotionRemover`` force, the temperature will converge to the
+            wrong value.
                  
         temperature: unit.Quantity compatible with kelvin, default=298*unit.kelvin
             The target temperature for the thermostat.
@@ -676,7 +677,7 @@ class NoseHooverChainVelocityVerletIntegrator(ThermostatedIntegrator):
         if chain_length < 0:
             raise Exception("Nosé-Hoover chain length must be at least 0")
         if chain_length == 0:
-            print("WARNING: Nosé-Hoover chain length is 0; falling back to regular velocity verlet algorithm.")
+            logger.warning('Nosé-Hoover chain length is 0; falling back to regular velocity verlet algorithm.')
         self.M           = chain_length
 
         # Define the "mass" of the thermostat particles (multiply by ndf for particle 0)
@@ -688,8 +689,8 @@ class NoseHooverChainVelocityVerletIntegrator(ThermostatedIntegrator):
         # Compute the number of degrees of freedom.
         #
         if system is None:
-            print("SEVERE WARNING: The system was not passed to the NoseHooverChainVelocityVerletIntegrator. "
-                  "For systems with constraints, the simulation will run at the wrong temperature.")
+            logger.warning('The system was not passed to the NoseHooverChainVelocityVerletIntegrator. '
+                           'For systems with constraints, the simulation will run at the wrong temperature.')
             # Fall back to old scheme, which only works for unconstrained systems
             self.addGlobalVariable("ndf", 0)
             self.addPerDofVariable("ones", 1.0)
@@ -749,7 +750,6 @@ class NoseHooverChainVelocityVerletIntegrator(ThermostatedIntegrator):
         if self.M: self.propagateNHC()
         # Compute heat bath energies
         self.computeEnergies()
-
 
     def propagateNHC(self):
         """ Propagate the Nosé-Hoover chain """

--- a/openmmtools/tests/test_integrators.py
+++ b/openmmtools/tests/test_integrators.py
@@ -224,10 +224,9 @@ def test_nose_hoover_integrator():
     
     # Coarse check for target temperature
     mean_temperature = np.mean(temperatures)
-    print(mean_temperature)
-    assert abs(mean_temperature - temperature.value_in_unit(unit.kelvin)) < 10.0
-    
-    
+    assert abs(mean_temperature - temperature.value_in_unit(unit.kelvin)) < 10.0, mean_temperature
+
+
 def test_pretty_formatting():
     """
     Test pretty-printing and pretty-formatting of integrators.


### PR DESCRIPTION
This fixes a bug affecting ``reduced_potential_at_states()`` when computing the reduced potential of systems in different ``GlobalParameterState``s when the same alchemical parameter appeared in force objects split in different force groups.