### PR TITLE
FIx module path

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,7 @@ language: python
 # Run jobs on container-based infrastructure, can be overridden per job
 
 matrix:
-  # TODO: Move macOS tests back to "include:" if they stop segfaulting after switching from nose to pytest (see also #402 and #430).
-  allow_failures:
+  include:
     # Extra includes for OSX since python language is not available by default on OSX
     - os: osx
       language: generic
@@ -13,13 +12,16 @@ matrix:
       language: generic
       env: PYTHON_VER=3.7
 
-  include:
     - os: linux
       language: generic  # No need to set Python version since its conda
       env: PYTHON_VER=3.6
     - os: linux
       language: generic
       env: PYTHON_VER=3.7
+
+  # TODO: Reactivate macOS tests if they stop segfaulting after switching from nose to pytest (see also #402 and #430).
+  allow_failures:
+    os: osx
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ language: python
 # Run jobs on container-based infrastructure, can be overridden per job
 
 matrix:
-  include:
+  # TODO: Move macOS tests back to "include:" if they stop segfaulting after switching from nose to pytest (see also #402 and #430).
+  allow_failures:
     # Extra includes for OSX since python language is not available by default on OSX
     - os: osx
       language: generic
@@ -12,7 +13,7 @@ matrix:
       language: generic
       env: PYTHON_VER=3.7
 
-
+  include:
     - os: linux
       language: generic  # No need to set Python version since its conda
       env: PYTHON_VER=3.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ matrix:
 
   # TODO: Reactivate macOS tests if they stop segfaulting after switching from nose to pytest (see also #402 and #430).
   allow_failures:
-    os: osx
+    - os: osx
 
 env:
   global:

--- a/docs/releasehistory.rst
+++ b/docs/releasehistory.rst
@@ -1,6 +1,13 @@
 Release History
 ***************
 
+Current development
+===================
+
+Bugfixes
+--------
+- Fixed a bug in ``multistateanalyzer.py`` where a function was imported from ``openmmtools.utils`` instead of ``openmmtools.multistate.utils`` (`#430 <https://github.com/choderalab/openmmtools/pull/430>`_).
+
 0.18.2 - Bugfix release
 =======================
 

--- a/openmmtools/multistate/multistateanalyzer.py
+++ b/openmmtools/multistate/multistateanalyzer.py
@@ -1067,7 +1067,7 @@ class PhaseAnalyzer(ABC):
         # Reset self._sign
         self._sign = '+'
         if self.name is None:
-            names.append(utils.generate_phase_name(self.name, []))
+            names.append(multistate.utils.generate_phase_name(self.name, []))
         else:
             names.append(self.name)
         if isinstance(other, MultiPhaseAnalyzer):
@@ -1077,7 +1077,7 @@ class PhaseAnalyzer(ABC):
             final_new_names = []
             for name in new_names:
                 other_names = [n for n in new_names if n != name]
-                final_new_names.append(utils.generate_phase_name(name, other_names + names))
+                final_new_names.append(multistate.utils.generate_phase_name(name, other_names + names))
             names.extend(final_new_names)
             for new_sign in new_signs:
                 if operator != '+' and new_sign == '+':
@@ -1086,7 +1086,7 @@ class PhaseAnalyzer(ABC):
                     signs.append('+')
             phases.extend(new_phases)
         elif isinstance(other, PhaseAnalyzer):
-            names.append(utils.generate_phase_name(other.name, names))
+            names.append(multistate.utils.generate_phase_name(other.name, names))
             if operator != '+' and other._sign == '+':
                 signs.append('-')
             else:


### PR DESCRIPTION
A simple bugfix for a function that was incorrectly imported from `openmmtools.utils` instead of `openmmtools.multistate.utils`.
