### PR TITLE
Overriding deepcopying behavior to avoid creating new ContextCaches.

### DIFF
--- a/openmmtools/mcmc.py
+++ b/openmmtools/mcmc.py
@@ -1279,6 +1279,21 @@ class LangevinSplittingDynamicsMove(LangevinDynamicsMove):
                                               measure_shadow_work=self.measure_shadow_work,
                                               measure_heat=self.measure_heat)
 
+    def __deepcopy__(self, memo):
+        """Overriding default deep copy behavior to avoid creating new ContextCache objects without need."""
+
+        if memo is None:
+            memo = {}
+
+        cls = self.__class__
+        new_state = cls.__new__(cls)
+        memo[id(self)] = new_state
+        for k, v in self.__dict__.items():
+            if k != 'context_cache':
+                new_state.__dict__[k] = copy.deepcopy(v, memo)
+        new_state.__dict__['context_cache'] = self.context_cache
+        return new_state
+
 
 # =============================================================================
 # GENERALIZED HYBRID MONTE CARLO MOVE

--- a/openmmtools/mcmc.py
+++ b/openmmtools/mcmc.py
@@ -762,6 +762,21 @@ class BaseIntegratorMove(MCMCMove):
         else:
             self.context_cache = utils.deserialize(serialization['context_cache'])
 
+    def __deepcopy__(self, memo):
+        """Overriding default deep copy behavior to avoid creating new ContextCache objects without need."""
+
+        if memo is None:
+            memo = {}
+
+        cls = self.__class__
+        new_state = cls.__new__(cls)
+        memo[id(self)] = new_state
+        for k, v in self.__dict__.items():
+            if k != 'context_cache':
+                new_state.__dict__[k] = copy.deepcopy(v, memo)
+        new_state.__dict__['context_cache'] = self.context_cache
+        return new_state
+
 
 # =============================================================================
 # METROPOLIZED MOVE BASE CLASS
@@ -1278,21 +1293,6 @@ class LangevinSplittingDynamicsMove(LangevinDynamicsMove):
                                               constraint_tolerance=self.constraint_tolerance,
                                               measure_shadow_work=self.measure_shadow_work,
                                               measure_heat=self.measure_heat)
-
-    def __deepcopy__(self, memo):
-        """Overriding default deep copy behavior to avoid creating new ContextCache objects without need."""
-
-        if memo is None:
-            memo = {}
-
-        cls = self.__class__
-        new_state = cls.__new__(cls)
-        memo[id(self)] = new_state
-        for k, v in self.__dict__.items():
-            if k != 'context_cache':
-                new_state.__dict__[k] = copy.deepcopy(v, memo)
-        new_state.__dict__['context_cache'] = self.context_cache
-        return new_state
 
 
 # =============================================================================


### PR DESCRIPTION
## Description
When you specify a context_cache to be used in the mcmc_move for the simulation it gets deep copied into every replica. This avoid creating new ContextCache for each replica, instead it uses a reference to the same given and hopefully compatible ContextCache.

Fixes #521 

## Todos
- [x] Implement feature / fix bug
- [x] Add [tests](https://github.com/choderalab/openmmtools/tree/master/openmmtools/tests)
- [ ] Update [documentation](https://github.com/choderalab/openmmtools/tree/master/docs) as needed
- [ ] Update [changelog](https://github.com/choderalab/openmmtools/blob/master/docs/releasehistory.rst)Notable points that this PR has either accomplished or will accomplish.
- [ ] Check how this affects serialization of objects.

## Status
- [x] Ready to go
