### PR TITLE
Remove logic for missing file when retrying to open a dataset

### DIFF
--- a/openmmtools/multistate/multistatereporter.py
+++ b/openmmtools/multistate/multistatereporter.py
@@ -362,13 +362,6 @@ class MultiStateReporter(object):
         for attempt in range(n_attempts-1):
             try:
                 return netcdf.Dataset(*args, **kwargs)
-            except IOError as e:
-                # If the file does not exist, it doesn't make sense to try again.
-                if catch_io_error:
-                    if io_error_warning is not None:
-                        logger.warning(io_error_warning)
-                    return None
-                raise e
             except:
                 logger.debug('Attempt {}/{} to open {} failed. Retrying '
                              'in {} seconds'.format(attempt+1, n_attempts, sleep_time))

--- a/openmmtools/multistate/multistatereporter.py
+++ b/openmmtools/multistate/multistatereporter.py
@@ -360,11 +360,14 @@ class MultiStateReporter(object):
         """
 
         # Check if file exists and warn if asked
-        if catch_io_error:
-            if not os.path.isfile(args[0]):
+        # raise IOError otherwise
+        if not os.path.isfile(args[0]):
+            if catch_io_error:
                 if io_error_warning is not None:
                     logger.warning(io_error_warning)
                 return None
+            raise IOError
+
 
         # Catch eventual errors n_attempts - 1 times.
         for attempt in range(n_attempts-1):

--- a/openmmtools/multistate/multistatereporter.py
+++ b/openmmtools/multistate/multistatereporter.py
@@ -366,7 +366,7 @@ class MultiStateReporter(object):
                 if io_error_warning is not None:
                     logger.warning(io_error_warning)
                 return None
-            raise IOError
+            raise IOError(f"{args[0]} does not exist")
 
 
         # Catch eventual errors n_attempts - 1 times.

--- a/openmmtools/multistate/multistatereporter.py
+++ b/openmmtools/multistate/multistatereporter.py
@@ -359,16 +359,6 @@ class MultiStateReporter(object):
         If the file is not found and catch_io_error is True, None is returned.
         """
 
-        # Check if file exists and warn if asked
-        # raise IOError otherwise
-        if not os.path.isfile(args[0]):
-            if catch_io_error:
-                if io_error_warning is not None:
-                    logger.warning(io_error_warning)
-                return None
-            raise IOError(f"{args[0]} does not exist")
-
-
         # Catch eventual errors n_attempts - 1 times.
         for attempt in range(n_attempts-1):
             try:
@@ -377,6 +367,15 @@ class MultiStateReporter(object):
                 logger.debug('Attempt {}/{} to open {} failed. Retrying '
                              'in {} seconds'.format(attempt+1, n_attempts, args[0], sleep_time))
                 time.sleep(sleep_time)
+
+        # Check if file exists and warn if asked
+        # raise IOError otherwise
+        if not os.path.isfile(args[0]):
+            if catch_io_error:
+                if io_error_warning is not None:
+                    logger.warning(io_error_warning)
+                return None
+            raise IOError(f"{args[0]} does not exist")
 
         # At the very last attempt, we try setting the environment variable
         # controlling the locking mechanism of HDF5 (see choderalab/yank#1165).

--- a/openmmtools/multistate/multistatereporter.py
+++ b/openmmtools/multistate/multistatereporter.py
@@ -358,13 +358,21 @@ class MultiStateReporter(object):
 
         If the file is not found and catch_io_error is True, None is returned.
         """
+
+        # Check if file exists and warn if asked
+        if catch_io_error:
+            if not os.path.isfile(args[0]):
+                if io_error_warning is not None:
+                    logger.warning(io_error_warning)
+                return None
+
         # Catch eventual errors n_attempts - 1 times.
         for attempt in range(n_attempts-1):
             try:
                 return netcdf.Dataset(*args, **kwargs)
             except:
                 logger.debug('Attempt {}/{} to open {} failed. Retrying '
-                             'in {} seconds'.format(attempt+1, n_attempts, sleep_time))
+                             'in {} seconds'.format(attempt+1, n_attempts, args[0], sleep_time))
                 time.sleep(sleep_time)
 
         # At the very last attempt, we try setting the environment variable


### PR DESCRIPTION
## Description
Provide a brief description of the PR's purpose here.

What should we do about these now defunct arguments to `_open_dataset_robustly`
`catch_io_error=False` and `io_error_warning=None`? Since the method is private, we should be able to just remove them from the function signature and update the code where we use it, thoughts?

## Todos
- [ ] Implement feature / fix bug
- [ ] Add [tests](https://github.com/choderalab/openmmtools/tree/master/openmmtools/tests)
- [ ] Update [documentation](https://github.com/choderalab/openmmtools/tree/master/docs) as needed
- [ ] Update [changelog](https://github.com/choderalab/openmmtools/blob/master/docs/releasehistory.rst)Notable points that this PR has either accomplished or will accomplish.

## Status
- [ ] Ready to go
