### PR TITLE
TestSystems for Double Well in WCA Fluid

### DIFF
--- a/docs/releasehistory.rst
+++ b/docs/releasehistory.rst
@@ -10,6 +10,8 @@ New features
 variables (`#380 <https://github.com/choderalab/openmmtools/pull/380>`_).
 - Allow to ignore velocities when building the dict representation of a ``SamplerState``. This can be useful for example
 to save bandwidth when sending a ``SamplerState`` over the network and velocities are not required (`#386 <https://github.com/choderalab/openmmtools/pull/386>`_).
+- Add ``DoubleWellDimer_WCAFluid`` and ``DoubleWellChain_WCAFluid`` test
+  systems (`#389 <https://github.com/choderalab/openmmtools/pull/389>`_).
 
 Enhancements
 ------------

--- a/docs/testsystems.rst
+++ b/docs/testsystems.rst
@@ -51,6 +51,8 @@ Clusters and simple fluids
     LennardJonesGrid
     CustomLennardJonesFluidMixture
     WCAFluid
+    DoubleWellDimer_WCAFluid
+    DoubleWellChain_WCAFluid
     TolueneVacuum
     TolueneImplicit
     TolueneImplicitHCT

--- a/openmmtools/tests/test_testsystems.py
+++ b/openmmtools/tests/test_testsystems.py
@@ -5,6 +5,7 @@ from simtk import openmm
 
 import os, os.path
 import logging
+from nose.tools import assert_raises
 
 from openmmtools import testsystems
 
@@ -222,3 +223,15 @@ def test_dw_systems_1_dimer():
     dimers = testsystems.DoubleWellDimer_WCAFluid(ndimers=1)
     chain = testsystems.DoubleWellChain_WCAFluid(nchained=2)
     assert _equiv_topology(dimers.topology, chain.topology)
+
+def test_double_well_dimer_errors():
+    with assert_raises(ValueError) as context:
+        testsystems.DoubleWellDimer_WCAFluid(ndimers=-1)
+    with assert_raises(ValueError) as context:
+        testsystems.DoubleWellDimer_WCAFluid(ndimers=6, nparticles=10)
+
+def test_double_well_chain_errors():
+    with assert_raises(ValueError) as context:
+        testsystems.DoubleWellChain_WCAFluid(nchained=-1)
+    with assert_raises(ValueError) as context:
+        testsystems.DoubleWellChain_WCAFluid(nchained=11, nparticles=10)

--- a/openmmtools/tests/test_testsystems.py
+++ b/openmmtools/tests/test_testsystems.py
@@ -192,3 +192,17 @@ def test_topology_all_testsystems():
         f = partial(check_topology, testsystem.system, testsystem.topology)
         f.description = "Testing topology for testsystem %s" % class_name
         yield f
+
+def test_dw_dimers_as_wca(self):
+    dimers = testsystems.DoubleWellDimer_WCAFluid(ndimers=0)
+    chain_1 = testsystems.DoubleWellChain_WCAFluid(nchained=1)
+    chain_0 = testsystems.DoubleWellChain_WCAFluid(nchained=0)
+    wca = testsystems.WCAFluid()
+    assert dimers.topology == wca.topology
+    assert chain_1.topology == wca.topology
+    assert chain_0.topology == wca.topology
+
+def test_dw_dimers_1_dimer(self):
+    dimers = testsystems.DoubleWellDimer_WCAFluid(ndimers=1)
+    chain = testsystems.DoubleWellChain_WCAFluid(nchained=2)
+    assert dimers.topollogy == chain.topology

--- a/openmmtools/tests/test_testsystems.py
+++ b/openmmtools/tests/test_testsystems.py
@@ -10,6 +10,18 @@ from openmmtools import testsystems
 
 from functools import partial
 
+def _equiv_topology(top_1, top_2):
+    """Compare topologies using string reps of atoms and bonds"""
+    for (b1, b2) in zip(top_1.bonds(), top_2.bonds()):
+        if str(b1) != str(b2):
+            return False
+
+    for (a1, a2) in zip(top_1.atoms(), top_2.atoms()):
+        if str(a1) != str(a2):
+            return False
+
+    return True
+
 def get_all_subclasses(cls):
     """
     Return all subclasses of a specified class.
@@ -193,16 +205,20 @@ def test_topology_all_testsystems():
         f.description = "Testing topology for testsystem %s" % class_name
         yield f
 
-def test_dw_dimers_as_wca(self):
+def test_dw_systems_as_wca():
+    # check that the double-well systems are equivalent to WCA fluid in
+    # certain limits
     dimers = testsystems.DoubleWellDimer_WCAFluid(ndimers=0)
     chain_1 = testsystems.DoubleWellChain_WCAFluid(nchained=1)
     chain_0 = testsystems.DoubleWellChain_WCAFluid(nchained=0)
     wca = testsystems.WCAFluid()
-    assert dimers.topology == wca.topology
-    assert chain_1.topology == wca.topology
-    assert chain_0.topology == wca.topology
+    assert _equiv_topology(dimers.topology, wca.topology)
+    assert _equiv_topology(chain_1.topology, wca.topology)
+    assert _equiv_topology(chain_0.topology, wca.topology)
 
-def test_dw_dimers_1_dimer(self):
+def test_dw_systems_1_dimer():
+    # check that the double-well systems are equivalent when there's only
+    # one dimer pair
     dimers = testsystems.DoubleWellDimer_WCAFluid(ndimers=1)
     chain = testsystems.DoubleWellChain_WCAFluid(nchained=2)
-    assert dimers.topollogy == chain.topology
+    assert _equiv_topology(dimers.topology, chain.topology)

--- a/openmmtools/tests/test_testsystems.py
+++ b/openmmtools/tests/test_testsystems.py
@@ -96,7 +96,7 @@ fast_testsystems = [
     "LennardJonesFluid",
     "LennardJonesGrid",
     "CustomLennardJonesFluidMixture",
-    "WCAFluid",
+    "WCAFluid", "DoubleWellDimer_WCAFluid", "DoubleWellChain_WCAFluid",
     "IdealGas",
     "WaterBox", "FlexibleWaterBox", "FourSiteWaterBox", "FiveSiteWaterBox", "DischargedWaterBox", "DischargedWaterBoxHsites", "AlchemicalWaterBox",
     "AlanineDipeptideVacuum", "AlanineDipeptideImplicit",

--- a/openmmtools/testsystems.py
+++ b/openmmtools/testsystems.py
@@ -2349,6 +2349,10 @@ class WCAFluid(TestSystem):
         self.system, self.positions = system, positions
 
 
+#=============================================================================================
+# Double Well Dimers in WCA Fluid
+#=============================================================================================
+
 class DoubleWellDimer_WCAFluid(WCAFluid):
 
     def __init__(self, ndimers=1, nparticles=216, density=0.96, mass=39.9 *
@@ -2491,6 +2495,10 @@ class DoubleWellDimer_WCAFluid(WCAFluid):
         for bond_idx in range(nbonds):
             yield (2 * bond_idx, 2 * bond_idx + 1)
 
+
+#=============================================================================================
+# Double Well Chain in WCA Fluid
+#=============================================================================================
 
 class DoubleWellChain_WCAFluid(DoubleWellDimer_WCAFluid):
     def __init__(self, nchained=3, nparticles=216, density=0.96, mass=39.9 *


### PR DESCRIPTION
This PR adds (two generalizations of) a test system that has been frequently used in rare events. I'm calling these `DoubleWellDimer_WCAFluid` and `DoubleWellChain_WCAFluid`. In both cases, we start with the existing `WCAFluid` test system, and add bonded interactions of the form $h (1 - ((r - r_0 - w) / w)^2)^2$. This is a symmetric potential with a minimum at $(r_0, 0)$, a maximum at $(r_0+w, h)$, and a second minimum at $(r_0 + 2w, 0)$. The widely-used test system adds this interaction between 2 atoms, so there is one dimer in the WCA fluid.

For the `DoubleWellDimer_WCAFluid`, the system will create bonds between pairs of atoms, so the bonds are created between atom 0 and 1, atom 2 and 3, etc., resulting in multiple separated dimers, each dimer connected by the double-well potential. This is similar to what was done in [Swenson and Bolhuis, JCP 2014](http://doi.org/10.1063/1.4890037). The standard example is `ndimers=1`.

For the `DoubleWellChain_WCAFluid`, the system will create a chain of bonds of the desired length, so bonds are created between atom 0 and 1, atom 1 and 2, etc. For `nchained=1`, this is just the WCA fluid; for `nchained=2`, this is identical to the `DoubleWellDimer_WCAFluid` with `ndimers=1`, and for `nchained=3` this is the same as the potential used in [Rogal and Bolhuis, JCP 2008](https://doi.org/10.1063/1.3029696).

The clever bit in the implementation is to recognize that the same algorithm works for both; the only difference is in which atom pairs are selected to have the custom bond force added to them.

 - [x] Implement feature / fix bug
 - [x] Add [tests](https://github.com/choderalab/openmmtools/tree/master/openmmtools/tests)
 - [x] Update [documentation](https://github.com/choderalab/openmmtools/tree/master/docs) as needed
 - [x] Update [changelog](https://github.com/choderalab/openmmtools/blob/master/docs/releasehistory.rst)