### PR TITLE
Minor travis cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,8 @@ script:
   - source activate test
   # Add org channel
   - conda config --add channels ${ORGNAME}
-  # TODO: remove this channel when OpenMM 7.3 has been released.
-  - conda config --add channels omnia/label/rc
   # Add omnia dev channels
-  - if [ $DEVOMNIA ]; then conda config --add channels https://conda.anaconda.org/omnia/label/dev; fi
+  - if [ $DEVOMNIA ]; then conda config --add channels omnia-dev; fi
   # Add conda-forge channel back to top priority
   - conda config --add channels conda-forge
   # Build the recipe
@@ -29,7 +27,7 @@ script:
   - conda install --yes --quiet --use-local ${PACKAGENAME}-dev
   # Install testing dependencies. Without specifying the numpy version, numpy
   # is downgraded to 1.9 and we get a "libgfortran not found" issue.
-  - conda install --yes --quiet nose nose-timer pymbar "numpy>=1.11"
+  - conda install --yes --quiet nose nose-timer pymbar "numpy>=1.14"
   # Test the package
   # TODO: remove the IGNORE_EXCEPTION_DETAIL when we drop Python2 support
   - cd devtools && nosetests $PACKAGENAME --nocapture --verbosity=2 --with-timer --with-doctest --doctest-options="+IGNORE_EXCEPTION_DETAIL" -a '!slow' && cd ..
@@ -47,9 +45,8 @@ env:
 
 matrix:
   allow_failures:
-  - env: python=3.5 CONDA_PY=35 DEVOMNIA=true
+  - env: python=3.7 CONDA_PY=37 DEVOMNIA=true
 
 after_success:
   - echo "after_success"
   - if [ "$TRAVIS_SECURE_ENV_VARS" == true ]; then source devtools/travis-ci/after_success.sh; fi
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ env:
   matrix:
     - python=3.6 CONDA_PY=36
     - python=3.7 CONDA_PY=37
+    - python=3.7 CONDA_PY=37 DEVOMNIA=true # allowed to fail
   global:
     - ORGNAME="omnia" # the name of the organization
     - PACKAGENAME="openmmtools" # the name of your package

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,7 @@ script:
   # is downgraded to 1.9 and we get a "libgfortran not found" issue.
   - conda install --yes --quiet nose nose-timer pymbar "numpy>=1.14"
   # Test the package
-  # TODO: remove the IGNORE_EXCEPTION_DETAIL when we drop Python2 support
-  - cd devtools && nosetests $PACKAGENAME --nocapture --verbosity=2 --with-timer --with-doctest --doctest-options="+IGNORE_EXCEPTION_DETAIL" -a '!slow' && cd ..
+  - cd devtools && nosetests $PACKAGENAME --nocapture --verbosity=2 --with-timer --with-doctest -a '!slow' && cd ..
 
 env:
   matrix:

--- a/openmmtools/alchemy.py
+++ b/openmmtools/alchemy.py
@@ -137,7 +137,7 @@ class AlchemicalState(states.GlobalParameterState):
     >>> alchemical_state.apply_to_system(alanine_alchemical_system)
     Traceback (most recent call last):
     ...
-    AlchemicalStateError: The system parameter lambda_sterics is not defined in this state.
+    openmmtools.alchemy.AlchemicalStateError: The system parameter lambda_electrostatics is not defined in this state.
 
     Create an AlchemicalState that matches the parameters defined in
     the System.

--- a/openmmtools/states.py
+++ b/openmmtools/states.py
@@ -1754,7 +1754,7 @@ class SamplerState(object):
         Position vectors for N particles (length units).
     velocities : Nx3 simtk.unit.Quantity, optional
         Velocity vectors for N particles (velocity units).
-    box_vectors : 3x3 simtk.unit.Quantity 
+    box_vectors : 3x3 simtk.unit.Quantity
         Current box vectors (length units).
 
     Attributes
@@ -1805,7 +1805,7 @@ class SamplerState(object):
     >>> sampler_state.update_from_context(incompatible_context)
     Traceback (most recent call last):
     ...
-    SamplerStateError: Specified positions with inconsistent number of particles.
+    openmmtools.states.SamplerStateError: Specified positions with inconsistent number of particles.
 
     Create a new SamplerState instead
 
@@ -1839,7 +1839,7 @@ class SamplerState(object):
             if isinstance(input, unit.Quantity) and not isinstance(input._value, np.ndarray):
                 args.append(np.array(input/input.unit)*input.unit)
             else:
-               args.append(copy.deepcopy(input))    
+               args.append(copy.deepcopy(input))
         self._initialize(*args)
 
     @classmethod
@@ -3065,7 +3065,7 @@ class GlobalParameterState(object):
     >>> my_composable_state.apply_to_system(system)
     Traceback (most recent call last):
     ...
-    GlobalParameterError: Could not find global parameter gamma_mysuffix in the system.
+    openmmtools.states.GlobalParameterError: Could not find global parameter gamma_mysuffix in the system.
 
     """
 

--- a/openmmtools/states.py
+++ b/openmmtools/states.py
@@ -269,7 +269,7 @@ class ThermodynamicsError(Exception):
     >>> raise ThermodynamicsError(ThermodynamicsError.MULTIPLE_BAROSTATS)
     Traceback (most recent call last):
     ...
-    ThermodynamicsError: System has multiple barostats.
+    openmmtools.states.ThermodynamicsError: System has multiple barostats.
 
     """
 
@@ -329,7 +329,7 @@ class SamplerStateError(Exception):
     >>> raise SamplerStateError(SamplerStateError.INCONSISTENT_VELOCITIES)
     Traceback (most recent call last):
     ...
-    SamplerStateError: Velocities have different length than positions.
+    openmmtools.states.SamplerStateError: Velocities have different length than positions.
 
     """
 
@@ -430,7 +430,7 @@ class ThermodynamicState(object):
     ...                            pressure=1.0*unit.atmosphere)
     Traceback (most recent call last):
     ...
-    ThermodynamicsError: Non-periodic systems cannot have a barostat.
+    openmmtools.states.ThermodynamicsError: Non-periodic systems cannot have a barostat.
 
     When temperature and/or pressure are not specified (i.e. they are
     None) ThermodynamicState tries to infer them from a thermostat or
@@ -439,7 +439,7 @@ class ThermodynamicState(object):
     >>> state = ThermodynamicState(system=waterbox)
     Traceback (most recent call last):
     ...
-    ThermodynamicsError: System does not have a thermostat specifying the temperature.
+    openmmtools.states.ThermodynamicsError: System does not have a thermostat specifying the temperature.
     >>> thermostat = openmm.AndersenThermostat(200.0*unit.kelvin, 1.0/unit.picosecond)
     >>> force_id = waterbox.addForce(thermostat)
     >>> state = ThermodynamicState(system=waterbox)
@@ -538,7 +538,7 @@ class ThermodynamicState(object):
         >>> state.system = alanine.system
         Traceback (most recent call last):
         ...
-        ThermodynamicsError: System does not have a thermostat specifying the temperature.
+        openmmtools.states.ThermodynamicsError: System does not have a thermostat specifying the temperature.
 
         We can fix both thermostat and barostat while setting the system.
         >>> state.set_system(alanine.system, fix_state=True)
@@ -812,7 +812,7 @@ class ThermodynamicState(object):
         >>> state.reduced_potential(incompatible_sampler_state)
         Traceback (most recent call last):
         ...
-        ThermodynamicsError: The sampler state has a different number of particles.
+        openmmtools.states.ThermodynamicsError: The sampler state has a different number of particles.
 
         In case a cached SamplerState containing the potential energy
         and the volume of the context is not available, the method


### PR DESCRIPTION
This PR updates `.travis.yml` to:
* Add a python 3.7 test branch that tests against `omnia-dev` development OpenMM nightly builds
* Cleans up some cruft that was supposed to have been culled out when OpenMM 7.3 was released and Python 2.7 was dropped