### PR TITLE
Set chunksize for iteration dimension to 1 and doc fixes

### DIFF
--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -25,7 +25,6 @@ dependencies:
   - sphinxcontrib-bibtex
   - mpiplus
   - pymbar
-  - pyyaml
 
     # Testing
   - nose

--- a/docs/gettingstarted.rst
+++ b/docs/gettingstarted.rst
@@ -761,7 +761,7 @@ part of a system.
 
 .. doctest::
 
-    >>> # Prepare the T4 Lysozyme + p-xylene system for alchemical modification.
+    >>> # Prepare the host-guest system for alchemical modification.
     >>> guest_atoms = host_guest.mdtraj_topology.select('resname B2')
     >>> alchemical_region = alchemy.AlchemicalRegion(alchemical_atoms=guest_atoms)
     >>> factory = alchemy.AbsoluteAlchemicalFactory()
@@ -786,8 +786,8 @@ Finally, let's mix Monte Carlo and dynamics for propagation.
 .. doctest::
 
     >>> sequence_move = mcmc.SequenceMove(move_list=[
-    ...     mcmc.MCDisplacementMove(atom_subset=pxylene_atoms),
-    ...     mcmc.MCRotationMove(atom_subset=pxylene_atoms),
+    ...     mcmc.MCDisplacementMove(atom_subset=guest_atoms),
+    ...     mcmc.MCRotationMove(atom_subset=guest_atoms),
     ...     mcmc.LangevinSplittingDynamicsMove(timestep=2.0*unit.femtoseconds, n_steps=n_steps,
     ...                                        reassign_velocities=True, n_restart_attempts=6)
     ... ])

--- a/docs/releasehistory.rst
+++ b/docs/releasehistory.rst
@@ -1,8 +1,8 @@
 Release History
 ***************
 
-0.18.3 - Disk writing enhancements and bugfixes
-===============================================
+0.18.3 - Storage enhancements and bugfixes
+==========================================
 
 Bugfixes
 --------
@@ -11,7 +11,9 @@ Bugfixes
 
 Enhancements
 ------------
-- Disk writing speed is much faster for multi-state samplers when the `checkpoint_interval` is large. This was due to the dimension of the netcdf chunk size increasing with the checkpoint interval and surpassing the dimension of the netcdf chunk cache. The chunk size of the iteration dimension is now always set to 1 (`#432 <https://github.com/choderalab/openmmtools/pull/432>`_).
+- Writing on disk is much faster when the `checkpoint_interval` of multi-state samplers is large. This was due
+  to the dimension of the netcdf chunk size increasing with the checkpoint interval and surpassing the dimension
+  of the netcdf chunk cache. The chunk size of the iteration dimension is now always set to 1 (`#432 <https://github.com/choderalab/openmmtools/pull/432>`_).
 
 0.18.2 - Bugfix release
 =======================

--- a/docs/releasehistory.rst
+++ b/docs/releasehistory.rst
@@ -1,6 +1,17 @@
 Release History
 ***************
 
+0.18.3 - Disk writing enhancements and bugfixes
+===============================================
+
+Bugfixes
+--------
+- Fixed a few imprecisions in the documentation (`#432 <https://github.com/choderalab/openmmtools/pull/432>`_).
+
+Enhancements
+------------
+- Disk writing speed is much faster for multi-state samplers when the `checkpoint_interval` is large. This was due to the dimension of the netcdf chunk size increasing with the checkpoint interval and surpassing the dimension of the netcdf chunk cache. The chunk size of the iteration dimension is now always set to 1 (`#432 <https://github.com/choderalab/openmmtools/pull/432>`_).
+
 0.18.2 - Bugfix release
 =======================
 

--- a/docs/states.rst
+++ b/docs/states.rst
@@ -25,3 +25,15 @@ States
     IComposableState
     GlobalParameterFunction
     GlobalParameterState
+
+|
+
+Utility functions
+-----------------
+
+.. currentmodule:: openmmtools.states
+.. autosummary::
+    :nosignatures:
+    :toctree: api/generated/
+
+    create_thermodynamic_state_protocol

--- a/openmmtools/integrators.py
+++ b/openmmtools/integrators.py
@@ -2125,22 +2125,29 @@ class GHMCIntegrator(LangevinIntegrator):
         kwargs['splitting'] = "O { V R V } O"
         super(GHMCIntegrator, self).__init__(*args, **kwargs)
 
+
 class FIREMinimizationIntegrator(mm.CustomIntegrator):
     """Fast Internal Relaxation Engine (FIRE) minimization.
+
     Notes
     -----
     This integrator is taken verbatim from Peter Eastman's example appearing in the CustomIntegrator header file documentation.
+
     References
     ----------
     Erik Bitzek, Pekka Koskinen, Franz Gaehler, Michael Moseler, and Peter Gumbsch.
     Structural Relaxation Made Simple. PRL 97:170201, 2006.
     http://dx.doi.org/10.1103/PhysRevLett.97.170201
+
     Examples
     --------
     >>> from openmmtools import testsystems
     >>> from simtk import openmm
     >>> t = testsystems.AlanineDipeptideVacuum()
     >>> system, positions = t.system, t.positions
+
+    Create a FIRE integrator with default parameters and minimize for 100 steps
+
     >>> integrator = FIREMinimizationIntegrator()
     >>> context = openmm.Context(system, integrator)
     >>> context.setPositions(positions)

--- a/openmmtools/mcmc.py
+++ b/openmmtools/mcmc.py
@@ -570,7 +570,7 @@ class BaseIntegratorMove(MCMCMove):
     reassign_velocities : bool, optional
         If True, the velocities will be reassigned from the Maxwell-Boltzmann
         distribution at the beginning of the move (default is False).
-    restart_attempts : int, optional
+    n_restart_attempts : int, optional
         When greater than 0, if after the integration there are NaNs in energies,
         the move will restart. When the integrator has a random component, this
         may help recovering. On the last attempt, the ``Context`` is
@@ -583,7 +583,7 @@ class BaseIntegratorMove(MCMCMove):
     n_steps : int
     context_cache : openmmtools.cache.ContextCache
     reassign_velocities : bool
-    restart_attempts : int or None
+    n_restart_attempts : int or None
 
     Examples
     --------

--- a/openmmtools/multistate/multistatereporter.py
+++ b/openmmtools/multistate/multistatereporter.py
@@ -733,12 +733,13 @@ class MultiStateReporter(object):
             self._ensure_dimension_exists('replica', n_replicas)
 
             # Create variables and attach units and description.
-            ncvar_states = self._storage_analysis.createVariable('states', 'i4', ('iteration', 'replica'),
-                                                                 zlib=False,
-                                                                 chunksizes=(self._checkpoint_interval, n_replicas))
-            setattr(ncvar_states, 'units', 'none')
-            setattr(ncvar_states, "long_name", ("states[iteration][replica] is the thermodynamic state index "
-                                                "(0..n_states-1) of replica 'replica' of iteration 'iteration'."))
+            ncvar_states = self._storage_analysis.createVariable(
+                'states', 'i4', ('iteration', 'replica'),
+                zlib=False, chunksizes=(1, n_replicas)
+            )
+            ncvar_states.units = 'none'
+            ncvar_states.long_name = ("states[iteration][replica] is the thermodynamic state index "
+                                      "(0..n_states-1) of replica 'replica' of iteration 'iteration'.")
 
         # Store thermodynamic states indices.
         self._storage_analysis.variables['states'][iteration, :] = state_indices[:]
@@ -837,29 +838,23 @@ class MultiStateReporter(object):
         self._ensure_dimension_exists('replica', n_replicas)
         self._ensure_dimension_exists('state', n_states)
         if 'energies' not in self._storage_analysis.variables:
-            ncvar_energies = self._storage_analysis.createVariable('energies',
-                                                                   'f8',
-                                                                   ('iteration', 'replica', 'state'),
-                                                                   zlib=False,
-                                                                   chunksizes=(self._checkpoint_interval,
-                                                                               n_replicas,
-                                                                               n_states))
+            ncvar_energies = self._storage_analysis.createVariable(
+                'energies', 'f8', ('iteration', 'replica', 'state'),
+                zlib=False, chunksizes=(1, n_replicas, n_states)
+            )
             ncvar_energies.units = 'kT'
             ncvar_energies.long_name = ("energies[iteration][replica][state] is the reduced (unitless) "
                                         "energy of replica 'replica' from iteration 'iteration' evaluated "
                                         "at the thermodynamic state 'state'.")
 
         if 'neighborhoods' not in self._storage_analysis.variables:
-            ncvar_neighborhoods = self._storage_analysis.createVariable('neighborhoods',
-                                                                   'i1',
-                                                                   ('iteration', 'replica', 'state'),
-                                                                   zlib=False,
-                                                                   fill_value=1, # old-style files will be upgraded to have all states
-                                                                   chunksizes=(self._checkpoint_interval,
-                                                                               n_replicas,
-                                                                               n_states))
-            ncvar_neighborhoods.long_name = ("neighborhoods[iteration][replica][state] is 1 if this energy was computed "
-                                             "during this iteration.")
+            ncvar_neighborhoods = self._storage_analysis.createVariable(
+                'neighborhoods', 'i1', ('iteration', 'replica', 'state'),
+                zlib=False, fill_value=1, # old-style files will be upgraded to have all states
+                chunksizes=(1, n_replicas, n_states)
+            )
+            ncvar_neighborhoods.long_name = ("neighborhoods[iteration][replica][state] is 1 if "
+                                             "this energy was computed during this iteration.")
 
         if 'unsampled_energies' not in self._storage_analysis.variables:
             # Check if we have unsampled states.
@@ -870,14 +865,10 @@ class MultiStateReporter(object):
                 if 'unsampled_energies' not in self._storage_analysis.variables:
 
                     # Create variable for thermodynamic state energies with units and descriptions.
-                    ncvar_unsampled = self._storage_analysis.createVariable('unsampled_energies',
-                                                                            'f8',
-                                                                            ('iteration', 'replica', 'unsampled'),
-                                                                            zlib=False,
-                                                                            chunksizes=(self._checkpoint_interval,
-                                                                                        n_replicas,
-                                                                                        n_unsampled_states)
-                                                                            )
+                    ncvar_unsampled = self._storage_analysis.createVariable(
+                        'unsampled_energies', 'f8', ('iteration', 'replica', 'unsampled'),
+                        zlib=False, chunksizes=(1, n_replicas, n_unsampled_states)
+                    )
                     ncvar_unsampled.units = 'kT'
                     ncvar_unsampled.long_name = ("unsampled_energies[iteration][replica][state] is the reduced "
                                                  "(unitless) energy of replica 'replica' from iteration 'iteration' "
@@ -940,28 +931,20 @@ class MultiStateReporter(object):
             self._ensure_dimension_exists('state', n_states)
 
             # Create variables with units and descriptions.
-            ncvar_accepted = self._storage_analysis.createVariable('accepted',
-                                                                   'i4',
-                                                                   ('iteration', 'state', 'state'),
-                                                                   zlib=False,
-                                                                   chunksizes=(self._checkpoint_interval,
-                                                                               n_states,
-                                                                               n_states)
-                                                                   )
-            ncvar_proposed = self._storage_analysis.createVariable('proposed',
-                                                                   'i4',
-                                                                   ('iteration', 'state', 'state'),
-                                                                   zlib=False,
-                                                                   chunksizes=(self._checkpoint_interval,
-                                                                               n_states,
-                                                                               n_states)
-                                                                   )
-            setattr(ncvar_accepted, 'units', 'none')
-            setattr(ncvar_proposed, 'units', 'none')
-            setattr(ncvar_accepted, 'long_name', ("accepted[iteration][i][j] is the number of proposed transitions "
-                                                  "between states i and j from iteration 'iteration-1'."))
-            setattr(ncvar_proposed, 'long_name', ("proposed[iteration][i][j] is the number of proposed transitions "
-                                                  "between states i and j from iteration 'iteration-1'."))
+            ncvar_accepted = self._storage_analysis.createVariable(
+                'accepted', 'i4', ('iteration', 'state', 'state'),
+                zlib=False, chunksizes=(1, n_states, n_states)
+            )
+            ncvar_proposed = self._storage_analysis.createVariable(
+                'proposed', 'i4', ('iteration', 'state', 'state'),
+                zlib=False, chunksizes=(1, n_states, n_states)
+            )
+            ncvar_accepted.units = 'none'
+            ncvar_proposed.units = 'none'
+            ncvar_accepted.long_name = ("accepted[iteration][i][j] is the number of proposed transitions "
+                                        "between states i and j from iteration 'iteration-1'.")
+            ncvar_proposed.long_name = ("proposed[iteration][i][j] is the number of proposed transitions "
+                                        "between states i and j from iteration 'iteration-1'.")
 
         # Store statistics.
         self._storage_analysis.variables['accepted'][iteration, :, :] = n_accepted_matrix[:, :]
@@ -1000,9 +983,8 @@ class MultiStateReporter(object):
         # Create variable if needed.
         for storage_key, storage in self._storage_dict.items():
             if 'timestamp' not in storage.variables:
-                timestamp = storage.createVariable('timestamp', str, ('iteration',),
-                                       zlib=False,
-                                       chunksizes=(self._storage_chunks[storage_key],))
+                storage.createVariable('timestamp', str, ('iteration',),
+                                       zlib=False, chunksizes=(1,))
 
         timestamp = time.ctime()
         self._storage_analysis.variables['timestamp'][iteration] = timestamp
@@ -1331,10 +1313,10 @@ class MultiStateReporter(object):
         if variable not in storage.variables:
             variable_parameters = self._determine_netcdf_variable_parameters(iteration, data, storage)
             logger.debug('Creating new NetCDF variable %s with parameters: %s' % (variable, variable_parameters)) # DEBUG
-            nc_var = storage.createVariable(variable, variable_parameters['dtype'],
-                                        dimensions=variable_parameters['dims'],
-                                        chunksizes=variable_parameters['chunksizes'],
-                                        zlib=False)
+            storage.createVariable(variable, variable_parameters['dtype'],
+                                   dimensions=variable_parameters['dims'],
+                                   chunksizes=variable_parameters['chunksizes'],
+                                   zlib=False)
 
         # Get the variable
         nc_var = storage[variable]
@@ -1401,7 +1383,7 @@ class MultiStateReporter(object):
 
         if iteration is not None:
             dims = ("iteration", data_dim)
-            chunks = (self._checkpoint_interval, size)
+            chunks = (1, size)
         else:
             dims = (data_dim,)
             chunks = (size,)
@@ -1536,7 +1518,7 @@ class MultiStateReporter(object):
         return storage.groups[group_name]
 
     @staticmethod
-    def _initialize_sampler_variables_on_file(dataset, n_atoms, n_replicas, is_periodic, iteration_chunk=1):
+    def _initialize_sampler_variables_on_file(dataset, n_atoms, n_replicas, is_periodic):
         """
         Initialize the NetCDF variables on the storage file needed to store sampler states.
         Does nothing if file already initialized
@@ -1551,8 +1533,6 @@ class MultiStateReporter(object):
             Number of Sampler states which will be written
         is_periodic : bool
             True if system is periodic; False otherwise.
-        iteration_chunk : int, Optional, Default: 1
-            What chunksize to use for the iteration dimension
         """
         if 'positions' not in dataset.variables:
 
@@ -1561,31 +1541,30 @@ class MultiStateReporter(object):
             if 'replica' not in dataset.dimensions:
                 dataset.createDimension('replica', n_replicas)
 
-            # Define position variables
+            # Define position variables.
             ncvar_positions = dataset.createVariable('positions', 'f4',
                                                      ('iteration', 'replica', 'atom', 'spatial'),
-                                                     zlib=True, chunksizes=(iteration_chunk, n_replicas, n_atoms, 3))
-            setattr(ncvar_positions, 'units', 'nm')
-            setattr(ncvar_positions, "long_name", ("positions[iteration][replica][atom][spatial] is position of "
-                                                   "coordinate 'spatial' of atom 'atom' from replica 'replica' for "
-                                                   "iteration 'iteration'."))
+                                                     zlib=True, chunksizes=(1, n_replicas, n_atoms, 3))
+            ncvar_positions.units = 'nm'
+            ncvar_positions.long_name = ("positions[iteration][replica][atom][spatial] is position of "
+                                         "coordinate 'spatial' of atom 'atom' from replica 'replica' for "
+                                         "iteration 'iteration'.")
 
             # Define variables for periodic systems
             if is_periodic:
                 ncvar_box_vectors = dataset.createVariable('box_vectors', 'f4',
                                                            ('iteration', 'replica', 'spatial', 'spatial'),
-                                                           zlib=False, chunksizes=(iteration_chunk, n_replicas, 3, 3))
+                                                           zlib=False, chunksizes=(1, n_replicas, 3, 3))
                 ncvar_volumes = dataset.createVariable('volumes', 'f8', ('iteration', 'replica'),
-                                                       zlib=False, chunksizes=(iteration_chunk, n_replicas))
+                                                       zlib=False, chunksizes=(1, n_replicas))
 
-                setattr(ncvar_box_vectors, 'units', 'nm')
-                setattr(ncvar_volumes, 'units', 'nm**3')
-
-                setattr(ncvar_box_vectors, "long_name", ("box_vectors[iteration][replica][i][j] is dimension j of box "
-                                                         "vector i for replica 'replica' from iteration "
-                                                         "'iteration-1'."))
-                setattr(ncvar_volumes, "long_name", ("volume[iteration][replica] is the box volume for replica "
-                                                     "'replica' from iteration 'iteration-1'."))
+                ncvar_box_vectors.units = 'nm'
+                ncvar_volumes.units = 'nm**3'
+                ncvar_box_vectors.long_name = ("box_vectors[iteration][replica][i][j] is dimension j of box "
+                                               "vector i for replica 'replica' from iteration "
+                                               "'iteration-1'.")
+                ncvar_volumes.long_name = ("volume[iteration][replica] is the box volume for replica "
+                                           "'replica' from iteration 'iteration-1'.")
 
     def _write_sampler_states_to_given_file(self, sampler_states: list, iteration: int,
                                             storage_file='checkpoint', obey_checkpoint_interval=True):
@@ -1612,8 +1591,7 @@ class MultiStateReporter(object):
         n_particles = sampler_states[0].n_particles
         n_replicas = len(sampler_states)
         self._initialize_sampler_variables_on_file(storage, n_particles,
-                                                   n_replicas, is_periodic,
-                                                   iteration_chunk=self._storage_chunks[storage_file])
+                                                   n_replicas, is_periodic)
         if obey_checkpoint_interval:
             write_iteration = self._calculate_checkpoint_iteration(iteration)
         else:
@@ -1768,11 +1746,6 @@ class MultiStateReporter(object):
             packed_data = np.empty(1, 'O')
             packed_data[0] = data_str
         nc_variable[:] = packed_data
-
-    @ property
-    def _storage_chunks(self):
-        """Known NetCDF storage chunk sizes"""
-        return {'checkpoint': 1, 'analysis': self._checkpoint_interval}
 
 
 # ==============================================================================


### PR DESCRIPTION
## Description
- Fix #409: Rename `restart_attempts` to `n_restart_attempts` in `BaseIntegratorMove` docstring.
- Fix #418: Rename references to T4Lysozyme+p-xylene to host-guest in the tutorial.
- Fix #408: Add `create_thermodynamic_state_protocol()` to RTD docs.
- Fix #422: Set chunksize for iteration dimension to 1.

## Status
- [X] Ready to go
