### PR TITLE
Set exact PME as default

### DIFF
--- a/docs/releasehistory.rst
+++ b/docs/releasehistory.rst
@@ -15,6 +15,8 @@ Enhancements
 ------------
 - New implementation of the exact PME handling that uses the parameter offset feature in OpenMM 7.3. This comes with a
 considerable speed improvement over the previous implementation (`#380 <https://github.com/choderalab/openmmtools/pull/380>`_).
+- Exact PME is now the default for the ``alchemical_pme_treatment`` parameter in the constructor of
+``AbsoluteAchemicalFactory`` (`#386 <https://github.com/choderalab/openmmtools/pull/386>`_).
 - It is now possible to have multiple composable states exposing the same attributes/getter/setter in a
 ``CompoundThermodynamicState`` (`#380 <https://github.com/choderalab/openmmtools/pull/380>`_).
 

--- a/docs/releasehistory.rst
+++ b/docs/releasehistory.rst
@@ -8,6 +8,8 @@ New features
 ------------
 - Add ``GlobalParameterFunction`` that allows to enslave a ``GlobalParameter`` to an arbitrary function of controlling
 variables (`#380 <https://github.com/choderalab/openmmtools/pull/380>`_).
+- Allow to ignore velocities when building the dict representation of a ``SamplerState``. This can be useful for example
+to save bandwidth when sending a ``SamplerState`` over the network and velocities are not required (`#386 <https://github.com/choderalab/openmmtools/pull/386>`_).
 
 Enhancements
 ------------

--- a/openmmtools/alchemy.py
+++ b/openmmtools/alchemy.py
@@ -616,7 +616,7 @@ class AbsoluteAlchemicalFactory(object):
     # -------------------------------------------------------------------------
 
     def __init__(self, consistent_exceptions=False, switch_width=1.0*unit.angstroms,
-                 alchemical_pme_treatment='direct-space', alchemical_rf_treatment='switched',
+                 alchemical_pme_treatment='exact', alchemical_rf_treatment='switched',
                  disable_alchemical_dispersion_correction=False, split_alchemical_forces=True):
 
         self.consistent_exceptions = consistent_exceptions

--- a/openmmtools/states.py
+++ b/openmmtools/states.py
@@ -2120,18 +2120,36 @@ class SamplerState(object):
         sampler_state._collective_variables = None
         return sampler_state
 
-    def __getstate__(self):
-        """Return a dictionary representation of the state."""
+    def __getstate__(self, ignore_velocities=False):
+        """Return a dictionary representation of the state.
+
+        Parameters
+        ----------
+        ignore_velocities : bool, optional
+            If True, velocities are not serialized. This can be useful for
+            example to save bandwidth when sending a ``SamplerState`` over
+            the network and velocities are not required (default is False).
+        """
+        velocities = None if ignore_velocities else self.velocities
         serialization = dict(
-            positions=self.positions, velocities=self.velocities,
+            positions=self.positions, velocities=velocities,
             box_vectors=self.box_vectors, potential_energy=self.potential_energy,
             kinetic_energy=self.kinetic_energy,
             collective_variables=self.collective_variables
         )
         return serialization
 
-    def __setstate__(self, serialization):
-        """Set the state from a dictionary representation."""
+    def __setstate__(self, serialization, ignore_velocities=False):
+        """Set the state from a dictionary representation.
+
+        Parameters
+        ----------
+        ignore_velocities : bool, optional
+            If True and the ``SamplerState`` has already velocities
+            defined, this does not overwrite the velocities.
+        """
+        if ignore_velocities and '_velocities' in self.__dict__:
+            serialization['velocities'] = self.velocities
         self._initialize(**serialization)
 
     # -------------------------------------------------------------------------

--- a/openmmtools/tests/test_alchemy.py
+++ b/openmmtools/tests/test_alchemy.py
@@ -1278,7 +1278,8 @@ class TestAbsoluteAlchemicalFactory(object):
     def generate_cases(cls):
         """Generate all test cases in cls.test_cases combinatorially."""
         cls.test_cases = dict()
-        factory = AbsoluteAlchemicalFactory(alchemical_rf_treatment='switched')
+        direct_space_factory = AbsoluteAlchemicalFactory(alchemical_pme_treatment='direct-space',
+                                                         alchemical_rf_treatment='switched')
         exact_pme_factory = AbsoluteAlchemicalFactory(alchemical_pme_treatment='exact')
 
         # We generate all possible combinations of annihilate_sterics/electrostatics
@@ -1324,7 +1325,7 @@ class TestAbsoluteAlchemicalFactory(object):
                     test_case_name += ', modified softcore parameters'
 
                 # Pre-generate alchemical system.
-                alchemical_system = factory.create_alchemical_system(test_system.system, test_region)
+                alchemical_system = direct_space_factory.create_alchemical_system(test_system.system, test_region)
 
                 # Add test case.
                 cls.test_cases[test_case_name] = (test_system, alchemical_system, test_region)
@@ -1343,7 +1344,7 @@ class TestAbsoluteAlchemicalFactory(object):
             # of the reference system to allow comparisons.
             if nonbonded_method == openmm.NonbondedForce.CutoffPeriodic:
                 forcefactories.replace_reaction_field(test_system.system, return_copy=False,
-                                                      switch_width=factory.switch_width)
+                                                      switch_width=direct_space_factory.switch_width)
 
     def filter_cases(self, condition_func, max_number=None):
         """Return the list of test cases that satisfy condition_func(test_case_name)."""

--- a/openmmtools/tests/test_states.py
+++ b/openmmtools/tests/test_states.py
@@ -22,8 +22,22 @@ from openmmtools.states import *
 
 
 # =============================================================================
+# CONSTANTS
+# =============================================================================
+
+# We use CPU as OpenCL sometimes causes segfaults on Travis.
+DEFAULT_PLATFORM = openmm.Platform.getPlatformByName('CPU')
+DEFAULT_PLATFORM.setPropertyDefaultValue('DeterministicForces', 'true')
+
+
+# =============================================================================
 # UTILITY FUNCTIONS
 # =============================================================================
+
+def create_default_context(thermodynamic_state, integrator):
+    """Shortcut to create a context from the thermodynamic state using the DEFAULT_PLATFORM."""
+    return thermodynamic_state.create_context(integrator, DEFAULT_PLATFORM)
+
 
 def get_barostat_temperature(barostat):
     """Backward-compatibly get barostat's temperature"""
@@ -579,8 +593,8 @@ class TestThermodynamicState(object):
             friction = 5.0/unit.picosecond
             integrator1 = openmm.VerletIntegrator(time_step)
             integrator2 = openmm.LangevinIntegrator(state2.temperature, friction, time_step)
-            context1 = state1.create_context(integrator1)
-            context2 = state2.create_context(integrator2)
+            context1 = create_default_context(state1, integrator1)
+            context2 = create_default_context(state2, integrator2)
             assert state1.is_context_compatible(context2) is is_compatible
             assert state2.is_context_compatible(context1) is is_compatible
 
@@ -611,10 +625,10 @@ class TestThermodynamicState(object):
         state0 = ThermodynamicState(self.barostated_alanine, self.std_temperature)
 
         langevin_integrator = openmm.LangevinIntegrator(self.std_temperature, friction, time_step)
-        context = state0.create_context(langevin_integrator)
+        context = create_default_context(state0, langevin_integrator)
 
         verlet_integrator = openmm.VerletIntegrator(1.0*unit.femtosecond)
-        thermostated_context = state0.create_context(verlet_integrator)
+        thermostated_context = create_default_context(state0, verlet_integrator)
 
         # Change context pressure.
         barostat = state0._find_barostat(context.getSystem())
@@ -670,7 +684,7 @@ class TestThermodynamicState(object):
         del thermostated_context, verlet_integrator
 
         verlet_integrator = openmm.VerletIntegrator(time_step)
-        nvt_context = state2.create_context(verlet_integrator)
+        nvt_context = create_default_context(state2, verlet_integrator)
         with nose.tools.assert_raises(ThermodynamicsError) as cm:
             state1.apply_to_context(nvt_context)
         assert cm.exception.code == ThermodynamicsError.INCOMPATIBLE_ENSEMBLE
@@ -682,7 +696,7 @@ class TestThermodynamicState(object):
         beta = 1.0 / (unit.MOLAR_GAS_CONSTANT_R * self.std_temperature)
         state = ThermodynamicState(self.alanine_explicit, self.std_temperature)
         integrator = openmm.VerletIntegrator(1.0*unit.femtosecond)
-        context = state.create_context(integrator)
+        context = create_default_context(state, integrator)
         context.setPositions(self.alanine_positions)
         sampler_state = SamplerState.from_context(context)
 
@@ -733,7 +747,7 @@ class TestThermodynamicState(object):
         for compatible_group in compatible_groups:
             # Create context.
             integrator = openmm.VerletIntegrator(2.0*unit.femtoseconds)
-            context = compatible_group[0].create_context(integrator)
+            context = create_default_context(compatible_group[0], integrator)
             if len(compatible_group) == 2:
                 context.setPositions(self.alanine_positions)
             else:
@@ -794,7 +808,7 @@ class TestSamplerState(object):
     @staticmethod
     def create_context(thermodynamic_state):
         integrator = openmm.VerletIntegrator(1.0*unit.femtoseconds)
-        return thermodynamic_state.create_context(integrator)
+        return thermodynamic_state.create_context(integrator, DEFAULT_PLATFORM)
 
     def test_inconsistent_n_particles(self):
         """Exception raised with inconsistent positions and velocities."""
@@ -1236,7 +1250,7 @@ class TestCompoundThermodynamicState(object):
         assert not compound_state.is_state_compatible(incompatible_state)
 
         integrator = openmm.VerletIntegrator(2.0*unit.femtoseconds)
-        context = incompatible_state.create_context(integrator)
+        context = create_default_context(incompatible_state, integrator)
         assert not compound_state.is_context_compatible(context)
 
     def test_method_apply_to_context(self):
@@ -1247,7 +1261,7 @@ class TestCompoundThermodynamicState(object):
         self.DummyState.set_dummy_parameter(thermodynamic_state.system, dummy_parameter)
 
         integrator = openmm.VerletIntegrator(2.0*unit.femtoseconds)
-        context = thermodynamic_state.create_context(integrator)
+        context = create_default_context(thermodynamic_state, integrator)
         barostat = ThermodynamicState._find_barostat(context.getSystem())
         assert context.getParameter('dummy_parameter') == dummy_parameter
         assert context.getParameter(barostat.Pressure()) == self.std_pressure / unit.bar
@@ -1264,7 +1278,7 @@ class TestCompoundThermodynamicState(object):
         alanine_explicit = copy.deepcopy(self.alanine_explicit)
         thermodynamic_state = ThermodynamicState(alanine_explicit, self.std_temperature)
         compound_state = CompoundThermodynamicState(thermodynamic_state, [self.dummy_state])
-        context = compound_state.create_context(openmm.VerletIntegrator(2.0*unit.femtoseconds))
+        context = create_default_context(compound_state, openmm.VerletIntegrator(2.0*unit.femtoseconds))
 
         # No force group should be updated if the two states are identical.
         assert compound_state._find_force_groups_to_update(context, compound_state, memo={}) == set()
@@ -1636,7 +1650,7 @@ class TestGlobalParameterState(object):
         """Test method GlobalParameterState.apply_to_context."""
         system = self.diatomic_molecule_ts.system
         integrator = openmm.VerletIntegrator(1.0*unit.femtosecond)
-        context = self.diatomic_molecule_ts.create_context(integrator)
+        context = create_default_context(self.diatomic_molecule_ts, integrator)
 
         def check_not_applicable(states, error, context):
             for s in states:
@@ -1874,7 +1888,7 @@ class TestGlobalParameterState(object):
 
         # Build all contexts for testing.
         integrator = openmm.VerletIntegrator(2.0*unit.femtoseconds)
-        contexts = [s.create_context(copy.deepcopy(integrator)) for s in compound_states]
+        contexts = [create_default_context(s, copy.deepcopy(integrator)) for s in compound_states]
 
         for state_idx, (compound_state, context) in enumerate(zip(compound_states, contexts)):
             # The state is compatible with itself.
@@ -1941,7 +1955,7 @@ class TestGlobalParameterState(object):
         for compatible_group in compatible_groups:
             # Create context.
             integrator = openmm.VerletIntegrator(2.0*unit.femtoseconds)
-            context = compatible_group[0].create_context(integrator)
+            context = create_default_context(compatible_group[0], integrator)
             context.setPositions(positions)
 
             # Compute with single-state method.


### PR DESCRIPTION
- Set exact PME as the default value for `alchemical_pme_treatment` in the `AbsoluteAlchemicalFactory` constructor.
- I've added an optional `ignore_velocities` argument in the `__setstate__` and `__getstate__` methods of `SamplerState`. This will allow us to generalize in YANK the way MPI process send back the info about the `SamplerState` to the root process (including collective variables) without wasting bandwidth.
- I'm also checking if using the CPU platform to create `Context`s fixes the random segfaults in the Travis tests.