### PR TITLE
Write sliced trajectories to XTC files

### DIFF
--- a/examples/trajectory-io-benchmarks/run.sh
+++ b/examples/trajectory-io-benchmarks/run.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+git checkout master > /dev/null
+python trajectory_io_benchmarks.py benchmark_master
+
+echo ""
+echo "****"
+echo ""
+git checkout multistate-xtc-traj > /dev/null
+python trajectory_io_benchmarks.py benchmark_multistate-xtc-traj

--- a/examples/trajectory-io-benchmarks/trajectory_io_benchmarks.py
+++ b/examples/trajectory-io-benchmarks/trajectory_io_benchmarks.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python
+
+"""
+Benchmark the performance of several trajectory output strategies.
+
+This script will test the performance of the strategy proposed in PR #434
+against the default monolythic NetCDF file.
+"""
+
+from argparse import ArgumentParser
+import time
+
+import numpy as np
+from openmmtools.tests.test_sampling import TestReporter
+from openmmtools import testsystems, states
+from simtk import unit
+
+import warnings
+warnings.simplefilter("ignore", UserWarning)
+
+
+def run_simulation(
+    test_system=testsystems.AlanineDipeptideVacuum,
+    n_states=10,
+    n_iterations=10,
+    analysis_particle_indices=list(range(1, 10)),
+    checkpoint_interval=2,
+):
+    """
+    Writes n_states SamplerStates over n_iterations to disk
+    and read them back to back.
+
+    Returns a tuple of two timings: write and read, per iteration and state
+    """
+    with TestReporter.temporary_reporter(
+        analysis_particle_indices=analysis_particle_indices,
+        checkpoint_interval=checkpoint_interval,
+    ) as reporter:
+        test = test_system()
+        positions = test.positions
+        box_vectors = unit.Quantity(
+            [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]], unit=unit.nanometer
+        )
+        sampler_states = [
+            states.SamplerState(positions=positions, box_vectors=box_vectors)
+            for _ in range(n_states)
+        ]
+        t0 = time.time()
+        for iteration in range(n_iterations):
+            reporter.write_sampler_states(sampler_states, iteration=iteration)
+        reporter.write_last_iteration(iteration)
+        t1 = time.time()
+        for iteration in range(n_iterations):
+            restored_sampler_states = reporter.read_sampler_states(iteration=iteration, analysis_particles_only=True)
+        t2 = time.time()
+
+    return (t1 - t0) / (n_states * n_iterations), (t2 - t1) / (n_states * n_iterations)
+
+def main():
+    tests = (
+        {
+            'test_system': testsystems.AlanineDipeptideVacuum,
+            'n_states': 10,
+            'n_iterations': 10,
+            'analysis_particle_indices': list(range(10)),
+            'checkpoint_interval': 20
+        },
+        {
+            'test_system': testsystems.SrcImplicit,
+            'n_states': 10,
+            'n_iterations': 10,
+            'analysis_particle_indices': list(range(2000)),
+            'checkpoint_interval': 20
+        },
+        {
+            'test_system': testsystems.DHFRExplicit,
+            'n_states': 10,
+            'n_iterations': 10,
+            'analysis_particle_indices': list(range(10000)),
+            'checkpoint_interval': 20
+        }
+    )
+    print('Timings per iteration and state, averaged over three attempts')
+    for options in tests:
+        read_timings, write_timings = [], []
+        for _ in range(3):
+            write, read = run_simulation(**options)
+            read_timings.append(read)
+            write_timings.append(write)
+        print(" ->", options['test_system'].__name__, f"({len(options['analysis_particle_indices'])}-atom subset)",
+              "\n\tW:", np.mean(write_timings), "+-", np.std(write_timings),
+              "\n\tR:", np.mean(read_timings), "+-", np.std(read_timings))
+
+
+if __name__ == '__main__':
+    main()

--- a/openmmtools/multistate/multistatereporter.py
+++ b/openmmtools/multistate/multistatereporter.py
@@ -1769,8 +1769,9 @@ class MultiStateReporter(object):
                 except IOError:
                     raise ValueError("Iteration is out of bounds at replica `{}`".format(iteration, path))
                 positions, _, _, box_vectors = xtc.read(n_frames=1)
-                box = box_vectors if box_vectors is not None else None
-                sampler_states.append(states.SamplerState(positions=positions[0], box_vectors=box))
+                box = unit.Quantity(box_vectors, unit=unit.nanometer) if box_vectors is not None else None
+                positions_quantity = unit.Quantity(positions[0], unit=unit.nanometer)
+                sampler_states.append(states.SamplerState(positions=positions_quantity, box_vectors=box))
         return sampler_states
 
     def _write_dict(self, path, data, storage_name='analysis',

--- a/openmmtools/multistate/multistatereporter.py
+++ b/openmmtools/multistate/multistatereporter.py
@@ -35,6 +35,7 @@ import glob
 import time
 import uuid
 import yaml
+import shutil
 import logging
 import warnings
 import collections
@@ -1695,7 +1696,7 @@ class MultiStateReporter(object):
 
         TODO: Can we use XTC frames to remove one dimension in the filenames?
         """
-        def _write_to_xtc(path, xyz, box):
+        def _write_to_xtc(path, positions, box_vectors):
             """
             Based on https://github.com/mdtraj/mdtraj/issues/1313#issuecomment-347988934
             """
@@ -1732,7 +1733,8 @@ class MultiStateReporter(object):
         for trajectory_file in trajectory_files:
             with XTCTrajectoryFile(trajectory_file, 'r') as xtc:
                 positions, _, _, box_vectors = xtc.read()
-                sampler_states.append(states.SamplerState(positions=positions, box_vectors=box_vectors))
+                sampler_states.append(states.SamplerState(positions=positions[0],
+                                                          box_vectors=box_vectors[0] if box_vectors is not None else None))
         return sampler_states
 
     def _write_dict(self, path, data, storage_name='analysis',

--- a/openmmtools/tests/test_sampling.py
+++ b/openmmtools/tests/test_sampling.py
@@ -467,7 +467,8 @@ class TestReporter(object):
             # Create sampler states.
             alanine_test = testsystems.AlanineDipeptideVacuum()
             positions = alanine_test.positions
-            sampler_states = [mmtools.states.SamplerState(positions=positions)
+            box_vectors = unit.Quantity([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]], unit=unit.nanometer)
+            sampler_states = [mmtools.states.SamplerState(positions=positions, box_vectors=box_vectors)
                               for _ in range(2)]
 
             # Check that after writing and reading, states are identical.


### PR DESCRIPTION
## Description

Following the conversation at #429, this PR adds support for writing and reading (sliced) sampler states to `xtc` files using `mdtraj` IO helpers.

To do that, I have modified `openmmtools.multistate.multistatereporter.MultiStateReporter.{write,read}_sampler_states` so they use two new methods:

- `._write_sampler_states_to_xtc()`. Writes to a `<prefix>_replica.<replica_index>.xtc` file per `StateSampler` in the given iteration. `mdtraj.formats.XTCFileTrajectory` does not support `append` mode, so we have to binary concatenate a temporary `xtc` file to work around that, resulting in two write operations. This might not be ideal for performance, so we might need to add real `a` support if the benchmarks don't show an improvement.
- `._read_sampler_states_from_xtc()`. Traverses the `<prefix>_replica.*.xtc` files and generates a `SamplerState` for each requested frame/iteration index.

## Todos
- [X] Implement feature / fix bug
- [x] Benchmark performance
- [X] Add [tests](https://github.com/choderalab/openmmtools/tree/master/openmmtools/tests)
    - Note: The existing tests already hit the new methods, but maybe we need to add more subtleties (box vectors, etc).
- [ ] Update [documentation](https://github.com/choderalab/openmmtools/tree/master/docs) as needed
- [ ] Update [changelog](https://github.com/choderalab/openmmtools/blob/master/docs/releasehistory.rst) with notable points that this PR has either accomplished or will accomplish.

## Status
- [ ] Ready to go
