### PR TITLE
logsumexp is now in scipy.special

### DIFF
--- a/devtools/travis-ci/install.sh
+++ b/devtools/travis-ci/install.sh
@@ -17,7 +17,7 @@ bash $MINICONDA -b -p $MINICONDA_HOME
 export PIP_ARGS="-U"
 export PATH=$MINICONDA_HOME/bin:$PATH
 conda config --add channels conda-forge
-conda install --yes conda\>=4.3 conda-build jinja2 anaconda-client pip
+conda install --yes conda\>=4.3 conda-build conda-verify jinja2 anaconda-client pip
 
 # Restore original directory
 popd

--- a/docs/releasehistory.rst
+++ b/docs/releasehistory.rst
@@ -1,14 +1,15 @@
 Release History
 ***************
 
-0.19.0
-======
+0.18.2 - Bugfix release
+=======================
 
 New features
 ------------
 
 Bugfixes
 --------
+- ``logsumexp`` is now imported from ``scipy.misc``
 
 
 0.18.1 - Bugfix release

--- a/docs/releasehistory.rst
+++ b/docs/releasehistory.rst
@@ -9,7 +9,7 @@ New features
 
 Bugfixes
 --------
-- ``logsumexp`` is now imported from ``scipy.misc``
+- ``logsumexp`` is now imported from ``scipy.misc`` (`#423 <https://github.com/choderalab/openmmtools/pull/423>`_)
 
 
 0.18.1 - Bugfix release

--- a/openmmtools/multistate/multistateanalyzer.py
+++ b/openmmtools/multistate/multistateanalyzer.py
@@ -31,7 +31,7 @@ import mdtraj
 import numpy as np
 from simtk import openmm
 import simtk.unit as units
-from scipy.misc import logsumexp
+from scipy.special import logsumexp
 from pymbar import MBAR, timeseries
 
 from openmmtools import multistate, utils, forces


### PR DESCRIPTION
`logsumexp` has been moved form `scipy.misc` to `scipy.special`.

 - [x] Implement feature / fix bug
 - [x] Update [changelog](https://github.com/choderalab/openmmtools/blob/master/docs/releasehistory.rst)

cc: https://github.com/choderalab/yank/pull/1162