### PR TITLE
Fix restrained atom indices

### DIFF
--- a/docs/releasehistory.rst
+++ b/docs/releasehistory.rst
@@ -1,18 +1,27 @@
 Release History
 ***************
 
+
+0.19.1 - Bugfix release
+=======================
+
+Bugfixes
+--------
+- Fixed a crash during the restraint unbiasing for systems with an unexpected order of atoms of receptor and ligands (`#462 <https://github.com/choderalab/openmmtools/pull/462>`_).
+
+
 0.19.0 - Multiple alchemical regions
 ====================================
 
 New features
 ------------
 - Added support in ``AbsoluteAlchemicalFactory`` for handling multiple independent alchemical regions (`#438 <https://github.com/choderalab/openmmtools/pull/438>`_).
-- Added support for anisotropic and membrane barostats in `ThermodynamicState` (`#437 <https://github.com/choderalab/openmmtools/pull/437>`_)
-- Added support for platform properties in ContextCache (e.g. for mixed and double precision CUDA in multistate sampler) (`#437 <https://github.com/choderalab/openmmtools/pull/437>`_)
+- Added support for anisotropic and membrane barostats in `ThermodynamicState` (`#437 <https://github.com/choderalab/openmmtools/pull/437>`_).
+- Added support for platform properties in ContextCache (e.g. for mixed and double precision CUDA in multistate sampler) (`#437 <https://github.com/choderalab/openmmtools/pull/437>`_).
 
 Bugfixes
 --------
-- The multistate samplers now issue experimental API warnings via ``logger.warn()`` rather than ```warnings.warn()`` (`#446 <https://github.com/choderalab/openmmtools/pull/446>`_)
+- The multistate samplers now issue experimental API warnings via ``logger.warn()`` rather than ``warnings.warn()`` (`#446 <https://github.com/choderalab/openmmtools/pull/446>`_).
 - Fix return value in ``states.reduced_potential_at_states`` (`#444 <https://github.com/choderalab/openmmtools/pull/444>`_).
 
 Known issues

--- a/openmmtools/multistate/multistateanalyzer.py
+++ b/openmmtools/multistate/multistateanalyzer.py
@@ -1688,11 +1688,19 @@ class MultiStateSamplerAnalyzer(PhaseAnalyzer):
         restraint_force = copy.deepcopy(restraint_force)
         is_periodic = restraint_force.usesPeriodicBoundaryConditions()
 
-        # Store the original indices of the restrained atoms.
-        original_restrained_atom_indices1 = restraint_force.restrained_atom_indices1
-        original_restrained_atom_indices2 = restraint_force.restrained_atom_indices2
-        original_restrained_atom_indices = (original_restrained_atom_indices1 +
-                                            original_restrained_atom_indices2)
+        # Store the indices of the restrained atoms in the reduced system.
+        analysis_indices = self._reporter.analysis_particle_indices
+
+        mapped_restrained_indices1 = restraint_force.restrained_atom_indices1
+        mapped_restrained_indices2 = restraint_force.restrained_atom_indices2
+
+        mapped_restrained_indices1 = [analysis_indices.index(index)
+                                      for index in mapped_restrained_indices1]
+        mapped_restrained_indices2 = [analysis_indices.index(index)
+                                      for index in mapped_restrained_indices2]
+
+        mapped_restrained_indices = (mapped_restrained_indices1 +
+                                     mapped_restrained_indices2)
 
         # Create new system with only solute and restraint forces.
         reduced_system = openmm.System()
@@ -1745,7 +1753,7 @@ class MultiStateSamplerAnalyzer(PhaseAnalyzer):
                                                                 analysis_particles_only=True)
 
             for replica_idx, sampler_state in enumerate(sampler_states):
-                sliced_sampler_state = sampler_state[original_restrained_atom_indices]
+                sliced_sampler_state = sampler_state[mapped_restrained_indices]
                 sliced_sampler_state.apply_to_context(context)
                 potential_energy = context.getState(getEnergy=True).getPotentialEnergy()
                 self._restraint_energies[iteration][replica_idx] = potential_energy / _OPENMM_ENERGY_UNIT
@@ -1762,11 +1770,11 @@ class MultiStateSamplerAnalyzer(PhaseAnalyzer):
                                                                    dtype=np.float32)
                             trajectory.image_molecules(inplace=True, anchor_molecules=anchor_molecules,
                                                        other_molecules=imaged_molecules)
-                            positions_group1 = trajectory.xyz[0][original_restrained_atom_indices1]
-                            positions_group2 = trajectory.xyz[0][original_restrained_atom_indices2]
+                            positions_group1 = trajectory.xyz[0][mapped_restrained_indices1]
+                            positions_group2 = trajectory.xyz[0][mapped_restrained_indices2]
                         else:
-                            positions_group1 = sampler_state.positions[original_restrained_atom_indices1]
-                            positions_group2 = sampler_state.positions[original_restrained_atom_indices2]
+                            positions_group1 = sampler_state.positions[mapped_restrained_indices1]
+                            positions_group2 = sampler_state.positions[mapped_restrained_indices2]
                             positions_group1 /= _MDTRAJ_DISTANCE_UNIT
                             positions_group2 /= _MDTRAJ_DISTANCE_UNIT
 


### PR DESCRIPTION
This is a port of a fix that was implemented by @SimonBoothroyd in choderalab/yank#1167 to fix choderalab/yank#1166 before the `multistate` subpackage was moved from YANK to OpenMMTools. See those issues for the details.
