### PR TITLE
Add Git Attributes File Required by Versioneer

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+openmmtools/_version.py export-subst


### PR DESCRIPTION
## Description
The MolSSI cookiecutter does not create a `.gitattributes` file by default, which is required to ensure that that conda releases made from git archive files (i.e. those release currently on omnia and soon to be on conda-forge) return a correct `__version__` string.

The current, invalid behaviour can be verified by running:

```
$ conda create --name openmmtools -c conda-forge -c omnia openmmtools
$ conda activate openmmtools
$ python -c "import openmmtools; print(openmmtools.__version__)"

0+unknown
```

Further details can be found here: https://github.com/MolSSI/cookiecutter-cms/issues/112

## Todos
- [X] Implement feature / fix bug
- [ ] Add [tests](https://github.com/choderalab/openmmtools/tree/master/openmmtools/tests)
- [ ] Update [documentation](https://github.com/choderalab/openmmtools/tree/master/docs) as needed
- [ ] Update [changelog](https://github.com/choderalab/openmmtools/blob/master/docs/releasehistory.rst)Notable points that this PR has either accomplished or will accomplish.

## Status
- [X] Ready to go
