### PR TITLE
Option to return fastest double-supporting platform

### DIFF
--- a/openmmtools/utils.py
+++ b/openmmtools/utils.py
@@ -513,10 +513,15 @@ def get_available_platforms():
             for i in range(openmm.Platform.getNumPlatforms())]
 
 
-def get_fastest_platform():
+def get_fastest_platform(double=False):
     """Return the fastest available platform.
 
     This relies on the hardcoded speed values in Platform.getSpeed().
+
+    Parameters
+    ----------
+    double : bool, default=False
+        if true, will return fastest platform that supports double precision
 
     Returns
     -------
@@ -525,6 +530,10 @@ def get_fastest_platform():
 
     """
     platforms = get_available_platforms()
+
+    if double is True:
+        # filering for platforms that support double
+        platforms = [p for p in platforms if p.supportsDoublePrecision()]
     fastest_platform = max(platforms, key=lambda x: x.getSpeed())
     return fastest_platform
 


### PR DESCRIPTION
## Description
double=True can be set. This is to help with issue
https://github.com/choderalab/perses/issues/657

default behaviour of function is unchanged

## Todos
- [ ] Implement feature / fix bug
- [ ] Add [tests](https://github.com/choderalab/openmmtools/tree/master/openmmtools/tests)
- [ ] Update [documentation](https://github.com/choderalab/openmmtools/tree/master/docs) as needed
- [ ] Update [changelog](https://github.com/choderalab/openmmtools/blob/master/docs/releasehistory.rst)Notable points that this PR has either accomplished or will accomplish.

## Status
- [ ] Ready to go
