### PR TITLE
updating depreciated getargspec to getfullargspec that returns 7 values

### DIFF
--- a/openmmtools/multistate/multistatesampler.py
+++ b/openmmtools/multistate/multistatesampler.py
@@ -1129,7 +1129,7 @@ class MultiStateSampler(object):
         """
         options_to_report = dict()
         for c in inspect.getmro(cls):
-            parameter_names, _, _, defaults = inspect.getargspec(c.__init__)
+            parameter_names, _, _, defaults, _, _, _ = inspect.getfullargspec(c.__init__)
             if defaults:
                 class_options = {parameter_name: defaults[index] for (index, parameter_name) in
                                  enumerate(parameter_names[-len(defaults):])}
@@ -1144,7 +1144,7 @@ class MultiStateSampler(object):
         """
         options_to_report = dict()
         for cls in inspect.getmro(type(self)):
-            parameter_names, _, _, defaults = inspect.getargspec(cls.__init__)
+            parameter_names, _, _, defaults, _, _, _ = inspect.getfullargspec(cls.__init__)
             if defaults:
                 class_options = {parameter_name: getattr(self, '_' + parameter_name) for
                                  parameter_name in parameter_names[-len(defaults):]}

--- a/openmmtools/testsystems.py
+++ b/openmmtools/testsystems.py
@@ -126,7 +126,7 @@ def handle_kwargs(func, defaults, input_kwargs):
 
     """
     # Get arguments that appear in function signature.
-    args, _, _, kwarg_defaults = inspect.getargspec(unwrap_py2(func))
+    args, _, _, kwarg_defaults, _, _, _ = inspect.getfullargspec(unwrap_py2(func))
     # Add defaults
     kwargs = { k : v for (k,v) in defaults.items() }
     # Override those that appear in args


### PR DESCRIPTION
This updates the depreciated `getargspec` function to `getfullargspec`. This returns 7 values, whereas `getargspec` returned only 4

ArgSpec(args, varargs, keywords, defaults)
FullArgSpec(args, varargs, varkw, defaults, kwonlyargs, kwonlydefaults, annotations)

 - [ ] Implement feature / fix bug
 - [ ] Add [tests](https://github.com/choderalab/openmmtools/tree/master/openmmtools/tests)
 - [ ] Update [documentation](https://github.com/choderalab/openmmtools/tree/master/docs) as needed
 - [ ] Update [changelog](https://github.com/choderalab/openmmtools/blob/master/docs/releasehistory.rst)