### PR TITLE
Update README badges for GHA

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-[![Linux Build Status](https://travis-ci.org/choderalab/openmmtools.png?branch=master)](https://travis-ci.org/choderalab/openmmtools/branches)
-[![Windows Build status](https://ci.appveyor.com/api/projects/status/70knpvcgvmah2qin?svg=true)](https://ci.appveyor.com/project/jchodera/openmmtools)
+[![GH Actions Status](https://github.com/choderalab/openmmtools/workflows/CI/badge.svg)](https://github.com/choderalab/openmmtools/actions?query=branch%3Amaster)
 [![Anaconda Badge](https://anaconda.org/omnia/openmmtools/badges/version.svg)](https://anaconda.org/omnia/openmmtools)
 [![Downloads Badge](https://anaconda.org/omnia/openmmtools/badges/downloads.svg)](https://anaconda.org/omnia/openmmtools/files)
 [![ReadTheDocs Badge](https://readthedocs.org/projects/openmmtools/badge/?version=master)](https://openmmtools.readthedocs.io/en/master/)


### PR DESCRIPTION
## Description

Replace Travis / AppVeyor badges with the new ones for GH Actions.