### PR TITLE
remove deprectated np.float alias

### DIFF
--- a/docs/releasehistory.rst
+++ b/docs/releasehistory.rst
@@ -6,12 +6,16 @@ Release History
 
 Enhancements
 ------------
-- ``openmmtools.utils.get_available_platforms()``` and ``.get_fastest_platform()``` now filter OpenMM Platforms based on specified minimum precision support, which defaults to ``mixed``
+- ``openmmtools.utils.get_available_platforms()`` and ``.get_fastest_platform()`` now filter OpenMM Platforms based on specified minimum precision support, which defaults to ``mixed``
 
 Bugfixes
 --------
 - Replace the `cython <https://cython.org/>`_ accelerated ``all-swap`` replica mixing scheme with a `numba <https://numba.pydata.org>`_ implementation for better stability, and portability, and speed
 - Fixes incorrect temperature spacing in ``ParallelTemperingSampler`` constructor
+
+Misc
+----
+- Resolve ``numpy 1.20`` ``DeprecationWarning`` about ``np.float``
 
 0.20.0 - Periodic alchemical integrators
 ========================================

--- a/openmmtools/testsystems.py
+++ b/openmmtools/testsystems.py
@@ -493,7 +493,7 @@ class TestSystem(object):
         self._system = openmm.System()
 
         # Store positions.
-        self._positions = unit.Quantity(np.zeros([0, 3], np.float), unit.nanometers)
+        self._positions = unit.Quantity(np.zeros([0, 3], float), unit.nanometers)
 
         # Empty topology.
         self._topology = app.Topology()


### PR DESCRIPTION
## Description
With numpy `1.20` released, a downstream project (`openpathsampling`) showed deprecation warnings coming from this code. This fixes that.

## Todos
- [X] Implement feature / fix bug
- [NA] Add [tests](https://github.com/choderalab/openmmtools/tree/master/openmmtools/tests)
- [NA] Update [documentation](https://github.com/choderalab/openmmtools/tree/master/docs) as needed
- [X] Update [changelog](https://github.com/choderalab/openmmtools/blob/master/docs/releasehistory.rst)

## Status
- [X] Ready to go


## Warning
```
DeprecationWarning: `np.float` is a deprecated alias for the builtin `float`. To silence this warning, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here.
  Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
    self._positions = unit.Quantity(np.zeros([0, 3], np.float), unit.nanometers)
```