### PR TITLE
Fix critical bug in which GPU contexts would fail to recognize mixed precision was available

### DIFF
--- a/docs/releasehistory.rst
+++ b/docs/releasehistory.rst
@@ -1,8 +1,20 @@
 Release History
 ***************
 
-0.20.2 - Remove leftover support for python 2.7
+0.20.3 - Bugfix release
+======================
 
+Bugfixes
+--------
+- Fixes [#505](https://github.com/choderalab/openmmtools/issues/505): GPU contexts would silently fail to enable 'mixed' precision; corrects reporting of available precisions
+
+0.20.2 - Bugfix release
+=======================
+
+Remove leftover support for python 2.7
+
+Cleanup
+-------
 - Remove leftover `six` imports and `xrange` (`#504 <https://github.com/choderalab/openmmtools/pull/504>`_)
 
 0.20.1 - Bugfix release

--- a/openmmtools/tests/test_utils.py
+++ b/openmmtools/tests/test_utils.py
@@ -21,6 +21,28 @@ from openmmtools.utils import *
 
 
 # =============================================================================
+# TEST CONTEXT UTILITIES
+# =============================================================================
+
+def test_platform_supports_precision():
+    """Test that platform_supports_precision works correctly."""
+    from simtk import openmm
+    
+    for platform_index in range(openmm.Platform.getNumPlatforms()):
+        platform = openmm.Platform.getPlatform(platform_index)
+        platform_name = platform.getName()
+        supported_precisions = { precision for precision in ['single', 'mixed', 'double'] if platform_supports_precision(platform, precision) }
+        if platform_name == 'Reference':
+            if supported_precisions != set(['double']):
+                raise Exception(f"'Reference' platform should only support 'double' precision, but platform_supports_precision reports {supported_precisions}")
+        if platform_name == 'CUDA':
+            if supported_precisions != set(['single', 'mixed', 'double']):
+                raise Exception(f"'CUDA' platform should support 'mixed' precision, but platform_supports_precision reports {supported_precisions}")
+        if platform_name == 'CPU':
+            if supported_precisions != set(['mixed']):
+                raise Exception(f"'CPU' platform should support 'mixed' precision, but platform_supports_precision reports {supported_precisions}")
+
+# =============================================================================
 # TEST STRING MATHEMATICAL EXPRESSION PARSING UTILITIES
 # =============================================================================
 

--- a/openmmtools/utils.py
+++ b/openmmtools/utils.py
@@ -534,18 +534,16 @@ def platform_supports_precision(platform, precision):
 
     if platform.getName() == 'Reference':
         # Reference is double precision
-        return True
+        return (precision == 'double')
 
     if platform.getName() == 'CPU':
-        if 'precision' in ['single', 'mixed']:
-            return True
-        else:
-            return False
+        return precision in ['mixed']
 
     if platform.getName() in ['CUDA', 'OpenCL']:
         from simtk import openmm
         properties = { 'Precision' : precision }
         system = openmm.System()
+        system.addParticle(1.0) # Cannot create Context on a system with no particles
         integrator = openmm.VerletIntegrator(0.001)
         try:
             context = openmm.Context(system, integrator, platform, properties)

--- a/openmmtools/utils.py
+++ b/openmmtools/utils.py
@@ -548,7 +548,7 @@ def platform_supports_precision(platform, precision):
         system = openmm.System()
         integrator = openmm.VerletIntegrator(0.001)
         try:
-            context = openmm.Context(system, integrator, properties)
+            context = openmm.Context(system, integrator, platform, properties)
             del context, integrator
             return True
         except Exception as e:


### PR DESCRIPTION
## Description
This PR fixes #505, where GPU contexts would fail to recognize mixed precision was available.
This may mean that applications were silently failing to use mixed precision on GPUs.

I fixed the logic to match the function docstring, but I'm not sure if this will break anything else. We'll have to wait for the tests to see.
I've verified the new `test_platform_supports_precision()` test passes on an NVIDIA GTX 1080.

## Todos
- [x] Implement feature / fix bug
- [x] Add [tests](https://github.com/choderalab/openmmtools/tree/master/openmmtools/tests)
- [x] Update [documentation](https://github.com/choderalab/openmmtools/tree/master/docs) as needed
- [x] Update [changelog](https://github.com/choderalab/openmmtools/blob/master/docs/releasehistory.rst)Notable points that this PR has either accomplished or will accomplish.

## Status
- [x] Ready to go
