### PR TITLE
do unit conversion first for precision

### DIFF
--- a/openmmtools/integrators.py
+++ b/openmmtools/integrators.py
@@ -207,8 +207,9 @@ class ThermostatedIntegrator(utils.RestorableOpenMMObject, PrettyPrintableIntegr
             The temperature of the heat bath in kelvins.
 
         """
-        kT = self.getGlobalVariableByName('kT') * _OPENMM_ENERGY_UNIT
-        temperature = kT / kB
+        # Do most unit conversion first for precision
+        conversion = _OPENMM_ENERGY_UNIT / kB
+        temperature = self.getGlobalVariableByName('kT') * conversion
         return temperature
 
     def setTemperature(self, temperature):


### PR DESCRIPTION
fixes #500 
## Description
Looking into the error on `master`, I noticed that the temperature you got from the integrator was `269.99999999999994` instead of the expected `270`, so I combined the unit conversion factor to keep some extra precision. This solves the issue the master tests have been having

## Todos
- [X] Implement feature / fix bug
- [NA] Add [tests](https://github.com/choderalab/openmmtools/tree/master/openmmtools/tests)
- [NA] Update [documentation](https://github.com/choderalab/openmmtools/tree/master/docs) as needed
- [X] Update [changelog](https://github.com/choderalab/openmmtools/blob/master/docs/releasehistory.rst)

## Status
- [X] Ready to go
