### PR TITLE
Fix travis since miniconda changed location

### DIFF
--- a/devtools/travis-ci/before_install.sh
+++ b/devtools/travis-ci/before_install.sh
@@ -3,7 +3,7 @@ pushd .
 cd $HOME
 # Make sure some level of pip is installed
 python -m ensurepip
-{% if (cookiecutter.dependency_source == 'Prefer conda-forge over the default anaconda channel with pip fallback' or cookiecutter.dependency_source == 'Prefer default anaconda channel with pip fallback') %}
+
 # Install Miniconda
 if [ "$TRAVIS_OS_NAME" == "osx" ]; then
     # Make OSX md5 mimic md5sum from linux, alias does not work
@@ -30,25 +30,12 @@ echo ". $MINICONDA_HOME/etc/profile.d/conda.sh" >> ~/.bashrc  # Source the profi
 echo "conda activate" >> ~/.bashrc  # Activate conda
 source ~/.bashrc  # source file to get new commands
 #export PATH=$MINICONDA_HOME/bin:$PATH  # Old way, should not be needed anymore
-    {% if cookiecutter.dependency_source == "Prefer conda-forge over the default anaconda channel with pip fallback" %}
+
 conda config --add channels conda-forge
-    {% endif %}
+
 conda config --set always_yes yes
 conda install conda conda-build jinja2 anaconda-client
 conda update --quiet --all
-{% elif cookiecutter.dependency_source == 'Dependencies from pip only (no conda)' %}
-if [ "$TRAVIS_OS_NAME" == "osx" ]; then
-    HOMEBREW_NO_AUTO_UPDATE=1 brew upgrade pyenv
-    # Pyenv requires minor revision, get the latest
-    PYENV_VERSION=$(pyenv install --list |grep $PYTHON_VER | sed -n "s/^[ \t]*\(${PYTHON_VER}\.*[0-9]*\).*/\1/p" | tail -n 1)
-    # Install version
-    pyenv install $PYENV_VERSION
-    # Use version for this
-    pyenv global $PYENV_VERSION
-    # Setup up path shims
-    eval "$(pyenv init -)"
-fi
-pip install --upgrade pip setuptools
-{% endif %}
+
 # Restore original directory
 popd

--- a/devtools/travis-ci/before_install.sh
+++ b/devtools/travis-ci/before_install.sh
@@ -3,7 +3,7 @@ pushd .
 cd $HOME
 # Make sure some level of pip is installed
 python -m ensurepip
-
+{% if (cookiecutter.dependency_source == 'Prefer conda-forge over the default anaconda channel with pip fallback' or cookiecutter.dependency_source == 'Prefer default anaconda channel with pip fallback') %}
 # Install Miniconda
 if [ "$TRAVIS_OS_NAME" == "osx" ]; then
     # Make OSX md5 mimic md5sum from linux, alias does not work
@@ -15,8 +15,8 @@ else
     MINICONDA=Miniconda3-latest-Linux-x86_64.sh
 fi
 MINICONDA_HOME=$HOME/miniconda
-MINICONDA_MD5=$(curl -s https://repo.continuum.io/miniconda/ | grep -A3 $MINICONDA | sed -n '4p' | sed -n 's/ *<td>\(.*\)<\/td> */\1/p')
-wget -q https://repo.continuum.io/miniconda/$MINICONDA
+MINICONDA_MD5=$(wget -qO- https://repo.anaconda.com/miniconda/ | grep -A3 $MINICONDA | sed -n '4p' | sed -n 's/ *<td>\(.*\)<\/td> */\1/p')
+wget -q https://repo.anaconda.com/miniconda/$MINICONDA
 if [[ $MINICONDA_MD5 != $(md5sum $MINICONDA | cut -d ' ' -f 1) ]]; then
     echo "Miniconda MD5 mismatch"
     exit 1
@@ -30,12 +30,25 @@ echo ". $MINICONDA_HOME/etc/profile.d/conda.sh" >> ~/.bashrc  # Source the profi
 echo "conda activate" >> ~/.bashrc  # Activate conda
 source ~/.bashrc  # source file to get new commands
 #export PATH=$MINICONDA_HOME/bin:$PATH  # Old way, should not be needed anymore
-    
+    {% if cookiecutter.dependency_source == "Prefer conda-forge over the default anaconda channel with pip fallback" %}
 conda config --add channels conda-forge
-    
+    {% endif %}
 conda config --set always_yes yes
 conda install conda conda-build jinja2 anaconda-client
 conda update --quiet --all
-
+{% elif cookiecutter.dependency_source == 'Dependencies from pip only (no conda)' %}
+if [ "$TRAVIS_OS_NAME" == "osx" ]; then
+    HOMEBREW_NO_AUTO_UPDATE=1 brew upgrade pyenv
+    # Pyenv requires minor revision, get the latest
+    PYENV_VERSION=$(pyenv install --list |grep $PYTHON_VER | sed -n "s/^[ \t]*\(${PYTHON_VER}\.*[0-9]*\).*/\1/p" | tail -n 1)
+    # Install version
+    pyenv install $PYENV_VERSION
+    # Use version for this
+    pyenv global $PYENV_VERSION
+    # Setup up path shims
+    eval "$(pyenv init -)"
+fi
+pip install --upgrade pip setuptools
+{% endif %}
 # Restore original directory
 popd


### PR DESCRIPTION
This PR fixes travis failures caused by the URL for `miniconda` changing.

cc: https://github.com/MolSSI/cookiecutter-cms/pull/104

