### PR TITLE
deal with openmm 7.6 package unwrapping

### DIFF
--- a/docs/releasehistory.rst
+++ b/docs/releasehistory.rst
@@ -7,6 +7,7 @@ Release History
 Enhancement
 -----------
 - Use of CODATA 2018 constants information from OpenMM 7.6.0. (#522)
+- Use new way of importing OpenMM >= 7.6. (#528)
 
 0.20.3 - Bugfix release
 ======================

--- a/examples/integrator-benchmarks/integrator-benchmarks.py
+++ b/examples/integrator-benchmarks/integrator-benchmarks.py
@@ -5,9 +5,14 @@ Benchmark various integrators provided in openmmtools on some test systems.
 
 """
 
-from simtk import openmm
-from simtk import unit
-from simtk.openmm import app
+try:
+    import openmm
+    from openmm import unit
+    from openmm import app
+except ImportError: # OpenMM < 7.6
+    from simtk import openmm
+    from simtk import unit
+    from simtk.openmm import app
 from openmmtools import testsystems
 from openmmtools import integrators
 import numpy as np

--- a/openmmtools/alchemy.py
+++ b/openmmtools/alchemy.py
@@ -41,7 +41,11 @@ import itertools
 import re
 
 import numpy as np
-from simtk import openmm, unit
+try:
+    import openmm
+    from openmm import unit
+except ImportError:  # OpenMM < 7.6
+    from simtk import openmm, unit
 
 from openmmtools import states, forcefactories, utils
 from openmmtools.constants import ONE_4PI_EPS0
@@ -155,7 +159,8 @@ class AlchemicalState(states.GlobalParameterState):
     used with CompoundThermodynamicState. All the alchemical parameters are
     accessible through the compound state.
 
-    >>> from simtk import openmm, unit
+    >>> import openmm
+    >>> from openmm import unit
     >>> thermodynamic_state = states.ThermodynamicState(system=alanine_alchemical_system,
     ...                                                 temperature=300*unit.kelvin)
     >>> compound_state = states.CompoundThermodynamicState(thermodynamic_state=thermodynamic_state,
@@ -225,7 +230,7 @@ class AlchemicalState(states.GlobalParameterState):
 
         Parameters
         ----------
-        system : simtk.openmm.System
+        system : openmm.System
             An alchemically modified system in a defined alchemical state.
         parameters_name_suffix : str, optional
             If specified, the state will search for a modified
@@ -355,7 +360,7 @@ class AlchemicalState(states.GlobalParameterState):
 
         Parameters
         ----------
-        system : simtk.openmm.System
+        system : openmm.System
             The system to modify.
 
         Raises
@@ -375,7 +380,7 @@ class AlchemicalState(states.GlobalParameterState):
 
         Parameters
         ----------
-        system : simtk.openmm.System
+        system : openmm.System
             The system to test.
 
         Raises
@@ -392,7 +397,7 @@ class AlchemicalState(states.GlobalParameterState):
 
         Parameters
         ----------
-        context : simtk.openmm.Context
+        context : openmm.Context
             The context to set.
 
         Raises
@@ -590,7 +595,8 @@ class AbsoluteAlchemicalFactory(object):
 
     You can also modify its Hamiltonian directly into a context
 
-    >>> from simtk import openmm, unit
+    >>> import openmm
+    >>> from openmm import unit
     >>> integrator = openmm.VerletIntegrator(1.0*unit.femtosecond)
     >>> context = openmm.Context(alchemical_system, integrator)
     >>> alchemical_state.set_alchemical_parameters(0.0)  # Set all lambda to 0
@@ -636,7 +642,7 @@ class AbsoluteAlchemicalFactory(object):
 
         Parameters
         ----------
-        reference_system : simtk.openmm.System
+        reference_system : openmm.System
             The system to use as a reference for the creation of the
             alchemical system. This will not be modified.
         alchemical_regions : AlchemicalRegion
@@ -648,7 +654,7 @@ class AbsoluteAlchemicalFactory(object):
 
         Returns
         -------
-        alchemical_system : simtk.openmm.System
+        alchemical_system : openmm.System
             Alchemically-modified version of reference_system.
 
         """
@@ -755,19 +761,19 @@ class AbsoluteAlchemicalFactory(object):
 
         Parameters
         ----------
-        alchemical_system : simtk.openmm.AlchemicalSystem
+        alchemical_system : openmm.AlchemicalSystem
             An alchemically modified system.
         alchemical_state : AlchemicalState
             The alchemical state to set the Context to.
-        positions : simtk.unit.Quantity of dimension (natoms, 3)
+        positions : openmm.unit.Quantity of dimension (natoms, 3)
             Coordinates to use for energy test (units of distance).
-        platform : simtk.openmm.Platform, optional
+        platform : openmm.Platform, optional
             The OpenMM platform to use to compute the energy. If None,
             OpenMM tries to select the fastest available.
 
         Returns
         -------
-        energy_components : dict str: simtk.unit.Quantity
+        energy_components : dict str: openmm.unit.Quantity
             A string label describing the role of the force associated to
             its contribution to the potential energy.
 
@@ -815,7 +821,7 @@ class AbsoluteAlchemicalFactory(object):
 
         Parameters
         ----------
-        system : simtk.openmm.System
+        system : openmm.System
             The system.
         alchemical_region : AlchemicalRegion
             The alchemical region of the system.
@@ -903,7 +909,7 @@ class AbsoluteAlchemicalFactory(object):
 
         Parameters
         ----------
-        system : simtk.openmm.System
+        system : openmm.System
             The system for which bonds are to be tabulated.
 
         Returns
@@ -947,7 +953,7 @@ class AbsoluteAlchemicalFactory(object):
             The set of alchemically modified atoms.
         reference_forces : dict str: force
             A dictionary of cached forces in the system accessible by names.
-        system : simtk.openmm.System
+        system : openmm.System
             The system.
 
         Returns
@@ -992,7 +998,7 @@ class AbsoluteAlchemicalFactory(object):
             The set of alchemically modified atoms.
         reference_forces : dict str: force
             A dictionary of cached forces in the system accessible by names.
-        system : simtk.openmm.System
+        system : openmm.System
             The system (unused).
 
         Returns
@@ -1021,7 +1027,7 @@ class AbsoluteAlchemicalFactory(object):
             The set of alchemically modified atoms.
         reference_forces : dict str: force
             A dictionary of cached forces in the system accessible by names.
-        system : simtk.openmm.System
+        system : openmm.System
             The system (unused).
 
         Returns
@@ -1111,7 +1117,7 @@ class AbsoluteAlchemicalFactory(object):
 
         Parameters
         ----------
-        reference_force : simtk.openmm.PeriodicTorsionForce
+        reference_force : openmm.PeriodicTorsionForce
             The reference PeriodicTorsionForce to be alchemically modify.
         alchemical_region : AlchemicalRegion
             The alchemical region containing the indices of the torsions to
@@ -1123,9 +1129,9 @@ class AbsoluteAlchemicalFactory(object):
 
         Returns
         -------
-        force : simtk.openmm.PeriodicTorsionForce
+        force : openmm.PeriodicTorsionForce
             The force responsible for the non-alchemical torsions.
-        custom_force : simtk.openmm.CustomTorsionForce
+        custom_force : openmm.CustomTorsionForce
             The force responsible for the alchemically-softened torsions.
             This will not be present if there are not alchemical torsions
             in alchemical_region.
@@ -1195,7 +1201,7 @@ class AbsoluteAlchemicalFactory(object):
 
         Parameters
         ----------
-        reference_force : simtk.openmm.HarmonicAngleForce
+        reference_force : openmm.HarmonicAngleForce
             The reference HarmonicAngleForce to be alchemically modify.
         alchemical_region : AlchemicalRegion
             The alchemical region containing the indices of the angles to
@@ -1207,9 +1213,9 @@ class AbsoluteAlchemicalFactory(object):
 
         Returns
         -------
-        force : simtk.openmm.HarmonicAngleForce
+        force : openmm.HarmonicAngleForce
             The force responsible for the non-alchemical angles.
-        custom_force : simtk.openmm.CustomAngleForce
+        custom_force : openmm.CustomAngleForce
             The force responsible for the alchemically-softened angles.
             This will not be present if there are not alchemical angles
             in alchemical_region.
@@ -1274,7 +1280,7 @@ class AbsoluteAlchemicalFactory(object):
 
         Parameters
         ----------
-        reference_force : simtk.openmm.HarmonicBondForce
+        reference_force : openmm.HarmonicBondForce
             The reference HarmonicBondForce to be alchemically modify.
         alchemical_region : AlchemicalRegion
             The alchemical region containing the indices of the bonds to
@@ -1286,9 +1292,9 @@ class AbsoluteAlchemicalFactory(object):
 
         Returns
         -------
-        force : simtk.openmm.HarmonicBondForce
+        force : openmm.HarmonicBondForce
             The force responsible for the non-alchemical bonds.
-        custom_force : simtk.openmm.CustomBondForce
+        custom_force : openmm.CustomBondForce
             The force responsible for the alchemically-softened bonds.
             This will not be present if there are not alchemical bonds
             in alchemical_region.
@@ -1535,7 +1541,7 @@ class AbsoluteAlchemicalFactory(object):
 
         Parameters
         ----------
-        reference_force : simtk.openmm.NonbondedForce
+        reference_force : openmm.NonbondedForce
             The reference NonbondedForce to be alchemically modify.
         alchemical_region : AlchemicalRegion
             The alchemical region containing the indices of the atoms to
@@ -1547,26 +1553,26 @@ class AbsoluteAlchemicalFactory(object):
 
         Returns
         -------
-        nonbonded_force : simtk.openmm.NonbondedForce
+        nonbonded_force : openmm.NonbondedForce
             The force responsible for interactions and exceptions of non-alchemical atoms.
-        aa_sterics_custom_nonbonded_force : simtk.openmm.CustomNonbondedForce
+        aa_sterics_custom_nonbonded_force : openmm.CustomNonbondedForce
             The force responsible for sterics interactions of alchemical/alchemical atoms.
-        aa_electrostatics_custom_nonbonded_force : simtk.openmm.CustomNonbondedForce
+        aa_electrostatics_custom_nonbonded_force : openmm.CustomNonbondedForce
             The force responsible for electrostatics interactions of alchemical/alchemical
             atoms.
-        na_sterics_custom_nonbonded_force : simtk.openmm.CustomNonbondedForce
+        na_sterics_custom_nonbonded_force : openmm.CustomNonbondedForce
             The force responsible for sterics interactions of non-alchemical/alchemical atoms.
-        na_electrostatics_custom_nonbonded_force : simtk.openmm.CustomNonbondedForce
+        na_electrostatics_custom_nonbonded_force : openmm.CustomNonbondedForce
             The force responsible for electrostatics interactions of non-alchemical/alchemical
             atoms.
-        aa_sterics_custom_bond_force : simtk.openmm.CustomBondForce
+        aa_sterics_custom_bond_force : openmm.CustomBondForce
             The force responsible for sterics exceptions of alchemical/alchemical atoms.
-        aa_electrostatics_custom_bond_force : simtk.openmm.CustomBondForce
+        aa_electrostatics_custom_bond_force : openmm.CustomBondForce
             The force responsible for electrostatics exceptions of alchemical/alchemical
             atoms.
-        na_sterics_custom_bond_force : simtk.openmm.CustomBondForce
+        na_sterics_custom_bond_force : openmm.CustomBondForce
             The force responsible for sterics exceptions of non-alchemical/alchemical atoms.
-        na_electrostatics_custom_bond_force : simtk.openmm.CustomBondForce
+        na_electrostatics_custom_bond_force : openmm.CustomBondForce
             The force responsible for electrostatics exceptions of non-alchemical/alchemical
             atoms.
 
@@ -2135,12 +2141,12 @@ class AbsoluteAlchemicalFactory(object):
         return [softcore_force]
 
     @staticmethod
-    def _alchemically_modify_GBSAOBCForce(reference_force, alchemical_region, _, sasa_model='ACE'): 
+    def _alchemically_modify_GBSAOBCForce(reference_force, alchemical_region, _, sasa_model='ACE'):
         """Create alchemically-modified version of GBSAOBCForce.
 
         Parameters
         ----------
-        reference_force : simtk.openmm.GBSAOBCForce
+        reference_force : openmm.GBSAOBCForce
             The reference GBSAOBCForce to be alchemically modify.
         alchemical_region : AlchemicalRegion
             The alchemical region containing the indices of the atoms to
@@ -2150,7 +2156,7 @@ class AbsoluteAlchemicalFactory(object):
 
         Returns
         -------
-        custom_force : simtk.openmm.CustomGBForce
+        custom_force : openmm.CustomGBForce
             The alchemical version of the reference force.
 
         TODO
@@ -2241,7 +2247,7 @@ class AbsoluteAlchemicalFactory(object):
 
         Parameters
         ----------
-        reference_force : simtk.openmm.GBSAOBCForce
+        reference_force : openmm.GBSAOBCForce
             The reference GBSAOBCForce to be alchemically modify.
         alchemical_region : AlchemicalRegion
             The alchemical region containing the indices of the atoms to
@@ -2249,7 +2255,7 @@ class AbsoluteAlchemicalFactory(object):
 
         Returns
         -------
-        custom_force : simtk.openmm.CustomGBForce
+        custom_force : openmm.CustomGBForce
             The alchemical version of the reference force.
 
         """
@@ -2499,7 +2505,7 @@ class AbsoluteAlchemicalFactory(object):
                 # Sort forces by number of bonds.
                 bond_forces = sorted(bond_forces, key=lambda x: x[1].getNumBonds())
                 (force_index1, force1), (force_index2, force2) = bond_forces
-                
+
                 # Check if both define their parameters (with decoupling the lambda
                 # parameter doesn't exist in the alchemical-alchemical force)
                 parameter_name = 'lambda_' + force_type

--- a/openmmtools/cache.py
+++ b/openmmtools/cache.py
@@ -18,7 +18,11 @@ import re
 import copy
 import collections
 
-from simtk import openmm, unit
+try:
+    import openmm
+    from openmm import unit
+except ImportError:  # OpenMM < 7.6
+    from simtk import openmm, unit
 
 from openmmtools import integrators
 
@@ -226,7 +230,7 @@ class ContextCache(object):
 
     Parameters
     ----------
-    platform : simtk.openmm.Platform, optional
+    platform : openmm.Platform, optional
         The OpenMM platform to use to create Contexts. If None, OpenMM
         tries to select the fastest one available (default is None).
     platform_properties : dict, optional
@@ -252,7 +256,7 @@ class ContextCache(object):
 
     Examples
     --------
-    >>> from simtk import unit
+    >>> from openmm import unit
     >>> from openmmtools import testsystems
     >>> from openmmtools.states import ThermodynamicState
     >>> alanine = testsystems.AlanineDipeptideExplicit()
@@ -394,14 +398,14 @@ class ContextCache(object):
         ----------
         thermodynamic_state : states.ThermodynamicState
             The thermodynamic state of the system.
-        integrator : simtk.openmm.Integrator, optional
+        integrator : openmm.Integrator, optional
             The integrator for the context (default is None).
 
         Returns
         -------
-        context : simtk.openmm.Context
+        context : openmm.Context
             The context in the given thermodynamic system.
-        context_integrator : simtk.openmm.Integrator
+        context_integrator : openmm.Integrator
             The integrator to be used to propagate the Context. Can be
             a difference instance from the one passed as an argument.
 
@@ -690,13 +694,13 @@ class DummyContextCache(object):
 
     Parameters
     ----------
-    platform : simtk.openmm.Platform, optional
+    platform : openmm.Platform, optional
         The OpenMM platform to use. If None, OpenMM tries to select
         the fastest one available (default is None).
 
     Attributes
     ----------
-    platform : simtk.openmm.Platform
+    platform : openmm.Platform
         The OpenMM platform to use. If None, OpenMM tries to select
         the fastest one available.
 
@@ -704,7 +708,8 @@ class DummyContextCache(object):
     --------
     Create a new ``Context`` object for alanine dipeptide in vacuum in NPT.
 
-    >>> from simtk import openmm, unit
+    >>> import openmm
+    >>> from openmm import unit
     >>> from openmmtools import states, testsystems
     >>> system = testsystems.AlanineDipeptideVacuum().system
     >>> thermo_state = states.ThermodynamicState(system, temperature=300*unit.kelvin)
@@ -729,7 +734,7 @@ class DummyContextCache(object):
         ----------
         thermodynamic_state : states.ThermodynamicState
             The thermodynamic state of the system.
-        integrator : simtk.openmm.Integrator, optional
+        integrator : openmm.Integrator, optional
             The integrator to bind to the new context. If ``None``, an arbitrary
             integrator is used. Currently, this is a ``LangevinIntegrator`` with
             "V R O R V" splitting, but this might change in the future. Default
@@ -737,9 +742,9 @@ class DummyContextCache(object):
 
         Returns
         -------
-        context : simtk.openmm.Context
+        context : openmm.Context
             The new context in the given thermodynamic system.
-        context_integrator : simtk.openmm.Integrator
+        context_integrator : openmm.Integrator
             The integrator bound to the context that can be used for
             propagation. This is identical to the ``integrator`` argument
             if it was passed.

--- a/openmmtools/constants.py
+++ b/openmmtools/constants.py
@@ -1,11 +1,14 @@
 from math import pi
-import simtk.unit as u
+try:
+    import openmm.unit as u
+except ImportError:  # OpenMM < 7.6
+    import simtk.unit as u
 
 kB = u.BOLTZMANN_CONSTANT_kB * u.AVOGADRO_CONSTANT_NA
 
 # OpenMM constant for Coulomb interactions in OpenMM units
 # (openmm/platforms/reference/include/SimTKOpenMMRealType.h)
-# TODO: Replace this with an import from simtk.openmm.constants once available
+# TODO: Replace this with an import from openmm.constants once available
 E_CHARGE = 1.602176634e-19 * u.coulomb
 EPSILON0 = 1e-6*8.8541878128e-12/(u.AVOGADRO_CONSTANT_NA*E_CHARGE**2) * u.farad/u.meter
 ONE_4PI_EPS0 = 1/(4*pi*EPSILON0) * EPSILON0.unit  # we need it unitless

--- a/openmmtools/data/alanine-dipeptide-explicit/generate-pdb.py
+++ b/openmmtools/data/alanine-dipeptide-explicit/generate-pdb.py
@@ -3,8 +3,12 @@ Generate PDB file containing periodic box data.
 
 """
 
-from simtk import openmm, unit
-from simtk.openmm import app
+try:
+    import openmm
+    from openmm import unit, app
+except ImportError:  # OpenMM < 7.6
+    from simtk import openmm, unit
+    from simtk.openmm import app
 
 prmtop_filename = 'alanine-dipeptide.prmtop'
 crd_filename = 'alanine-dipeptide.crd'

--- a/openmmtools/data/dna_dodecamer_explicit/minimize.py
+++ b/openmmtools/data/dna_dodecamer_explicit/minimize.py
@@ -2,8 +2,12 @@
 Script to minimize and coarsely thermalize the Drew-Dickinson B-DNA dodecamer.
 """
 
-from simtk import openmm, unit
-from simtk.openmm import app
+try:
+    import openmm
+    from openmm import app, unit
+except ImportError:  # OpenMM < 7.6
+    from simtk import openmm, unit
+    from simtk.openmm import app
 
 # Thermodynamic and simulation control parameters
 temperature = 300.0 * unit.kelvin

--- a/openmmtools/data/src-explicit/prepare_pdb.py
+++ b/openmmtools/data/src-explicit/prepare_pdb.py
@@ -8,10 +8,13 @@ Retrieve a PDB file from the RCSB, solvate it, and minimize.
 ################################################################################
 # IMPORTS
 ################################################################################
-
-from simtk import unit
-from simtk import openmm
-from simtk.openmm import app
+try:
+    import openmm
+    from openmm import unit, app
+except ImportError:  # OpenMM < 7.6
+    from simtk import unit
+    from simtk import openmm
+    from simtk.openmm import app
 from pdbfixer import PDBFixer
 
 ################################################################################

--- a/openmmtools/data/src-implicit/prepare_pdb.py
+++ b/openmmtools/data/src-implicit/prepare_pdb.py
@@ -9,9 +9,14 @@ Retrieve a PDB file from the RCSB, solvate it, and minimize.
 # IMPORTS
 ################################################################################
 
-from simtk import unit
-from simtk import openmm
-from simtk.openmm import app
+try:
+    import openmm
+    from openmm import unit
+    from openmm import app
+except ImportError:  # OpenMM < 7.6
+    from simtk import unit
+    from simtk import openmm
+    from simtk.openmm import app
 from pdbfixer import PDBFixer
 
 ################################################################################

--- a/openmmtools/forcefactories.py
+++ b/openmmtools/forcefactories.py
@@ -18,7 +18,11 @@ import copy
 
 import numpy as np
 import mdtraj
-from simtk import openmm, unit
+try:
+    import openmm
+    from openmm import unit
+except ImportError:  # OpenMM < 7.6
+    from simtk import openmm, unit
 
 from openmmtools import forces
 
@@ -40,10 +44,10 @@ def replace_reaction_field(reference_system, switch_width=1.0*unit.angstrom,
 
     Parameters
     ----------
-    reference_system : simtk.openmm.System
+    reference_system : openmm.System
         The system to use as a reference. This will be modified only if
         `return_copy` is `False`.
-    switch_width : simtk.unit.Quantity, default=1.0*angstrom
+    switch_width : openmm.unit.Quantity, default=1.0*angstrom
         Switch width for electrostatics (units of distance).
     return_copy : bool, optional, default=True
         If `True`, `reference_system` is not modified, and a copy is returned.
@@ -54,7 +58,7 @@ def replace_reaction_field(reference_system, switch_width=1.0*unit.angstrom,
 
     Returns
     -------
-    system : simtk.openmm.System
+    system : openmm.System
         System with reaction-field converted to c_rf = 0
 
     """
@@ -109,11 +113,11 @@ def restrain_atoms(thermodynamic_state, sampler_state, restrained_atoms, sigma=3
         The thermodynamic state with the system. This will be modified.
     sampler_state : openmmtools.states.SamplerState
         The sampler state with the positions.
-    topology : mdtraj.Topology or simtk.openmm.Topology
+    topology : mdtraj.Topology or openmm.Topology
         The topology of the system.
     atoms_dsl : str
         The MDTraj DSL string for selecting the atoms to restrain.
-    sigma : simtk.unit.Quantity, optional
+    sigma : openmm.unit.Quantity, optional
         Controls the strength of the restrain. The smaller, the tighter
         (units of distance, default is 3.0*angstrom).
 

--- a/openmmtools/forces.py
+++ b/openmmtools/forces.py
@@ -24,7 +24,11 @@ import re
 
 import scipy
 import numpy as np
-from simtk import openmm, unit
+try:
+    import openmm
+    from openmm import unit
+except ImportError:  # OpenMM < 7.6
+    from simtk import openmm, unit
 
 from openmmtools import utils
 from openmmtools.constants import ONE_4PI_EPS0, STANDARD_STATE_VOLUME
@@ -61,7 +65,7 @@ def find_forces(system, force_type, only_one=False, include_subclasses=False):
 
     Parameters
     ----------
-    system : simtk.openmm.System
+    system : openmm.System
         The system to search.
     force_type : str, or type
         The class of the force to search, or a regular expression that
@@ -172,17 +176,17 @@ def _compute_harmonic_volume(radius, spring_constant, beta):
 
     Parameters
     ----------
-    radius : simtk.unit.Quantity
+    radius : openmm.unit.Quantity
         The upper limit on the distance (units of length).
-    spring_constant : simtk.unit.Quantity
+    spring_constant : openmm.unit.Quantity
         The spring constant of the harmonic potential (units of
         energy/mole/length^2).
-    beta : simtk.unit.Quantity
+    beta : openmm.unit.Quantity
         Thermodynamic beta (units of mole/energy).
 
     Returns
     -------
-    volume : simtk.unit.Quantity
+    volume : openmm.unit.Quantity
         The volume of the harmonic potential (units of length^3).
 
     """
@@ -206,15 +210,15 @@ def _compute_harmonic_radius(spring_constant, potential_energy):
 
     Parameters
     ----------
-    spring_constant : simtk.unit.Quantity
+    spring_constant : openmm.unit.Quantity
         The spring constant of the harmonic potential (units of
         energy/mole/length^2).
-    potential_energy : simtk.unit.Quantity
+    potential_energy : openmm.unit.Quantity
         The energy of the harmonic restraint (units of energy/mole).
 
     Returns
     -------
-    radius : simtk.unit.Quantity
+    radius : openmm.unit.Quantity
         The radius at which the harmonic potential is energy.
 
     """
@@ -344,12 +348,12 @@ class RadiallySymmetricRestraintForce(utils.RestorableOpenMMObject):
 
         Parameters
         ----------
-        potential_energy : simtk.unit.Quantity
+        potential_energy : openmm.unit.Quantity
             The potential energy of the restraint (units of energy/mole).
 
         Returns
         -------
-        distance : simtk.unit.Quantity
+        distance : openmm.unit.Quantity
             The distance at which the potential energy is ``potential_energy``
             (units of length).
 
@@ -385,7 +389,7 @@ class RadiallySymmetricRestraintForce(utils.RestorableOpenMMObject):
             If True, this computes the standard state correction assuming
             the restraint to obey a square well potential. The energy
             cutoff is still applied to the original energy potential.
-        radius_cutoff : simtk.unit.Quantity, optional
+        radius_cutoff : openmm.unit.Quantity, optional
             The maximum distance achievable by the restraint (units
             compatible with nanometers). This is equivalent to placing
             a hard wall potential at this distance.
@@ -393,7 +397,7 @@ class RadiallySymmetricRestraintForce(utils.RestorableOpenMMObject):
             The maximum potential energy achievable by the restraint in kT.
             This is equivalent to placing a hard wall potential at a
             distance such that ``potential_energy(distance) == energy_cutoff``.
-        max_volume : simtk.unit.Quantity or 'system', optional
+        max_volume : openmm.unit.Quantity or 'system', optional
             The volume of the periodic box (units compatible with nanometer**3).
             This must be provided the thermodynamic state is in NPT. If the
             string 'system' is passed, the maximum volume is computed from
@@ -470,7 +474,7 @@ class RadiallySymmetricRestraintForce(utils.RestorableOpenMMObject):
             If True, this computes the standard state correction assuming
             the restraint to obey a square well potential. The energy
             cutoff is still applied to the original energy potential.
-        radius_cutoff : simtk.unit.Quantity, optional
+        radius_cutoff : openmm.unit.Quantity, optional
             The maximum distance achievable by the restraint (units
             compatible with nanometers). This is equivalent to placing
             a hard wall potential at this distance.
@@ -481,7 +485,7 @@ class RadiallySymmetricRestraintForce(utils.RestorableOpenMMObject):
 
         Returns
         -------
-        restraint_volume : simtk.unit.Quantity
+        restraint_volume : openmm.unit.Quantity
             The volume of the restraint (units of length^3).
 
         """
@@ -502,7 +506,7 @@ class RadiallySymmetricRestraintForce(utils.RestorableOpenMMObject):
             If True, this computes the standard state correction assuming
             the restraint to obey a square well potential. The energy
             cutoff is still applied to the original energy potential.
-        radius_cutoff : simtk.unit.Quantity, optional
+        radius_cutoff : openmm.unit.Quantity, optional
             The maximum distance achievable by the restraint (units
             compatible with nanometers). This is equivalent to placing
             a hard wall potential at this distance.
@@ -513,7 +517,7 @@ class RadiallySymmetricRestraintForce(utils.RestorableOpenMMObject):
 
         Returns
         -------
-        restraint_volume : simtk.unit.Quantity
+        restraint_volume : openmm.unit.Quantity
             The volume of the restraint (units of length^3).
 
         """
@@ -607,7 +611,7 @@ class RadiallySymmetricRestraintForce(utils.RestorableOpenMMObject):
             If True, this computes the standard state correction assuming
             the restraint to obey a square well potential. The energy
             cutoff is still applied to the original energy potential.
-        radius_cutoff : simtk.unit.Quantity, optional
+        radius_cutoff : openmm.unit.Quantity, optional
             The maximum distance achievable by the restraint (units
             compatible with nanometers). This is equivalent to placing
             a hard wall potential at this distance.
@@ -618,11 +622,11 @@ class RadiallySymmetricRestraintForce(utils.RestorableOpenMMObject):
 
         Returns
         -------
-        r_min : simtk.unit.Quantity
+        r_min : openmm.unit.Quantity
             The lower limit for numerical integration.
-        r_max : simtk.unit.Quantity
+        r_max : openmm.unit.Quantity
             The upper limit for numerical integration.
-        analytical_volume : simtk.unit.Quantity
+        analytical_volume : openmm.unit.Quantity
             Volume excluded from the numerical integration that has been
             computed analytically. This will be summed to the volume
             computed through numerical integration.
@@ -810,7 +814,7 @@ class HarmonicRestraintForceMixIn(object):
 
     @property
     def spring_constant(self):
-        """unit.simtk.Quantity: The spring constant K (units of energy/mole/distance^2)."""
+        """unit.openmm.Quantity: The spring constant K (units of energy/mole/distance^2)."""
         # This works for both CustomBondForce and CustomCentroidBondForce.
         parameters = self.getBondParameters(0)[-1]
         return parameters[0] * unit.kilojoule_per_mole/unit.nanometers**2
@@ -820,12 +824,12 @@ class HarmonicRestraintForceMixIn(object):
 
         Parameters
         ----------
-        potential_energy : simtk.unit.Quantity
+        potential_energy : openmm.unit.Quantity
             The potential energy of the restraint (units of energy/mole).
 
         Returns
         -------
-        distance : simtk.unit.Quantity
+        distance : openmm.unit.Quantity
             The distance at which the potential energy is ``potential_energy``
             (units of length).
 
@@ -871,7 +875,7 @@ class HarmonicRestraintForce(HarmonicRestraintForceMixIn,
 
     Parameters
     ----------
-    spring_constant : simtk.unit.Quantity
+    spring_constant : openmm.unit.Quantity
         The spring constant K (see energy expression above) in units
         compatible with joule/nanometer**2/mole.
     restrained_atom_indices1 : iterable of int
@@ -904,7 +908,7 @@ class HarmonicRestraintBondForce(HarmonicRestraintForceMixIn,
 
     Parameters
     ----------
-    spring_constant : simtk.unit.Quantity
+    spring_constant : openmm.unit.Quantity
         The spring constant K (see energy expression above) in units
         compatible with joule/nanometer**2/mole.
     restrained_atom_index1 : int
@@ -946,14 +950,14 @@ class FlatBottomRestraintForceMixIn(object):
 
     @property
     def spring_constant(self):
-        """unit.simtk.Quantity: The spring constant K (units of energy/mole/length^2)."""
+        """unit.openmm.Quantity: The spring constant K (units of energy/mole/length^2)."""
         # This works for both CustomBondForce and CustomCentroidBondForce.
         parameters = self.getBondParameters(0)[-1]
         return parameters[0] * unit.kilojoule_per_mole/unit.nanometers**2
 
     @property
     def well_radius(self):
-        """unit.simtk.Quantity: The distance at which the harmonic restraint is imposed (units of length)."""
+        """unit.openmm.Quantity: The distance at which the harmonic restraint is imposed (units of length)."""
         # This works for both CustomBondForce and CustomCentroidBondForce.
         parameters = self.getBondParameters(0)[-1]
         return parameters[1] * unit.nanometers
@@ -963,12 +967,12 @@ class FlatBottomRestraintForceMixIn(object):
 
         Parameters
         ----------
-        potential_energy : simtk.unit.Quantity
+        potential_energy : openmm.unit.Quantity
             The potential energy of the restraint (units of energy/mole).
 
         Returns
         -------
-        distance : simtk.unit.Quantity
+        distance : openmm.unit.Quantity
             The distance at which the potential energy is ``potential_energy``
             (units of length).
 
@@ -1034,10 +1038,10 @@ class FlatBottomRestraintForce(FlatBottomRestraintForceMixIn,
 
     Parameters
     ----------
-    spring_constant : simtk.unit.Quantity
+    spring_constant : openmm.unit.Quantity
         The spring constant K (see energy expression above) in units
         compatible with joule/nanometer**2/mole.
-    well_radius : simtk.unit.Quantity
+    well_radius : openmm.unit.Quantity
         The distance r0 (see energy expression above) at which the harmonic
         restraint is imposed in units of distance.
     restrained_atom_indices1 : iterable of int
@@ -1071,10 +1075,10 @@ class FlatBottomRestraintBondForce(FlatBottomRestraintForceMixIn,
 
     Parameters
     ----------
-    spring_constant : simtk.unit.Quantity
+    spring_constant : openmm.unit.Quantity
         The spring constant K (see energy expression above) in units
         compatible with joule/nanometer**2/mole.
-    well_radius : simtk.unit.Quantity
+    well_radius : openmm.unit.Quantity
         The distance r0 (see energy expression above) at which the harmonic
         restraint is imposed in units of distance.
     restrained_atom_index1 : int
@@ -1112,9 +1116,9 @@ class UnshiftedReactionFieldForce(openmm.CustomNonbondedForce):
 
     Parameters
     ----------
-    cutoff_distance : simtk.unit.Quantity, default 15*angstroms
+    cutoff_distance : openmm.unit.Quantity, default 15*angstroms
         The cutoff distance (units of distance).
-    switch_width : simtk.unit.Quantity, default 1.0*angstrom
+    switch_width : openmm.unit.Quantity, default 1.0*angstrom
         Switch width for electrostatics (units of distance).
     reaction_field_dielectric : float
         The dielectric constant used for the solvent.
@@ -1163,9 +1167,9 @@ class UnshiftedReactionFieldForce(openmm.CustomNonbondedForce):
 
         Parameters
         ----------
-        nonbonded_force : simtk.openmm.NonbondedForce
+        nonbonded_force : openmm.NonbondedForce
             The nonbonded force to copy.
-        switch_width : simtk.unit.Quantity
+        switch_width : openmm.unit.Quantity
             Switch width for electrostatics (units of distance).
 
         Returns
@@ -1205,9 +1209,9 @@ class UnshiftedReactionFieldForce(openmm.CustomNonbondedForce):
 
         Parameters
         ----------
-        system : simtk.openmm.System
+        system : openmm.System
             The system containing the nonbonded force to copy.
-        switch_width : simtk.unit.Quantity
+        switch_width : openmm.unit.Quantity
             Switch width for electrostatics (units of distance).
 
         Returns
@@ -1229,9 +1233,9 @@ class SwitchedReactionFieldForce(openmm.CustomNonbondedForce):
 
     Parameters
     ----------
-    cutoff_distance : simtk.unit.Quantity, default 15*angstroms
+    cutoff_distance : openmm.unit.Quantity, default 15*angstroms
         The cutoff distance (units of distance).
-    switch_width : simtk.unit.Quantity, default 1.0*angstrom
+    switch_width : openmm.unit.Quantity, default 1.0*angstrom
         Switch width for electrostatics (units of distance).
     reaction_field_dielectric : float
         The dielectric constant used for the solvent.
@@ -1282,9 +1286,9 @@ class SwitchedReactionFieldForce(openmm.CustomNonbondedForce):
 
         Parameters
         ----------
-        nonbonded_force : simtk.openmm.NonbondedForce
+        nonbonded_force : openmm.NonbondedForce
             The nonbonded force to copy.
-        switch_width : simtk.unit.Quantity
+        switch_width : openmm.unit.Quantity
             Switch width for electrostatics (units of distance).
 
         Returns
@@ -1324,9 +1328,9 @@ class SwitchedReactionFieldForce(openmm.CustomNonbondedForce):
 
         Parameters
         ----------
-        system : simtk.openmm.System
+        system : openmm.System
             The system containing the nonbonded force to copy.
-        switch_width : simtk.unit.Quantity
+        switch_width : openmm.unit.Quantity
             Switch width for electrostatics (units of distance).
 
         Returns

--- a/openmmtools/integrators.py
+++ b/openmmtools/integrators.py
@@ -37,8 +37,12 @@ import logging
 import re
 
 import numpy as np
-import simtk.unit as unit
-import simtk.openmm as mm
+try:
+    import openmm.unit as unit
+    import openmm as mm
+except ImportError:  # OpenMM < 7.6
+    import simtk.unit as unit
+    import simtk.openmm as mm
 
 from openmmtools.constants import kB
 from openmmtools import respa, utils
@@ -150,7 +154,8 @@ class ThermostatedIntegrator(utils.RestorableOpenMMObject, PrettyPrintableIntegr
     setters and getters for the temperature and to add a per-DOF constant
     "sigma" that we need to update only when the temperature is changed.
 
-    >>> from simtk import openmm, unit
+    >>> import openmm
+    >>> from openmm import unit
     >>> class TestIntegrator(ThermostatedIntegrator):
     ...     def __init__(self, temperature=298.0*unit.kelvin, timestep=1.0*unit.femtoseconds):
     ...         super(TestIntegrator, self).__init__(temperature, timestep)
@@ -257,7 +262,7 @@ class ThermostatedIntegrator(utils.RestorableOpenMMObject, PrettyPrintableIntegr
 
         Parameters
         ----------
-        integrator : simtk.openmm.Integrator
+        integrator : openmm.Integrator
             The integrator to check.
 
         Returns
@@ -281,7 +286,7 @@ class ThermostatedIntegrator(utils.RestorableOpenMMObject, PrettyPrintableIntegr
 
         Parameters
         ----------
-        integrator : simtk.openmm.CustomIntegrator
+        integrator : openmm.CustomIntegrator
             The integrator to which add methods.
 
         Returns
@@ -305,7 +310,7 @@ class ThermostatedIntegrator(utils.RestorableOpenMMObject, PrettyPrintableIntegr
 
     @property
     def kT(self):
-        """The thermal energy in simtk.openmm.Quantity"""
+        """The thermal energy in openmm.Quantity"""
         return self.getGlobalVariableByName("kT") * _OPENMM_ENERGY_UNIT
 
 
@@ -1689,7 +1694,8 @@ class AlchemicalNonequilibriumLangevinIntegrator(NonequilibriumLangevinIntegrato
 
     >>> # Create harmonic oscillator testsystem
     >>> from openmmtools import testsystems
-    >>> from simtk import openmm, unit
+    >>> import openmm
+    >>> from openmm import unit
     >>> testsystem = testsystems.HarmonicOscillator()
     >>> # Create a nonequilibrium alchemical integrator
     >>> alchemical_functions = { 'testsystems_HarmonicOscillator_x0' : 'lambda' }
@@ -1925,7 +1931,8 @@ class PeriodicNonequilibriumIntegrator(AlchemicalNonequilibriumLangevinIntegrato
 
     >>> # Create harmonic oscillator testsystem
     >>> from openmmtools import testsystems
-    >>> from simtk import openmm, unit
+    >>> import openmm
+    >>> from openmm import unit
     >>> testsystem = testsystems.HarmonicOscillator()
     >>> # Create a nonequilibrium alchemical integrator
     >>> alchemical_functions = { 'testsystems_HarmonicOscillator_x0' : 'lambda' }
@@ -2059,7 +2066,8 @@ class ExternalPerturbationLangevinIntegrator(NonequilibriumLangevinIntegrator):
 
     >>> # Create harmonic oscillator testsystem
     >>> from openmmtools import testsystems
-    >>> from simtk import openmm, unit
+    >>> import openmm
+    >>> from openmm import unit
     >>> testsystem = testsystems.HarmonicOscillator()
     >>> # Create an external perturbation integrator
     >>> integrator = ExternalPerturbationLangevinIntegrator(temperature=300*unit.kelvin, collision_rate=1.0/unit.picoseconds, timestep=1.0*unit.femtoseconds)
@@ -2296,7 +2304,7 @@ class FIREMinimizationIntegrator(mm.CustomIntegrator):
     Examples
     --------
     >>> from openmmtools import testsystems
-    >>> from simtk import openmm
+    >>> import openmm
     >>> t = testsystems.AlanineDipeptideVacuum()
     >>> system, positions = t.system, t.positions
 

--- a/openmmtools/mcmc.py
+++ b/openmmtools/mcmc.py
@@ -46,7 +46,7 @@ Jun S. Liu. Monte Carlo Strategies in Scientific Computing. Springer, 2008.
 
 Examples
 --------
->>> from simtk import unit
+>>> from openmm import unit
 >>> from openmmtools import testsystems, cache
 >>> from openmmtools.states import ThermodynamicState, SamplerState
 
@@ -115,7 +115,11 @@ import copy
 import logging
 
 import numpy as np
-from simtk import openmm, unit
+try:
+    import openmm
+    from openmm import unit
+except ImportError:  # OpenMM < 7.6
+    from simtk import openmm, unit
 
 from openmmtools import integrators, cache, utils
 from openmmtools.utils import SubhookedABCMeta, Timer
@@ -196,7 +200,7 @@ class MCMCSampler(object):
     --------
 
     >>> import numpy as np
-    >>> from simtk import unit
+    >>> from openmm import unit
     >>> from openmmtools import testsystems
     >>> from openmmtools.states import ThermodynamicState, SamplerState
 
@@ -256,7 +260,7 @@ class MCMCSampler(object):
 
         Parameters
         ----------
-        tolerance : simtk.unit.Quantity, optional
+        tolerance : openmm.unit.Quantity, optional
             Tolerance to use for minimization termination criterion (units of
             energy/(mole*distance), default is 1*kilocalories_per_mole/angstroms).
         max_iterations : int, optional
@@ -317,7 +321,7 @@ class SequenceMove(MCMCMove):
     NPT ensemble simulation of a Lennard Jones fluid with a sequence of moves.
 
     >>> import numpy as np
-    >>> from simtk import unit
+    >>> from openmm import unit
     >>> from openmmtools import testsystems
     >>> from openmmtools.states import ThermodynamicState, SamplerState
     >>> test = testsystems.LennardJonesFluid(nparticles=200)
@@ -406,7 +410,7 @@ class WeightedMove(MCMCMove):
     Create and run an alanine dipeptide simulation with a weighted move.
 
     >>> import numpy as np
-    >>> from simtk import unit
+    >>> from openmm import unit
     >>> from openmmtools import testsystems
     >>> from openmmtools.states import ThermodynamicState, SamplerState
     >>> test = testsystems.AlanineDipeptideVacuum()
@@ -494,7 +498,7 @@ class IntegratorMoveError(Exception):
         A description of the error.
     move : MCMCMove
         The MCMCMove that raised the error.
-    context : simtk.openmm.Context, optional
+    context : openmm.Context, optional
         The context after the integration.
 
     """
@@ -590,7 +594,7 @@ class BaseIntegratorMove(MCMCMove):
     Create a VerletIntegratorMove class.
 
     >>> from openmmtools import testsystems, states
-    >>> from simtk.openmm import VerletIntegrator
+    >>> from openmm import VerletIntegrator
     >>> class VerletMove(BaseIntegratorMove):
     ...     def __init__(self, timestep, n_steps, **kwargs):
     ...         super(VerletMove, self).__init__(n_steps, **kwargs)
@@ -795,7 +799,7 @@ class MetropolizedMove(MCMCMove):
 
     Examples
     --------
-    >>> from simtk import unit
+    >>> from openmm import unit
     >>> from openmmtools import testsystems, states
     >>> class AddOneVector(MetropolizedMove):
     ...     def __init__(self, **kwargs):
@@ -954,7 +958,7 @@ class IntegratorMove(BaseIntegratorMove):
 
     Parameters
     ----------
-    integrator : simtk.openmm.Integrator
+    integrator : openmm.Integrator
         An instance of an OpenMM Integrator object to use for propagation.
     n_steps : int
         The number of integration steps to take each time the move is applied.
@@ -1015,12 +1019,12 @@ class LangevinDynamicsMove(BaseIntegratorMove):
 
     Parameters
     ----------
-    timestep : simtk.unit.Quantity, optional
+    timestep : openmm.unit.Quantity, optional
         The timestep to use for Langevin integration
-        (time units, default is 1*simtk.unit.femtosecond).
-    collision_rate : simtk.unit.Quantity, optional
+        (time units, default is 1*openmm.unit.femtosecond).
+    collision_rate : openmm.unit.Quantity, optional
         The collision rate with fictitious bath particles
-        (1/time units, default is 10/simtk.unit.picoseconds).
+        (1/time units, default is 10/openmm.unit.picoseconds).
     n_steps : int, optional
         The number of integration timesteps to take each time the
         move is applied (default is 1000).
@@ -1033,9 +1037,9 @@ class LangevinDynamicsMove(BaseIntegratorMove):
 
     Attributes
     ----------
-    timestep : simtk.unit.Quantity
+    timestep : openmm.unit.Quantity
         The timestep to use for Langevin integration (time units).
-    collision_rate : simtk.unit.Quantity
+    collision_rate : openmm.unit.Quantity
         The collision rate with fictitious bath particles (1/time units).
     n_steps : int
         The number of integration timesteps to take each time the move
@@ -1053,7 +1057,7 @@ class LangevinDynamicsMove(BaseIntegratorMove):
     state to propagate. Here we create an alanine dipeptide system
     in vacuum.
 
-    >>> from simtk import unit
+    >>> from openmm import unit
     >>> from openmmtools import testsystems
     >>> from openmmtools.states import SamplerState, ThermodynamicState
     >>> test = testsystems.AlanineDipeptideVacuum()
@@ -1140,12 +1144,12 @@ class LangevinSplittingDynamicsMove(LangevinDynamicsMove):
 
     Parameters
     ----------
-    timestep : simtk.unit.Quantity, optional
+    timestep : openmm.unit.Quantity, optional
         The timestep to use for Langevin integration
-        (time units, default is 1*simtk.unit.femtosecond).
-    collision_rate : simtk.unit.Quantity, optional
+        (time units, default is 1*openmm.unit.femtosecond).
+    collision_rate : openmm.unit.Quantity, optional
         The collision rate with fictitious bath particles
-        (1/time units, default is 10/simtk.unit.picoseconds).
+        (1/time units, default is 10/openmm.unit.picoseconds).
     n_steps : int, optional
         The number of integration timesteps to take each time the
         move is applied (default is 1000).
@@ -1174,9 +1178,9 @@ class LangevinSplittingDynamicsMove(LangevinDynamicsMove):
 
     Attributes
     ----------
-    timestep : simtk.unit.Quantity
+    timestep : openmm.unit.Quantity
         The timestep to use for Langevin integration (time units).
-    collision_rate : simtk.unit.Quantity
+    collision_rate : openmm.unit.Quantity
         The collision rate with fictitious bath particles (1/time units).
     n_steps : int
         The number of integration timesteps to take each time the move
@@ -1202,7 +1206,7 @@ class LangevinSplittingDynamicsMove(LangevinDynamicsMove):
     state to propagate. Here we create an alanine dipeptide system
     in vacuum.
 
-    >>> from simtk import unit
+    >>> from openmm import unit
     >>> from openmmtools import testsystems
     >>> from openmmtools.states import SamplerState, ThermodynamicState
     >>> test = testsystems.AlanineDipeptideVacuum()
@@ -1292,12 +1296,12 @@ class GHMCMove(BaseIntegratorMove):
 
     Parameters
     ----------
-    timestep : simtk.unit.Quantity, optional
+    timestep : openmm.unit.Quantity, optional
         The timestep to use for Langevin integration (time units, default
-        is 1*simtk.unit.femtoseconds).
-    collision_rate : simtk.unit.Quantity, optional
+        is 1*openmm.unit.femtoseconds).
+    collision_rate : openmm.unit.Quantity, optional
         The collision rate with fictitious bath particles (1/time units,
-        default is 20/simtk.unit.picoseconds).
+        default is 20/openmm.unit.picoseconds).
     n_steps : int, optional
         The number of integration timesteps to take each time the move
         is applied (default is 1000).
@@ -1307,9 +1311,9 @@ class GHMCMove(BaseIntegratorMove):
 
     Attributes
     ----------
-    timestep : simtk.unit.Quantity
+    timestep : openmm.unit.Quantity
         The timestep to use for Langevin integration (time units).
-    collision_rate : simtk.unit.Quantity
+    collision_rate : openmm.unit.Quantity
         The collision rate with fictitious bath particles (1/time units).
     n_steps : int
         The number of integration timesteps to take each time the move
@@ -1334,7 +1338,7 @@ class GHMCMove(BaseIntegratorMove):
     state to propagate. Here we create an alanine dipeptide system
     in vacuum.
 
-    >>> from simtk import unit
+    >>> from openmm import unit
     >>> from openmmtools import testsystems
     >>> from openmmtools.states import ThermodynamicState, SamplerState
     >>> test = testsystems.AlanineDipeptideVacuum()
@@ -1466,9 +1470,9 @@ class HMCMove(BaseIntegratorMove):
 
     Parameters
     ----------
-    timestep : simtk.unit.Quantity, optional
+    timestep : openmm.unit.Quantity, optional
        The timestep to use for HMC dynamics, which uses velocity Verlet following
-       velocity randomization (time units, default is 1*simtk.unit.femtosecond)
+       velocity randomization (time units, default is 1*openmm.unit.femtosecond)
     n_steps : int, optional
        The number of dynamics steps to take before Metropolis acceptance/rejection
        (default is 1000).
@@ -1478,7 +1482,7 @@ class HMCMove(BaseIntegratorMove):
 
     Attributes
     ----------
-    timestep : simtk.unit.Quantity
+    timestep : openmm.unit.Quantity
        The timestep to use for HMC dynamics, which uses velocity Verlet following
        velocity randomization (time units).
     n_steps : int
@@ -1493,7 +1497,7 @@ class HMCMove(BaseIntegratorMove):
     state to propagate. Here we create an alanine dipeptide system
     in vacuum.
 
-    >>> from simtk import unit
+    >>> from openmm import unit
     >>> from openmmtools import testsystems
     >>> from openmmtools.states import ThermodynamicState, SamplerState
     >>> test = testsystems.AlanineDipeptideVacuum()
@@ -1595,7 +1599,7 @@ class MonteCarloBarostatMove(BaseIntegratorMove):
     force. The class ThermodynamicState takes care of adding one when
     we specify the pressure in its constructor.
 
-    >>> from simtk import unit
+    >>> from openmm import unit
     >>> from openmmtools import testsystems
     >>> from openmmtools.states import ThermodynamicState, SamplerState
     >>> test = testsystems.AlanineDipeptideExplicit()
@@ -1682,7 +1686,7 @@ class MCDisplacementMove(MetropolizedMove):
 
     Parameters
     ----------
-    displacement_sigma : simtk.unit.Quantity
+    displacement_sigma : openmm.unit.Quantity
         The standard deviation of the normal distribution used to propose the
         random displacement (units of length, default is 1.0*nanometer).
     atom_subset : slice or list of int, optional
@@ -1718,15 +1722,15 @@ class MCDisplacementMove(MetropolizedMove):
 
         Parameters
         ----------
-        positions : nx3 numpy.ndarray simtk.unit.Quantity
+        positions : nx3 numpy.ndarray openmm.unit.Quantity
             The positions to displace.
-        displacement_sigma : simtk.unit.Quantity
+        displacement_sigma : openmm.unit.Quantity
             The standard deviation of the normal distribution used to propose
             the random displacement (units of length, default is 1.0*nanometer).
 
         Returns
         -------
-        rotated_positions : nx3 numpy.ndarray simtk.unit.Quantity
+        rotated_positions : nx3 numpy.ndarray openmm.unit.Quantity
             The displaced positions.
 
         """
@@ -1790,12 +1794,12 @@ class MCRotationMove(MetropolizedMove):
 
         Parameters
         ----------
-        positions : nx3 numpy.ndarray simtk.unit.Quantity
+        positions : nx3 numpy.ndarray openmm.unit.Quantity
             The positions to rotate.
 
         Returns
         -------
-        rotated_positions : nx3 numpy.ndarray simtk.unit.Quantity
+        rotated_positions : nx3 numpy.ndarray openmm.unit.Quantity
             The rotated positions.
 
         """

--- a/openmmtools/multistate/multistateanalyzer.py
+++ b/openmmtools/multistate/multistateanalyzer.py
@@ -29,8 +29,12 @@ from typing import Optional, NamedTuple, Union
 
 import mdtraj
 import numpy as np
-from simtk import openmm
-import simtk.unit as units
+try:
+    import openmm
+    import openmm.unit as units
+except ImportError:  # OpenMM < 7.6
+    from simtk import openmm
+    import simtk.unit as units
 from scipy.special import logsumexp
 from pymbar import MBAR, timeseries
 
@@ -1143,7 +1147,7 @@ class MultiStateSamplerAnalyzer(PhaseAnalyzer):
         be set to the 99.9-percentile of the distribution of the restraint energies
         in the bound state.
 
-    restraint_distance_cutoff : simtk.unit.Quantity or 'auto', optional
+    restraint_distance_cutoff : openmm.unit.Quantity or 'auto', optional
         When the restraint is unbiased, the analyzer discards all the samples
         for which the distance between the restrained atoms is above this cutoff.
         Effectively, this is equivalent to placing a hard wall potential at a
@@ -1321,9 +1325,9 @@ class MultiStateSamplerAnalyzer(PhaseAnalyzer):
         -------
         restraint_force : forces.RadiallySymmetricRestraintForce
             The restraint force used in the bound state.
-        weights_group1 : list of simtk.unit.Quantity
+        weights_group1 : list of openmm.unit.Quantity
             The masses of the restrained atoms in the first centroid group.
-        weights_group2 : list of simtk.unit.Quantity
+        weights_group2 : list of openmm.unit.Quantity
             The masses of the restrained atoms in the second centroid group.
 
         Raises
@@ -1641,10 +1645,10 @@ class MultiStateSamplerAnalyzer(PhaseAnalyzer):
 
         Returns
         -------
-        restraint_energies_ln : simtk.unit.Quantity
+        restraint_energies_ln : openmm.unit.Quantity
             A (n_sampled_states * n_decorrelated_iterations)-long array with
             the restrain energies (units of energy/mole).
-        restraint_distances_ln : simtk.unit.Quantity or None
+        restraint_distances_ln : openmm.unit.Quantity or None
             If we are not applying a distance cutoff, this is None. Otherwise,
             a (n_sampled_states * n_decorrelated_iterations)-long array with
             the restrain distances (units of length) for each frame.

--- a/openmmtools/multistate/multistatereporter.py
+++ b/openmmtools/multistate/multistatereporter.py
@@ -43,7 +43,10 @@ import netCDF4 as netcdf
 
 from typing import Union, Any
 
-from simtk import unit
+try:
+    from openmm import unit
+except ImportError:  # OpenMM < 7.6
+    from simtk import unit
 
 from openmmtools.utils import deserialize, with_timer, serialize, quantity_from_string
 from openmmtools import states
@@ -1781,7 +1784,7 @@ class _DictYamlLoader(yaml.CLoader):
 
 
 class _DictYamlDumper(yaml.CDumper):
-    """PyYAML Dumper that handle simtk Quantities through !Quantity tags."""
+    """PyYAML Dumper that handle openmm Quantities through !Quantity tags."""
 
     def __init__(self, *args, **kwargs):
         super(_DictYamlDumper, self).__init__(*args, **kwargs)

--- a/openmmtools/multistate/multistatesampler.py
+++ b/openmmtools/multistate/multistatesampler.py
@@ -37,7 +37,11 @@ import logging
 import datetime
 
 import numpy as np
-from simtk import unit, openmm
+try:
+    import openmm
+    from openmm import unit
+except ImportError:  # OpenMM < 7.6
+    from simtk import unit, openmm
 
 from openmmtools import multistate, utils, states, mcmc, cache
 import mpiplus
@@ -551,7 +555,7 @@ class MultiStateSampler(object):
 
         Parameters
         ----------
-        tolerance : simtk.unit.Quantity, optional
+        tolerance : openmm.unit.Quantity, optional
             Minimization tolerance (units of energy/mole/length, default is
             ``1.0 * unit.kilojoules_per_mole / unit.nanometers``).
         max_iterations : int, optional

--- a/openmmtools/multistate/paralleltempering.py
+++ b/openmmtools/multistate/paralleltempering.py
@@ -55,7 +55,7 @@ class ParallelTemperingSampler(ReplicaExchangeSampler):
 
     Create the system.
 
-    >>> from simtk import unit
+    >>> from openmm import unit
     >>> from openmmtools import testsystems, states, mcmc
     >>> import tempfile
     >>> testsystem = testsystems.AlanineDipeptideImplicit()
@@ -126,14 +126,14 @@ class ParallelTemperingSampler(ReplicaExchangeSampler):
             If str: path to the storage file, checkpoint options are default
             If Reporter: Instanced :class:`Reporter` class, checkpoint information is read from
             In the future this will be able to take a Storage class as well.
-        min_temperature : simtk.unit.Quantity, optional
+        min_temperature : openmm.unit.Quantity, optional
            Minimum temperature (units of temperature, default is None).
-        max_temperature : simtk.unit.Quantity, optional
+        max_temperature : openmm.unit.Quantity, optional
            Maximum temperature (units of temperature, default is None).
         n_temperatures : int, optional
            Number of exponentially-spaced temperatures between ``min_temperature``
            and ``max_temperature`` (default is None).
-        temperatures : list of simtk.unit.Quantity, optional
+        temperatures : list of openmm.unit.Quantity, optional
            If specified, this list of temperatures will be used instead of
            ``min_temperature``, ``max_temperature``, and ``n_temperatures`` (units of temperature,
            default is None).
@@ -154,7 +154,10 @@ class ParallelTemperingSampler(ReplicaExchangeSampler):
         if temperatures is not None:
             logger.debug("Using provided temperatures")
         elif min_temperature is not None and max_temperature is not None and n_temperatures is not None:
-            from simtk import unit
+            try:
+                from openmm import unit
+            except ImportError: # OpenMM < 7.6
+                from simtk import unit
             temperature_unit = unit.kelvin
             temperatures = np.logspace(np.log10(min_temperature/temperature_unit), np.log10(max_temperature/temperature_unit), num=n_temperatures) * temperature_unit
             logger.debug('using temperatures {}'.format(temperatures))

--- a/openmmtools/multistate/replicaexchange.py
+++ b/openmmtools/multistate/replicaexchange.py
@@ -119,7 +119,7 @@ class ReplicaExchangeSampler(multistate.MultiStateSampler):
     Create the system.
 
     >>> import math
-    >>> from simtk import unit
+    >>> from openmm import unit
     >>> from openmmtools import testsystems, states, mcmc
     >>> testsystem = testsystems.AlanineDipeptideImplicit()
     >>> import os

--- a/openmmtools/multistate/sams.py
+++ b/openmmtools/multistate/sams.py
@@ -81,7 +81,7 @@ class SAMSSampler(multistate.MultiStateSampler):
     Create the system:
 
     >>> import math
-    >>> from simtk import unit
+    >>> from openmm import unit
     >>> from openmmtools import testsystems, states, mcmc
     >>> testsystem = testsystems.AlanineDipeptideVacuum()
     >>> import os

--- a/openmmtools/respa.py
+++ b/openmmtools/respa.py
@@ -10,7 +10,7 @@ Portions copyright (c) 2013 Stanford University and the Authors.
 Authors: Peter Eastman
 Contributors:
 
-Permission is hereby granted, free of charge, to any person obtaining a 
+Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),
 to deal in the Software without restriction, including without limitation
 the rights to use, copy, modify, merge, publish, distribute, sublicense,
@@ -31,34 +31,37 @@ USE OR OTHER DEALINGS IN THE SOFTWARE.
 __author__ = "Peter Eastman"
 __version__ = "1.0"
 
-from simtk.openmm import CustomIntegrator
+try:
+    from openmm import CustomIntegrator
+except ImportError:  # OpenMM < 7.6
+    from simtk.openmm import CustomIntegrator
 
 class MTSIntegrator(CustomIntegrator):
     """MTSIntegrator implements the rRESPA multiple time step integration algorithm.
-    
+
     This integrator allows different forces to be evaluated at different frequencies,
     for example to evaluate the expensive, slowly changing forces less frequently than
     the inexpensive, quickly changing forces.
-    
+
     To use it, you must first divide your forces into two or more groups (by calling
     setForceGroup() on them) that should be evaluated at different frequencies.  When
     you create the integrator, you provide a tuple for each group specifying the index
     of the force group and the frequency (as a fraction of the outermost time step) at
     which to evaluate it.  For example:
-    
+
     integrator = MTSIntegrator(4*femtoseconds, [(0,1), (1,2), (2,8)])
-    
+
     This specifies that the outermost time step is 4 fs, so each step of the integrator
     will advance time by that much.  It also says that force group 0 should be evaluated
     once per time step, force group 1 should be evaluated twice per time step (every 2 fs),
     and force group 2 should be evaluated eight times per time step (every 0.5 fs).
-    
+
     For details, see Tuckerman et al., J. Chem. Phys. 97(3) pp. 1990-2001 (1992).
     """
-    
+
     def __init__(self, dt, groups):
         """Create an MTSIntegrator.
-        
+
         Parameters:
          - dt (time) The largest (outermost) integration time step to use
          - groups (list) A list of tuples defining the force groups.  The first element of each
@@ -73,7 +76,7 @@ class MTSIntegrator(CustomIntegrator):
         self.addUpdateContextState();
         self._createSubsteps(1, groups)
         self.addConstrainVelocities();
-            
+
     def _createSubsteps(self, parentSubsteps, groups):
         group, substeps = groups[0]
         stepsPerParentStep = substeps/parentSubsteps

--- a/openmmtools/scripts/test_openmm_platforms.py
+++ b/openmmtools/scripts/test_openmm_platforms.py
@@ -138,8 +138,12 @@ import os.path
 import sys
 import math
 
-import simtk.unit as units
-import simtk.openmm as openmm
+try:
+    import openmm
+    import openmm.unit as units
+except ImportError:  # OpenMM < 7.6
+    import simtk.unit as units
+    import simtk.openmm as openmm
 
 from openmmtools import testsystems
 
@@ -157,12 +161,12 @@ def assert_approximately_equal(computed_potential, expected_potential, tolerance
 
     ARGUMENTS
 
-    computed_potential (simtk.unit.Quantity in units of energy) - computed potential energy
-    expected_potential (simtk.unit.Quantity in units of energy) - expected
+    computed_potential (openmm.unit.Quantity in units of energy) - computed potential energy
+    expected_potential (openmm.unit.Quantity in units of energy) - expected
 
     OPTIONAL ARGUMENTS
 
-    tolerance (simtk.unit.Quantity in units of energy) - acceptable tolerance
+    tolerance (openmm.unit.Quantity in units of energy) - acceptable tolerance
 
     EXAMPLES
 
@@ -185,14 +189,14 @@ def compute_potential_and_force(system, positions, platform):
 
     ARGUMENTS
 
-    system (simtk.openmm.System) - the system for which the energy is to be computed
-    positions (simtk.unit.Quantity of Nx3 numpy.array in units of distance) - positions for which energy and force are to be computed
-    platform (simtk.openmm.Platform) - platform object to be used to compute the energy and force
+    system (openmm.System) - the system for which the energy is to be computed
+    positions (openmm.unit.Quantity of Nx3 numpy.array in units of distance) - positions for which energy and force are to be computed
+    platform (openmm.Platform) - platform object to be used to compute the energy and force
 
     RETURNS
 
-    potential (simtk.unit.Quantity in energy/mole) - the potential
-    force (simtk.unit.Quantity of Nx3 numpy.array in units of energy/mole/distance) - the force
+    potential (openmm.unit.Quantity in energy/mole) - the potential
+    force (openmm.unit.Quantity of Nx3 numpy.array in units of energy/mole/distance) - the force
 
     """
 
@@ -220,15 +224,15 @@ def compute_potential_and_force_by_force_index(system, positions, platform, forc
 
     ARGUMENTS
 
-    system (simtk.openmm.System) - the system for which the energy is to be computed
-    positions (simtk.unit.Quantity of Nx3 numpy.array in units of distance) - positions for which energy and force are to be computed
-    platform (simtk.openmm.Platform) - platform object to be used to compute the energy and force
+    system (openmm.System) - the system for which the energy is to be computed
+    positions (openmm.unit.Quantity of Nx3 numpy.array in units of distance) - positions for which energy and force are to be computed
+    platform (openmm.Platform) - platform object to be used to compute the energy and force
     force_index (int) - index of force to be computed (all others ignored)
 
     RETURNS
 
-    potential (simtk.unit.Quantity in energy/mole) - the potential
-    force (simtk.unit.Quantity of Nx3 numpy.array in units of energy/mole/distance) - the force
+    potential (openmm.unit.Quantity in energy/mole) - the potential
+    force (openmm.unit.Quantity of Nx3 numpy.array in units of energy/mole/distance) - the force
 
     """
 
@@ -270,15 +274,15 @@ def compute_potential_and_force_by_force_group(system, positions, platform, forc
 
     ARGUMENTS
 
-    system (simtk.openmm.System) - the system for which the energy is to be computed
-    positions (simtk.unit.Quantity of Nx3 numpy.array in units of distance) - positions for which energy and force are to be computed
-    platform (simtk.openmm.Platform) - platform object to be used to compute the energy and force
+    system (openmm.System) - the system for which the energy is to be computed
+    positions (openmm.unit.Quantity of Nx3 numpy.array in units of distance) - positions for which energy and force are to be computed
+    platform (openmm.Platform) - platform object to be used to compute the energy and force
     force_group (int) - index of force group to be computed (all others ignored)
 
     RETURNS
 
-    potential (simtk.unit.Quantity in energy/mole) - the potential
-    force (simtk.unit.Quantity of Nx3 numpy.array in units of energy/mole/distance) - the force
+    potential (openmm.unit.Quantity in energy/mole) - the potential
+    force (openmm.unit.Quantity of Nx3 numpy.array in units of energy/mole/distance) - the force
 
     """
 

--- a/openmmtools/storage/iodrivers.py
+++ b/openmmtools/storage/iodrivers.py
@@ -31,7 +31,10 @@ try:
 except ImportError:
     from yaml import Loader, Dumper
 
-from simtk import unit
+try:
+    from openmm import unit
+except ImportError:  # OpenMM < 7.6
+    from simtk import unit
 
 from ..utils import typename, quantity_from_string
 
@@ -774,8 +777,8 @@ class NCVariableCodec(Codec):
             _bind_write methods should pass a 0
             _bind_append methods should pass 1
         store_unit_string : String, optional, Default: 'NoneType'
-            String representation of the simtk.unit attached to this data. This string should be able to be fed into
-            quantity_from_string(store_unit_string) and return a valid simtk.Unit object. Typically generated from
+            String representation of the openmm.unit attached to this data. This string should be able to be fed into
+            quantity_from_string(store_unit_string) and return a valid openmm.Unit object. Typically generated from
                 str(unit).
             If no unit is assigned to the data, then the default of 'NoneType' should be given.
 
@@ -1396,7 +1399,7 @@ class NCIterable(NCVariableCodec):
 
 class NCQuantity(NCVariableCodec):
     """
-    NetCDF codec for ALL simtk.unit.Quantity's
+    NetCDF codec for ALL openmm.unit.Quantity's
     """
     @property
     def dtype(self):

--- a/openmmtools/tests/test_alchemy.py
+++ b/openmmtools/tests/test_alchemy.py
@@ -70,7 +70,7 @@ def compute_energy(system, positions, platform=None, force_group=-1):
 
     Parameters
     ----------
-    platform : simtk.openmm.Platform or None, optional
+    platform : openmm.Platform or None, optional
         If None, the global GLOBAL_ALCHEMY_PLATFORM will be used.
     force_group : int flag or set of int, optional
         Passed to the groups argument of Context.getState().
@@ -91,16 +91,16 @@ def minimize(system, positions, platform=None, tolerance=1.0*unit.kilocalories_p
 
     Parameters
     ----------
-    platform : simtk.openmm.Platform or None, optional
+    platform : openmm.Platform or None, optional
         If None, the global GLOBAL_ALCHEMY_PLATFORM will be used.
-    tolerance : simtk.unit.Quantity with units compatible with energy/distance, optional, default = 1*kilocalories_per_mole/angstroms
+    tolerance : openmm.unit.Quantity with units compatible with energy/distance, optional, default = 1*kilocalories_per_mole/angstroms
         Minimization tolerance
     maxIterations : int, optional, default=50
         Maximum number of iterations for minimization
 
     Returns
     -------
-    minimized_positions : simtk.openmm.Quantity with shape [nparticle,3] with units compatible with distance
+    minimized_positions : openmm.Quantity with shape [nparticle,3] with units compatible with distance
         The energy-minimized positions.
 
     """
@@ -220,9 +220,9 @@ def dissect_nonbonded_energy(reference_system, positions, alchemical_atoms, othe
 
     Parameters
     ----------
-    reference_system : simtk.openmm.System
+    reference_system : openmm.System
         The reference system with the NonbondedForce to dissect.
-    positions : simtk.openmm.unit.Quantity of dimension [nparticles,3] with units compatible with Angstroms
+    positions : openmm.unit.Quantity of dimension [nparticles,3] with units compatible with Angstroms
         The positions to test.
     alchemical_atoms : set of int
         The indices of the alchemical atoms.
@@ -231,7 +231,7 @@ def dissect_nonbonded_energy(reference_system, positions, alchemical_atoms, othe
 
     Returns
     -------
-    tuple of simtk.openmm.unit.Quantity with units compatible with kJ/mol
+    tuple of openmm.unit.Quantity with units compatible with kJ/mol
         All contributions to the potential energy of NonbondedForce in the order:
         nn_particle_sterics: particle sterics interactions between nonalchemical atoms
         aa_particle_sterics: particle sterics interactions between alchemical atoms
@@ -376,7 +376,7 @@ def compute_direct_space_correction(nonbonded_force, alchemical_atoms, positions
 
     Parameters
     ----------
-    nonbonded_force : simtk.openmm.NonbondedForce
+    nonbonded_force : openmm.NonbondedForce
         The nonbonded force to compute the direct space correction.
     alchemical_atoms : set
         Set of alchemical particles in the force.
@@ -385,9 +385,9 @@ def compute_direct_space_correction(nonbonded_force, alchemical_atoms, positions
 
     Returns
     -------
-    aa_correction : simtk.openmm.unit.Quantity with units compatible with kJ/mol
+    aa_correction : openmm.unit.Quantity with units compatible with kJ/mol
         The correction to the direct spaced caused by exceptions between alchemical atoms.
-    na_correction : simtk.openmm.unit.Quantity with units compatible with kJ/mol
+    na_correction : openmm.unit.Quantity with units compatible with kJ/mol
         The correction to the direct spaced caused by exceptions between nonalchemical-alchemical atoms.
 
     """
@@ -525,13 +525,13 @@ def check_multi_interacting_energy_components(reference_system, alchemical_syste
 
     Parameters
     ----------
-    reference_system : simtk.openmm.System
+    reference_system : openmm.System
         The reference system.
-    alchemical_system : simtk.openmm.System
+    alchemical_system : openmm.System
         The alchemically modified system to test.
     alchemical_regions : AlchemicalRegion.
        The alchemically modified region.
-    positions : n_particlesx3 array-like of simtk.openmm.unit.Quantity
+    positions : n_particlesx3 array-like of openmm.unit.Quantity
         The positions to test (units of length).
 
     Note
@@ -556,13 +556,13 @@ def check_interacting_energy_components(reference_system, alchemical_system, alc
 
     Parameters
     ----------
-    reference_system : simtk.openmm.System
+    reference_system : openmm.System
         The reference system.
-    alchemical_system : simtk.openmm.System
+    alchemical_system : openmm.System
         The alchemically modified system to test.
     alchemical_regions : AlchemicalRegion.
        The alchemically modified region.
-    positions : n_particlesx3 array-like of simtk.openmm.unit.Quantity
+    positions : n_particlesx3 array-like of openmm.unit.Quantity
         The positions to test (units of length).
     multi_regions : boolean
         Indicates if mutiple regions are being tested
@@ -747,13 +747,13 @@ def check_multi_noninteracting_energy_components(reference_system, alchemical_sy
     """wrapper around check_noninteracting_energy_components for multiple regions
     Parameters
     ----------
-    reference_system : simtk.openmm.System
+    reference_system : openmm.System
         The reference system (not alchemically modified).
-    alchemical_system : simtk.openmm.System
+    alchemical_system : openmm.System
         The alchemically modified system to test.
     alchemical_regions : AlchemicalRegion.
        The alchemically modified region.
-    positions : n_particlesx3 array-like of simtk.openmm.unit.Quantity
+    positions : n_particlesx3 array-like of openmm.unit.Quantity
         The positions to test (units of length).
     """
     for region in alchemical_regions:
@@ -764,13 +764,13 @@ def check_noninteracting_energy_components(reference_system, alchemical_system, 
     """Check non-interacting energy components are zero when appropriate.
     Parameters
     ----------
-    reference_system : simtk.openmm.System
+    reference_system : openmm.System
         The reference system (not alchemically modified).
-    alchemical_system : simtk.openmm.System
+    alchemical_system : openmm.System
         The alchemically modified system to test.
     alchemical_regions : AlchemicalRegion.
        The alchemically modified region.
-    positions : n_particlesx3 array-like of simtk.openmm.unit.Quantity
+    positions : n_particlesx3 array-like of openmm.unit.Quantity
         The positions to test (units of length).
     multi_regions : boolean
         Indicates if mutiple regions are being tested
@@ -952,15 +952,15 @@ def benchmark(reference_system, alchemical_regions, positions, nsteps=500,
 
     Parameters
     ----------
-    reference_system : simtk.openmm.System
+    reference_system : openmm.System
         The reference System object to compare with.
     alchemical_regions : AlchemicalRegion
         The region to alchemically modify.
-    positions : n_particlesx3 array-like of simtk.unit.Quantity
+    positions : n_particlesx3 array-like of openmm.unit.Quantity
         The initial positions (units of distance).
     nsteps : int, optional
         Number of molecular dynamics steps to use for benchmarking (default is 500).
-    timestep : simtk.unit.Quantity, optional
+    timestep : openmm.unit.Quantity, optional
         Timestep to use for benchmarking (units of time, default is 1.0*unit.femtoseconds).
 
     """
@@ -1018,7 +1018,10 @@ def benchmark_alchemy_from_pdb():
 
     import mdtraj
     import argparse
-    from simtk.openmm import app
+    try:
+        from openmm import app
+    except ImportError:  # OpenMM < 7.6
+        from simtk.openmm import app
 
     parser = argparse.ArgumentParser(description='Benchmark performance of alchemically-modified system.')
     parser.add_argument('-p', '--pdb', metavar='PDBFILE', type=str, action='store', required=True,
@@ -1058,11 +1061,11 @@ def overlap_check(reference_system, alchemical_system, positions, nsteps=50, nsa
 
     Parameters
     ----------
-    reference_system : simtk.openmm.System
+    reference_system : openmm.System
         The reference System object to compare with.
-    alchemical_system : simtk.openmm.System
+    alchemical_system : openmm.System
         Alchemically-modified system.
-    positions : n_particlesx3 array-like of simtk.unit.Quantity
+    positions : n_particlesx3 array-like of openmm.unit.Quantity
         The initial positions (units of distance).
     nsteps : int, optional
         Number of molecular dynamics steps between samples (default is 50).

--- a/openmmtools/tests/test_cache.py
+++ b/openmmtools/tests/test_cache.py
@@ -16,7 +16,10 @@ Test Context cache classes in cache.py.
 import itertools
 
 import nose
-from simtk import unit
+try:
+    from openmm import unit
+except ImportError:  # OpenMM < 7.6
+    from simtk import unit
 
 from openmmtools import testsystems, states
 

--- a/openmmtools/tests/test_forcefactories.py
+++ b/openmmtools/tests/test_forcefactories.py
@@ -56,7 +56,7 @@ def compute_forces(system, positions, platform=None, force_group=-1):
 
     Parameters
     ----------
-    platform : simtk.openmm.Platform or None, optional
+    platform : openmm.Platform or None, optional
         If None, the global GLOBAL_ALCHEMY_PLATFORM will be used.
     force_group : int flag or set of int, optional
         Passed to the groups argument of Context.getState().
@@ -77,15 +77,15 @@ def compare_system_forces(reference_system, alchemical_system, positions, name="
 
     Parameters
     ----------
-    reference_system : simtk.openmm.System
+    reference_system : openmm.System
         Reference System
-    alchemical_system : simtk.openmm.System
+    alchemical_system : openmm.System
         System to compare to reference
-    positions : simtk.unit.Quantity of shape [nparticles,3] with units of distance
+    positions : openmm.unit.Quantity of shape [nparticles,3] with units of distance
         The particle positions to use
     name : str, optional, default=""
         System name to use for debugging.
-    platform : simtk.openmm.Platform, optional, default=None
+    platform : openmm.Platform, optional, default=None
         If specified, use this platform
 
     """
@@ -110,14 +110,14 @@ def generate_new_positions(system, positions, platform=None, nsteps=50):
 
     Parameters
     ----------
-    platform : simtk.openmm.Platform or None, optional
+    platform : openmm.Platform or None, optional
         If None, the global GLOBAL_ALCHEMY_PLATFORM will be used.
     nsteps : int, optional, default=50
         Number of steps of dynamics to take.
 
     Returns
     -------
-    new_positions : simtk.unit.Quantity of shape [nparticles,3] with units compatible with distance
+    new_positions : openmm.unit.Quantity of shape [nparticles,3] with units compatible with distance
         New positions
 
     """

--- a/openmmtools/tests/test_integrators.py
+++ b/openmmtools/tests/test_integrators.py
@@ -20,8 +20,12 @@ import pymbar
 from unittest import TestCase
 
 import numpy as np
-from simtk import unit
-from simtk import openmm
+try:
+    import openmm
+    from openmm import unit
+except ImportError:  # OpenMM < 7.6
+    from simtk import unit
+    from simtk import openmm
 
 from openmmtools import integrators, testsystems
 from openmmtools.integrators import (ThermostatedIntegrator, AlchemicalNonequilibriumLangevinIntegrator,
@@ -70,7 +74,7 @@ def check_stability(integrator, test, platform=None, nsteps=100, temperature=300
 
     Parameters
     ----------
-    integrator : simtk.openmm.Integrator
+    integrator : openmm.Integrator
        The integrator to test.
     test : testsystem
        The testsystem to test.
@@ -419,7 +423,10 @@ class TestExternalPerturbationLangevinIntegrator(TestCase):
         """
         Ensure the protocol work is initially zero and remains zero after a number of integrator steps.
         """
-        from simtk.openmm import app
+        try:
+            from openmm import app
+        except ImportError:  # OpenMM < 7.6
+            from simtk.openmm import app
         parameter_name = 'lambda_electrostatics'
         temperature = 298.0 * unit.kelvin
         parameter_initial = 1.0
@@ -440,7 +447,11 @@ class TestExternalPerturbationLangevinIntegrator(TestCase):
         Make sure the protocol work that is accumulated internally by the langevin integrator matches the protocol
         is correctly reset with the reset_protocol_work() command.
         """
-        from simtk.openmm import app
+        try:
+            from openmm import app
+        except ImportError:  # OpenMM < 7.6
+            from simtk.openmm import app
+
         parameter_name = 'lambda_electrostatics'
         temperature = 298.0 * unit.kelvin
         parameter_initial = 1.0
@@ -471,7 +482,11 @@ class TestExternalPerturbationLangevinIntegrator(TestCase):
         context.updateParametersInContext() and the integrator is a compound integrator. The NCMC scheme tested below
         is based on the one used by the saltswap and protons code-bases.
         """
-        from simtk.openmm import app
+        try:
+            from openmm import app
+        except ImportError:  # OpenMM < 7.6
+            from simtk.openmm import app
+
         from openmmtools.constants import kB
 
         size = 20.0
@@ -541,7 +556,10 @@ class TestExternalPerturbationLangevinIntegrator(TestCase):
     def test_protocol_work_accumulation_waterbox(self):
         """Testing protocol work accumulation for ExternalPerturbationLangevinIntegrator with AlchemicalWaterBox
         """
-        from simtk.openmm import app
+        try:
+            from openmm import app
+        except ImportError:  # OpenMM < 7.6
+            from simtk.openmm import app
         parameter_name = 'lambda_electrostatics'
         parameter_initial = 1.0
         parameter_final = 0.0
@@ -557,7 +575,10 @@ class TestExternalPerturbationLangevinIntegrator(TestCase):
         Testing protocol work accumulation for ExternalPerturbationLangevinIntegrator with AlchemicalWaterBox with barostat.
         For brevity, only using CutoffPeriodic as the non-bonded method.
         """
-        from simtk.openmm import app
+        try:
+            from openmm import app
+        except ImportError:  # OpenMM < 7.6
+            from simtk.openmm import app
         parameter_name = 'lambda_electrostatics'
         parameter_initial = 1.0
         parameter_final = 0.0
@@ -836,7 +857,10 @@ def test_periodic_langevin_integrator(splitting="H V R O R V H", ncycles=40, nst
     assert integrator.getGlobalVariableByName("n_steps_per_cycle") == nsteps_per_cycle
 
     if write_trajectory:
-        from simtk.openmm.app import PDBFile
+        try:
+            from openmm.app import PDBFile
+        except ImportError:  # OpenMM < 7.6
+            from simtk.openmm.app import PDBFile
         filename = 'neq-trajectory.pdb'
         print(f'Writing trajectory to {filename}')
         with open(filename, 'wt') as outfile:

--- a/openmmtools/tests/test_integrators_and_testsystems.py
+++ b/openmmtools/tests/test_integrators_and_testsystems.py
@@ -17,8 +17,12 @@ import re
 import inspect
 from functools import partial
 
-from simtk import unit
-from simtk import openmm
+try:
+    import openmm
+    from openmm import unit
+except ImportError:  # OpenMM < 7.6
+    from simtk import unit
+    from simtk import openmm
 
 #=============================================================================================
 # CONSTANTS
@@ -36,7 +40,7 @@ def check_combination(integrator, test, platform=None):
 
     Parameters
     ----------
-    integrator : simtk.openmm.Integrator
+    integrator : openmm.Integrator
        The integrator to test.
     test : testsystem
        The testsystem to test.

--- a/openmmtools/tests/test_sampling.py
+++ b/openmmtools/tests/test_sampling.py
@@ -27,7 +27,11 @@ import scipy.integrate
 import yaml
 from nose.plugins.attrib import attr
 from nose.tools import assert_raises
-from simtk import openmm, unit
+try:
+    import openmm
+    from openmm import unit
+except ImportError:  # OpenMM < 7.6
+    from simtk import openmm, unit
 import mpiplus
 
 import openmmtools as mmtools
@@ -1682,8 +1686,10 @@ class TestParallelTempering(TestMultiStateSampler):
     # ------------------------------------
     # VARIABLES TO SET FOR EACH TEST CLASS
     # ------------------------------------
-
-    from simtk import unit
+    try:
+        from openmm import unit
+    except ImportError:  # OpenMM < 7.6
+        from simtk import unit
     N_SAMPLERS = 3
     N_STATES = 3
     SAMPLER = ParallelTemperingSampler
@@ -1723,8 +1729,10 @@ class TestParallelTempering(TestMultiStateSampler):
             self.call_sampler_create(sampler, reporter,
                 thermodynamic_states, sampler_states,
                 unsampled_states)
-
-            from simtk import unit
+            try:
+                from openmm import unit
+            except ImportError:  # OpenMM < 7.6
+                from simtk import unit
             temperatures = [state.temperature/unit.kelvin for state in sampler._thermodynamic_states] # in kelvin
             assert len(temperatures) == self.N_STATES, f"There are {len(temperatures)} thermodynamic states; expected {self.N_STATES}"
             assert np.isclose(min(temperatures), (self.MIN_TEMP/unit.kelvin)), f"Min temperature is {min(temperatures)} K; expected {(self.MIN_TEMP/unit.kelvin)} K"

--- a/openmmtools/tests/test_storage_interface.py
+++ b/openmmtools/tests/test_storage_interface.py
@@ -13,7 +13,10 @@ Testing the storage handlers themselves should be left to the test_storage_iodri
 # =============================================================================================
 
 import numpy as np
-from simtk import unit
+try:
+    from openmm import unit
+except ImportError:  # OpenMM < 7.6
+    from simtk import unit
 import contextlib
 import tempfile
 from openmmtools.utils import temporary_directory

--- a/openmmtools/tests/test_storage_iodrivers.py
+++ b/openmmtools/tests/test_storage_iodrivers.py
@@ -10,7 +10,10 @@ Test iodrivers.py facility.
 # =============================================================================================
 
 import numpy as np
-from simtk import unit
+try:
+    from openmm import unit
+except ImportError:  # OpenMM < 7.6
+    from simtk import unit
 import contextlib
 import tempfile
 
@@ -212,7 +215,7 @@ def test_netcdf_array_type_codec():
 
 
 def test_netcdf_quantity_type_codec():
-    """Test that the simtk.unit.Quantity type codec can read/write/append with various unit and _value types"""
+    """Test that the openmm.unit.Quantity type codec can read/write/append with various unit and _value types"""
     input_data = 4 * unit.kelvin
     generic_type_codec_check(input_data)
     overwrite_data = 5 * unit.kelvin

--- a/openmmtools/tests/test_testsystems.py
+++ b/openmmtools/tests/test_testsystems.py
@@ -1,7 +1,11 @@
 import numpy as np
 
-from simtk import unit
-from simtk import openmm
+try:
+    import openmm
+    from openmm import unit
+except ImportError:  # OpenMM < 7.6
+    from simtk import unit
+    from simtk import openmm
 
 import os, os.path
 import logging
@@ -128,9 +132,9 @@ def check_potential_energy(system, positions):
 
     Parameters
     ----------
-    system : simtk.openmm.System
+    system : openmm.System
        The system
-    positions : simtk.unit.Quantity
+    positions : openmm.unit.Quantity
        The positions
 
     """

--- a/openmmtools/tests/test_utils.py
+++ b/openmmtools/tests/test_utils.py
@@ -26,8 +26,11 @@ from openmmtools.utils import *
 
 def test_platform_supports_precision():
     """Test that platform_supports_precision works correctly."""
-    from simtk import openmm
-    
+    try:
+        import openmm
+    except ImportError:  # OpenMM < 7.6
+        from simtk import openmm
+
     for platform_index in range(openmm.Platform.getNumPlatforms()):
         platform = openmm.Platform.getPlatform(platform_index)
         platform_name = platform.getName()

--- a/openmmtools/testsystems.py
+++ b/openmmtools/testsystems.py
@@ -53,9 +53,14 @@ import scipy
 import scipy.special
 import scipy.integrate
 
-from simtk import openmm
-from simtk import unit
-from simtk.openmm import app
+try:
+    import openmm
+    from openmm import unit
+    from openmm import app
+except ImportError:  # Openmm < 7.6
+    from simtk import openmm
+    from simtk import unit
+    from simtk.openmm import app
 
 from .constants import kB
 
@@ -135,11 +140,11 @@ def handle_kwargs(func, defaults, input_kwargs):
     return kwargs
 
 def in_openmm_units(quantity):
-    """Strip the units from a simtk.unit.Quantity object after converting to natural OpenMM units
+    """Strip the units from a openmm.unit.Quantity object after converting to natural OpenMM units
 
     Parameters
     ----------
-    quantity : simtk.unit.Quantity
+    quantity : openmm.unit.Quantity
        The quantity to convert
 
     Returns
@@ -230,14 +235,14 @@ def subrandom_particle_positions(nparticles, box_vectors, method='sobol'):
     ----------
     nparticles : int
         The number of particles.
-    box_vectors : simtk.unit.Quantity of (3,3) with units compatible with nanometer
+    box_vectors : openmm.unit.Quantity of (3,3) with units compatible with nanometer
         Periodic box vectors in which particles should lie.
     method : str, optional, default='sobol'
         Method for creating subrandom sequence (one of 'halton' or 'sobol')
 
     Returns
     -------
-    positions : simtk.unit.Quantity of (natoms,3) with units compatible with nanometer
+    positions : openmm.unit.Quantity of (natoms,3) with units compatible with nanometer
         The particle positions.
 
     Examples
@@ -414,11 +419,11 @@ class ThermodynamicState(object):
         Parameters
         ----------
 
-        system : simtk.openmm.System, optional, default=None
+        system : openmm.System, optional, default=None
             System object describing the potential energy function for the system
-        temperature : simtk.unit.Quantity compatible with 'kelvin', optional, default=None
+        temperature : openmm.unit.Quantity compatible with 'kelvin', optional, default=None
             Temperature for a system with constant temperature
-        pressure : simtk.unit.Quantity compatible with 'atmospheres', optional, default=None
+        pressure : openmm.unit.Quantity compatible with 'atmospheres', optional, default=None
             If not None, specifies the pressure for constant-pressure systems.
 
 
@@ -444,7 +449,7 @@ class TestSystem(object):
 
     Attributes
     ----------
-    system : simtk.openmm.System
+    system : openmm.System
         System object for the test system
     positions : list
         positions of test system
@@ -504,7 +509,7 @@ class TestSystem(object):
 
     @property
     def system(self):
-        """The simtk.openmm.System object corresponding to the test system."""
+        """The openmm.System object corresponding to the test system."""
         return self._system
 
     @system.setter
@@ -517,7 +522,7 @@ class TestSystem(object):
 
     @property
     def positions(self):
-        """The simtk.unit.Quantity object containing the particle positions, with units compatible with simtk.unit.nanometers."""
+        """The openmm.unit.Quantity object containing the particle positions, with units compatible with openmm.unit.nanometers."""
         return self._positions
 
     @positions.setter
@@ -530,7 +535,7 @@ class TestSystem(object):
 
     @property
     def topology(self):
-        """The simtk.openmm.app.Topology object corresponding to the test system."""
+        """The openmm.app.Topology object corresponding to the test system."""
         return self._topology
 
     @topology.setter
@@ -585,8 +590,10 @@ class TestSystem(object):
             Serialized XML form of State object containing particle positions.
 
         """
-
-        from simtk.openmm import XmlSerializer
+        try:
+            from openmm import XmlSerializer
+        except ImportError:  # OpenMM < 7.6
+            from simtk.openmm import XmlSerializer
 
         # Serialize System.
         system_xml = XmlSerializer.serialize(self._system)
@@ -622,7 +629,7 @@ class CustomExternalForcesTestSystem(TestSystem):
         Each string in the tuple will add a CustomExternalForce to the
         OpenMM system.  Each force will be assigned a different force
         group, starting with 0.  By default this will be a 3D harmonic oscillator.
-    mass : simtk.unit.Quantity, optional, default=39.948 * unit.amu
+    mass : openmm.unit.Quantity, optional, default=39.948 * unit.amu
         particle mass.  Default corresponds to argon.
     n_particles : int, optional, default=500
         Number of (identical) particles to add.
@@ -676,11 +683,11 @@ class HarmonicOscillator(TestSystem):
 
     Parameters
     ----------
-    K : simtk.unit.Quantity, optional, default=100.0 * unit.kilocalories_per_mole/unit.angstrom**2
+    K : openmm.unit.Quantity, optional, default=100.0 * unit.kilocalories_per_mole/unit.angstrom**2
         harmonic restraining potential
-    mass : simtk.unit.Quantity, optional, default=39.948 * unit.amu
+    mass : openmm.unit.Quantity, optional, default=39.948 * unit.amu
         particle mass
-    U0 : simtk.unit.Quantity, optional, default=0.0 * unit.kilocalories_per_mole
+    U0 : openmm.unit.Quantity, optional, default=0.0 * unit.kilocalories_per_mole
         Potential offset for harmonic oscillator
 
     The functional form is given by
@@ -689,7 +696,7 @@ class HarmonicOscillator(TestSystem):
 
     Attributes
     ----------
-    system : simtk.openmm.System
+    system : openmm.System
         Openmm system with the harmonic oscillator
     positions : list
         positions of harmonic oscillator
@@ -735,7 +742,7 @@ class HarmonicOscillator(TestSystem):
 
     Compute the potential expectation and standard deviation
 
-    >>> import simtk.unit as u
+    >>> import openmm.unit as u
     >>> thermodynamic_state = ThermodynamicState(temperature=298.0*u.kelvin, system=system)
     >>> potential_mean = ho.get_potential_expectation(thermodynamic_state)
     >>> potential_stddev = ho.get_potential_standard_deviation(thermodynamic_state)
@@ -801,7 +808,7 @@ class HarmonicOscillator(TestSystem):
         Returns
         -------
 
-        potential_mean : simtk.unit.Quantity compatible with simtk.unit.kilojoules_per_mole
+        potential_mean : openmm.unit.Quantity compatible with openmm.unit.kilojoules_per_mole
             The expectation of the potential energy.
 
         """
@@ -820,7 +827,7 @@ class HarmonicOscillator(TestSystem):
         Returns
         -------
 
-        potential_stddev : simtk.unit.Quantity compatible with simtk.unit.kilojoules_per_mole
+        potential_stddev : openmm.unit.Quantity compatible with openmm.unit.kilojoules_per_mole
             potential energy standard deviation if implemented, or else None
 
         """
@@ -834,16 +841,16 @@ class PowerOscillator(TestSystem):
 
     Parameters
     ----------
-    K : simtk.unit.Quantity, optional, default=100.0
+    K : openmm.unit.Quantity, optional, default=100.0
         harmonic restraining potential.  The units depend on the power,
         so we accept unitless inputs and add units of the form
         unit.kilocalories_per_mole / unit.angstrom ** b
-    mass : simtk.unit.Quantity, optional, default=39.948 * unit.amu
+    mass : openmm.unit.Quantity, optional, default=39.948 * unit.amu
         particle mass
 
     Attributes
     ----------
-    system : simtk.openmm.System
+    system : openmm.System
         Openmm system with the harmonic oscillator
     positions : list
         positions of harmonic oscillator
@@ -908,7 +915,7 @@ class PowerOscillator(TestSystem):
         Returns
         -------
 
-        potential_mean : simtk.unit.Quantity compatible with simtk.unit.kilojoules_per_mole
+        potential_mean : openmm.unit.Quantity compatible with openmm.unit.kilojoules_per_mole
             The expectation of the potential energy.
 
         """
@@ -939,15 +946,15 @@ class Diatom(TestSystem):
 
     Parameters
     ----------
-    K : simtk.unit.Quantity, optional, default=290.1 * unit.kilocalories_per_mole / unit.angstrom**2
+    K : openmm.unit.Quantity, optional, default=290.1 * unit.kilocalories_per_mole / unit.angstrom**2
         harmonic bond potential.  default is GAFF c-c bond
-    r0 : simtk.unit.Quantity, optional, default=1.550 * unit.amu
+    r0 : openmm.unit.Quantity, optional, default=1.550 * unit.amu
         bond length.  Default is Amber GAFF c-c bond.
     constraint : bool, default=False
         if True, the bond length will be constrained
-    m1 : simtk.unit.Quantity, optional, default=12.01 * unit.amu
+    m1 : openmm.unit.Quantity, optional, default=12.01 * unit.amu
         particle1 mass
-    m2 : simtk.unit.Quantity, optional, default=12.01 * unit.amu
+    m2 : openmm.unit.Quantity, optional, default=12.01 * unit.amu
         particle2 mass
     use_central_potential : bool, optional, default=False
         if True, a soft central potential will also be added to keep the system from drifting away
@@ -1040,7 +1047,7 @@ class Diatom(TestSystem):
         Returns
         -------
 
-        potential_mean : simtk.unit.Quantity compatible with simtk.unit.kilojoules_per_mole
+        potential_mean : openmm.unit.Quantity compatible with openmm.unit.kilojoules_per_mole
             The expectation of the potential energy.
 
         """
@@ -1064,27 +1071,27 @@ class DiatomicFluid(TestSystem):
     ----------
     nmolecules : int, optional, default=250
         Number of molecules.
-    K : simtk.unit.Quantity, optional, default=290.1 * unit.kilocalories_per_mole / unit.angstrom**2
+    K : openmm.unit.Quantity, optional, default=290.1 * unit.kilocalories_per_mole / unit.angstrom**2
         harmonic bond potential.  default is GAFF c-c bond
-    r0 : simtk.unit.Quantity, optional, default=1.550 * unit.amu
+    r0 : openmm.unit.Quantity, optional, default=1.550 * unit.amu
         bond length.  Default is Amber GAFF c-c bond.
     constraint : bool, default=False
         if True, the bond length will be constrained
-    m1 : simtk.unit.Quantity, optional, default=12.01 * unit.amu
+    m1 : openmm.unit.Quantity, optional, default=12.01 * unit.amu
         particle1 mass
-    m2 : simtk.unit.Quantity, optional, default=12.01 * unit.amu
+    m2 : openmm.unit.Quantity, optional, default=12.01 * unit.amu
         particle2 mass
-    epsilon : simtk.unit.Quantity, optional, default=0.1700 * unit.kilocalories_per_mole
+    epsilon : openmm.unit.Quantity, optional, default=0.1700 * unit.kilocalories_per_mole
         particle Lennard-Jones well depth
-    sigma : simtk.unit.Quantity, optional, default=1.8240 * unit.angstroms
+    sigma : openmm.unit.Quantity, optional, default=1.8240 * unit.angstroms
         particle Lennard-Jones sigma
-    charge : simtk.unit.Quantity, optional, default=0.0 * unit.elementary_charge
+    charge : openmm.unit.Quantity, optional, default=0.0 * unit.elementary_charge
         charge to place on atomic centers to create a dipole
     reduced_density : float, optional, default=0.05
         Reduced density (density * sigma**3); default is appropriate for gas
-    cutoff : simtk.unit.Quantity, optional, default=None
+    cutoff : openmm.unit.Quantity, optional, default=None
         if specified, the specified cutoff will be used; otherwise, 3.0 * sigma will be used
-    switch_width : simtk.unit.Quantity with units compatible with angstroms, optional, default=0.2*unit.angstroms
+    switch_width : openmm.unit.Quantity with units compatible with angstroms, optional, default=0.2*unit.angstroms
         switching function is turned on at cutoff - switch_width
         If None, no switch will be applied (e.g. hard cutoff).
     dispersion_correction : bool, optional, default=True
@@ -1237,7 +1244,7 @@ class DiatomicFluid(TestSystem):
 
         Returns
         -------
-        potential_mean : simtk.unit.Quantity compatible with simtk.unit.kilojoules_per_mole
+        potential_mean : openmm.unit.Quantity compatible with openmm.unit.kilojoules_per_mole
             The expectation of the potential energy.
 
         """
@@ -1340,16 +1347,16 @@ class ConstraintCoupledHarmonicOscillator(TestSystem):
 
     Parameters
     ----------
-    K : simtk.unit.Quantity, optional, default=1.0 * unit.kilojoules_per_mole / unit.nanometer**2
+    K : openmm.unit.Quantity, optional, default=1.0 * unit.kilojoules_per_mole / unit.nanometer**2
         harmonic restraining potential
-    d : simtk.unit.Quantity, optional, default=1.0 * unit.nanometer
+    d : openmm.unit.Quantity, optional, default=1.0 * unit.nanometer
         distance between harmonic oscillators.  Default is Amber GAFF c-c bond.
-    mass : simtk.unit.Quantity, default=39.948 * unit.amu
+    mass : openmm.unit.Quantity, default=39.948 * unit.amu
         particle mass
 
     Attributes
     ----------
-    system : simtk.openmm.System
+    system : openmm.System
     positions : list
 
     Notes
@@ -1431,18 +1438,18 @@ class HarmonicOscillatorArray(TestSystem):
 
     Parameters
     ----------
-    K : simtk.unit.Quantity, optional, default=90.0 * unit.kilocalories_per_mole/unit.angstroms**2
+    K : openmm.unit.Quantity, optional, default=90.0 * unit.kilocalories_per_mole/unit.angstroms**2
         harmonic restraining potential
-    d : simtk.unit.Quantity, optional, default=1.0 * unit.nanometer
+    d : openmm.unit.Quantity, optional, default=1.0 * unit.nanometer
         distance between harmonic oscillators.  Default is Amber GAFF c-c bond.
-    mass : simtk.unit.Quantity, default=39.948 * unit.amu
+    mass : openmm.unit.Quantity, default=39.948 * unit.amu
         particle mass
     N : int, optional, default=5
         Number of harmonic oscillators
 
     Attributes
     ----------
-    system : simtk.openmm.System
+    system : openmm.System
     positions : list
 
     Notes
@@ -1517,7 +1524,7 @@ class HarmonicOscillatorArray(TestSystem):
 
         Returns
         -------
-        potential_mean : simtk.unit.Quantity compatible with simtk.unit.kilojoules_per_mole
+        potential_mean : openmm.unit.Quantity compatible with openmm.unit.kilojoules_per_mole
             The expectation of the potential energy.
 
         """
@@ -1534,7 +1541,7 @@ class HarmonicOscillatorArray(TestSystem):
 
         Returns
         -------
-        potential_stddev : simtk.unit.Quantity compatible with simtk.unit.kilojoules_per_mole
+        potential_stddev : openmm.unit.Quantity compatible with openmm.unit.kilojoules_per_mole
             potential energy standard deviation if implemented, or else None
 
         """
@@ -1552,7 +1559,7 @@ class SodiumChlorideCrystal(TestSystem):
 
     Each atom is represented by a charged Lennard-Jones sphere in an Ewald lattice.
 
-    switch_width : simtk.unit.Quantity with units compatible with angstroms, optional, default=0.2*unit.angstroms
+    switch_width : openmm.unit.Quantity with units compatible with angstroms, optional, default=0.2*unit.angstroms
         switching function is turned on at cutoff - switch_width
         If None, no switch will be applied (e.g. hard cutoff).
     dispersion_correction : bool, optional, default=True
@@ -1673,12 +1680,12 @@ class LennardJonesCluster(TestSystem):
         number of particles in the y direction
     nz : int, optional, default=3
         number of particles in the z direction
-    K : simtk.unit.Quantity, optional, default=1.0 * unit.kilojoules_per_mole/unit.nanometer**2
+    K : openmm.unit.Quantity, optional, default=1.0 * unit.kilojoules_per_mole/unit.nanometer**2
         harmonic restraining potential
-    cutoff : simtk.unit.Quantity, optional, default=None
+    cutoff : openmm.unit.Quantity, optional, default=None
         If None, will use NoCutoff for the NonbondedForce.  Otherwise,
         use CutoffNonPeriodic with the specified cutoff.
-    switch_width : simtk.unit.Quantity, optional, default=None
+    switch_width : openmm.unit.Quantity, optional, default=None
         If None, the cutoff is a hard cutoff.  If switch_width is specified,
         use a switching function with this width.
 
@@ -1781,7 +1788,7 @@ class WaterCluster(TestSystem):
         ----------
         n_waters : int
             Number of water molecules in the cluster
-        K : simtk.unit.Quantity (energy / distance^2)
+        K : openmm.unit.Quantity (energy / distance^2)
             spring constant for restraining potential
         model : string
             Must be one of ['tip3p', 'tip4pew', 'tip5p', 'spce']
@@ -1872,15 +1879,15 @@ class LennardJonesFluid(TestSystem):
         Number of Lennard-Jones particles.
     reduced_density : float, optional, default=0.05
         Reduced density (density * sigma**3); default is appropriate for gas
-    mass : simtk.unit.Quantity, optional, default=39.9 * unit.amu
+    mass : openmm.unit.Quantity, optional, default=39.9 * unit.amu
         mass of each particle; default is appropriate for argon
-    sigma : simtk.unit.Quantity, optional, default=3.4 * unit.angstrom
+    sigma : openmm.unit.Quantity, optional, default=3.4 * unit.angstrom
         Lennard-Jones sigma parameter; default is appropriate for argon
-    epsilon : simtk.unit.Quantity, optional, default=0.238 * unit.kilocalories_per_mole
+    epsilon : openmm.unit.Quantity, optional, default=0.238 * unit.kilocalories_per_mole
         Lennard-Jones well depth; default is appropriate for argon
-    cutoff : simtk.unit.Quantity, optional, default=None
+    cutoff : openmm.unit.Quantity, optional, default=None
         Cutoff for nonbonded interactions.  If None, defaults to 3.0 * sigma
-    switch_width : simtk.unit.Quantity with units compatible with angstroms, optional, default=3.4 * unit.angstrom
+    switch_width : openmm.unit.Quantity with units compatible with angstroms, optional, default=3.4 * unit.angstrom
         switching function is turned on at cutoff - switch_width
         If None, no switch will be applied (e.g. hard cutoff).
         Ignored if `shift=True`.
@@ -1891,7 +1898,7 @@ class LennardJonesFluid(TestSystem):
     lattice : bool, optional, default=False
         If True, use fcc sphere packing to generate initial positions.  The box
         size will be determined by `nparticles` and `reduced_density`.
-    charge : simtk.unit, optional, default=None
+    charge : openmm.unit, optional, default=None
         If not None, use alternating plus and minus `charge` for the particle charges.
         Also, if not None, use PME for electrostatics.  Obviously this is no
         longer a traditional LJ system, but this option could be useful for
@@ -2079,15 +2086,15 @@ class LennardJonesGrid(LennardJonesFluid):
         Number of particles in x, y, and z dimensions.
     reduced_density : float, optional, default=0.86
         Reduced density (density * sigma**3); default is appropriate for liquid argon.
-    mass : simtk.unit.Quantity, optional, default=39.9 * unit.amu
+    mass : openmm.unit.Quantity, optional, default=39.9 * unit.amu
         mass of each particle; default is appropriate for argon
-    sigma : simtk.unit.Quantity, optional, default=3.4 * unit.angstrom
+    sigma : openmm.unit.Quantity, optional, default=3.4 * unit.angstrom
         Lennard-Jones sigma parameter; default is appropriate for argon
-    epsilon : simtk.unit.Quantity, optional, default=0.238 * unit.kilocalories_per_mole
+    epsilon : openmm.unit.Quantity, optional, default=0.238 * unit.kilocalories_per_mole
         Lennard-Jones well depth; default is appropriate for argon
-    cutoff : simtk.unit.Quantity, optional, default=None
+    cutoff : openmm.unit.Quantity, optional, default=None
         Cutoff for nonbonded interactions.  If None, defaults to 2.5 * sigma
-    switch_width : simtk.unit.Quantity with units compatible with angstroms, optional, default=0.2*unit.angstroms
+    switch_width : openmm.unit.Quantity with units compatible with angstroms, optional, default=0.2*unit.angstroms
         switching function is turned on at cutoff - switch_width
         If None, no switch will be applied (e.g. hard cutoff).
     dispersion_correction : bool, optional, default=True
@@ -2165,15 +2172,15 @@ class CustomLennardJonesFluidMixture(TestSystem):
         Number of Lennard-Jones particles.
     reduced_density : float, optional, default=0.05
         Reduced density (density * sigma**3); default is appropriate for gas
-    mass : simtk.unit.Quantity, optional, default=39.9 * unit.amu
+    mass : openmm.unit.Quantity, optional, default=39.9 * unit.amu
         mass of each particle.
-    sigma : simtk.unit.Quantity, optional, default=3.4 * unit.angstrom
+    sigma : openmm.unit.Quantity, optional, default=3.4 * unit.angstrom
         Lennard-Jones sigma parameter
-    epsilon : simtk.unit.Quantity, optional, default=0.238 * unit.kilocalories_per_mole
+    epsilon : openmm.unit.Quantity, optional, default=0.238 * unit.kilocalories_per_mole
         Lennard-Jones well depth
-    cutoff : simtk.unit.Quantity, optional, default=None
+    cutoff : openmm.unit.Quantity, optional, default=None
         Cutoff for nonbonded interactions.  If None, defaults to 3 * sigma
-    switch_width : simtk.unit.Quantity with units compatible with angstroms, optional, default=None
+    switch_width : openmm.unit.Quantity with units compatible with angstroms, optional, default=None
         switching function is turned on at cutoff - switch_width
         If None, no switch will be applied (e.g. hard cutoff).
     dispersion_correction : bool, optional, default=True
@@ -2309,11 +2316,11 @@ class WCAFluid(TestSystem):
             Number of particles.
         density : float, optional, default = 0.96
             Reduced density, N sigma^3 / V.
-        mass : simtk.unit.Quantity with units compatible with angstrom, optional, default=39.9 amu
+        mass : openmm.unit.Quantity with units compatible with angstrom, optional, default=39.9 amu
             Particle mass.
-        epsilon : simtk.unit.Quantity with units compatible with kilocalories_per_mole, optional, default=120K*kB
+        epsilon : openmm.unit.Quantity with units compatible with kilocalories_per_mole, optional, default=120K*kB
             WCA well depth.
-        sigma : simtk.unit.Quantity
+        sigma : openmm.unit.Quantity
             WCA sigma.
 
         """
@@ -2404,17 +2411,17 @@ class DoubleWellDimer_WCAFluid(WCAFluid):
             Number of particles.
         density : float, optional, default = 0.96
             Reduced density, N sigma^3 / V.
-        mass : simtk.unit.Quantity with units compatible with angstrom, optional, default=39.9 amu
+        mass : openmm.unit.Quantity with units compatible with angstrom, optional, default=39.9 amu
             Particle mass.
-        epsilon : simtk.unit.Quantity with units compatible with kilocalories_per_mole, optional, default=120K*kB
+        epsilon : openmm.unit.Quantity with units compatible with kilocalories_per_mole, optional, default=120K*kB
             WCA well depth.
-        sigma : simtk.unit.Quantity, optional, default = 3.4 angstrom
+        sigma : openmm.unit.Quantity, optional, default = 3.4 angstrom
             WCA sigma.
-        h : simtk.unit.Quantity, optional, default = 593.28K * kB
+        h : openmm.unit.Quantity, optional, default = 593.28K * kB
             Double well barrier height.
-        r0 : simtk.unit.Quantity, optional, default = 2^(1/6) * 3.4 angstrom
+        r0 : openmm.unit.Quantity, optional, default = 2^(1/6) * 3.4 angstrom
             Double well "short" state distance for minimum energy.
-        w: simtk.unit.Quanity, optional, default = 1.02 angstrom
+        w : openmm.unit.Quanity, optional, default = 1.02 angstrom
             Double well width; "extended" state minimum energy distance is
             r0 + 2w.
 
@@ -2546,17 +2553,17 @@ class DoubleWellChain_WCAFluid(DoubleWellDimer_WCAFluid):
             Number of particles.
         density : float, optional, default = 0.96
             Reduced density, N sigma^3 / V.
-        mass : simtk.unit.Quantity with units compatible with angstrom, optional, default=39.9 amu
+        mass : openmm.unit.Quantity with units compatible with angstrom, optional, default=39.9 amu
             Particle mass.
-        epsilon : simtk.unit.Quantity with units compatible with kilocalories_per_mole, optional, default=120K*kB
+        epsilon : openmm.unit.Quantity with units compatible with kilocalories_per_mole, optional, default=120K*kB
             WCA well depth.
-        sigma : simtk.unit.Quantity, optional, default = 3.4 angstrom
+        sigma : openmm.unit.Quantity, optional, default = 3.4 angstrom
             WCA sigma.
-        h : simtk.unit.Quantity, optional, default = 593.28K * kB
+        h : openmm.unit.Quantity, optional, default = 593.28K * kB
             Double well barrier height.
-        r0 : simtk.unit.Quantity, optional, default = 2^(1/6) * 3.4 angstrom
+        r0 : openmm.unit.Quantity, optional, default = 2^(1/6) * 3.4 angstrom
             Double well "short" state distance for minimum energy.
-        w: simtk.unit.Quanity, optional, default = 1.02 angstrom
+        w : openmm.unit.Quanity, optional, default = 1.02 angstrom
             Double well width; "extended" state minimum energy distance is
             r0 + 2w.
 
@@ -2698,7 +2705,7 @@ class IdealGas(TestSystem):
 
         Returns
         -------
-        potential_mean : simtk.unit.Quantity compatible with simtk.unit.kilojoules_per_mole
+        potential_mean : openmm.unit.Quantity compatible with openmm.unit.kilojoules_per_mole
             The expectation of the potential energy.
 
         """
@@ -2715,7 +2722,7 @@ class IdealGas(TestSystem):
 
         Returns
         -------
-        potential_stddev : simtk.unit.Quantity compatible with simtk.unit.kilojoules_per_mole
+        potential_stddev : openmm.unit.Quantity compatible with openmm.unit.kilojoules_per_mole
             potential energy standard deviation if implemented, or else None
 
         """
@@ -2732,7 +2739,7 @@ class IdealGas(TestSystem):
 
         Returns
         -------
-        potential_mean : simtk.unit.Quantity compatible with simtk.unit.kilojoules_per_mole
+        potential_mean : openmm.unit.Quantity compatible with openmm.unit.kilojoules_per_mole
             The expectation of the potential energy.
 
         """
@@ -2749,7 +2756,7 @@ class IdealGas(TestSystem):
 
         Returns
         -------
-        potential_stddev : simtk.unit.Quantity compatible with simtk.unit.kilojoules_per_mole
+        potential_stddev : openmm.unit.Quantity compatible with openmm.unit.kilojoules_per_mole
             potential energy standard deviation if implemented, or else None
 
         """
@@ -2766,7 +2773,7 @@ class IdealGas(TestSystem):
 
         Returns
         -------
-        volume_mean : simtk.unit.Quantity compatible with simtk.unit.nanometers**3
+        volume_mean : openmm.unit.Quantity compatible with openmm.unit.nanometers**3
             The expectation of the volume at equilibrium.
 
         Notes
@@ -2793,7 +2800,7 @@ class IdealGas(TestSystem):
 
         Returns
         -------
-        volume_stddev : simtk.unit.Quantity compatible with simtk.unit.nanometers**3
+        volume_stddev : openmm.unit.Quantity compatible with openmm.unit.nanometers**3
             The standard deviation of the volume at equilibrium.
 
         Notes
@@ -2849,19 +2856,19 @@ class WaterBox(TestSystem):
         Parameters
         ----------
 
-        box_edge : simtk.unit.Quantity with units compatible with nanometers, optional, default = 2.5 nm
+        box_edge : openmm.unit.Quantity with units compatible with nanometers, optional, default = 2.5 nm
            Edge length for cubic box [should be greater than 2*cutoff]
-        cutoff : simtk.unit.Quantity with units compatible with nanometers, optional, default = DEFAULT_CUTOFF_DISTANCE
+        cutoff : openmm.unit.Quantity with units compatible with nanometers, optional, default = DEFAULT_CUTOFF_DISTANCE
            Nonbonded cutoff
         model : str, optional, default = 'tip3p'
            The name of the water model to use ['tip3p', 'tip4p', 'tip4pew', 'tip5p', 'spce']
-        switch_width : simtk.unit.Quantity with units compatible with nanometers, optional, default = DEFAULT_SWITCH_WIDTH
+        switch_width : openmm.unit.Quantity with units compatible with nanometers, optional, default = DEFAULT_SWITCH_WIDTH
            Sets the width of the switch function for Lennard-Jones.
         constrained : bool, optional, default=True
            Sets whether water geometry should be constrained (rigid water implemented via SETTLE) or flexible.
         dispersion_correction : bool, optional, default=True
            Sets whether the long-range dispersion correction should be used.
-        nonbondedMethod : simtk.openmm.app nonbonded method, optional, default=app.PME
+        nonbondedMethod : openmm.app nonbonded method, optional, default=app.PME
            Sets the nonbonded method to use for the water box (one of app.CutoffPeriodic, app.Ewald, app.PME).
         ewaldErrorTolerance : float, optional, default=DEFAULT_EWALD_ERROR_TOLERANCE
            The Ewald or PME tolerance.  Used only if nonbondedMethod is Ewald or PME.
@@ -2869,7 +2876,7 @@ class WaterBox(TestSystem):
             The positive ion to add (default is Na+).
         negative_ion : str, optional
             The negative ion to add (default is Cl-).
-        ionic_strength : simtk.unit.Quantity, optional
+        ionic_strength : openmm.unit.Quantity, optional
             The total concentration of ions (both positive and negative)
             to add (default is 0.0*molar).
 
@@ -3343,7 +3350,7 @@ class AlanineDipeptideVacuum(TestSystem):
 
     Parameters
     ----------
-    constraints : optional, default=simtk.openmm.app.HBonds
+    constraints : optional, default=openmm.app.HBonds
     hydrogenMass : unit, optional, default=None
         If set, will pass along a modified hydrogen mass for OpenMM to
         use mass repartitioning.
@@ -3413,7 +3420,7 @@ class AlanineDipeptideImplicit(TestSystem):
 
     Parameters
     ----------
-    constraints : optional, default=simtk.openmm.app.HBonds
+    constraints : optional, default=openmm.app.HBonds
     hydrogenMass : unit, optional, default=None
         If set, will pass along a modified hydrogen mass for OpenMM to
         use mass repartitioning.
@@ -3456,19 +3463,19 @@ class AlanineDipeptideExplicit(TestSystem):
 
     Parameters
     ----------
-    constraints : optional, default=simtk.openmm.app.HBonds
+    constraints : optional, default=openmm.app.HBonds
     rigid_water : bool, optional, default=True
     nonbondedCutoff : Quantity, optional, default=9.0 * unit.angstroms
     use_dispersion_correction : bool, optional, default=True
         If True, the long-range disperson correction will be used.
-    nonbondedMethod : simtk.openmm.app nonbonded method, optional, default=app.PME
+    nonbondedMethod : openmm.app nonbonded method, optional, default=app.PME
        Sets the nonbonded method to use for the water box (one of app.CutoffPeriodic, app.Ewald, app.PME).
     hydrogenMass : unit, optional, default=None
         If set, will pass along a modified hydrogen mass for OpenMM to
         use mass repartitioning.
-    cutoff : simtk.unit.Quantity with units compatible with angstroms, optional, default = DEFAULT_CUTOFF_DISTANCE
+    cutoff : openmm.unit.Quantity with units compatible with angstroms, optional, default = DEFAULT_CUTOFF_DISTANCE
         Cutoff distance
-    switch_width : simtk.unit.Quantity with units compatible with angstroms, optional, default = DEFAULT_SWITCH_WIDTH
+    switch_width : openmm.unit.Quantity with units compatible with angstroms, optional, default = DEFAULT_SWITCH_WIDTH
         switching function is turned on at cutoff - switch_width
         If None, no switch will be applied (e.g. hard cutoff).
     ewaldErrorTolerance : float, optional, default=DEFAULT_EWALD_ERROR_TOLERANCE
@@ -3524,7 +3531,7 @@ class TolueneVacuum(TestSystem):
 
     Parameters
     ----------
-    constraints : optional, default=simtk.openmm.app.HBonds
+    constraints : optional, default=openmm.app.HBonds
     hydrogenMass : unit, optional, default=None
         If set, will pass along a modified hydrogen mass for OpenMM to
         use mass repartitioning.
@@ -3566,7 +3573,7 @@ class TolueneImplicit(TestSystem):
 
     Parameters
     ----------
-    constraints : optional, default=simtk.openmm.app.HBonds
+    constraints : optional, default=openmm.app.HBonds
     hydrogenMass : unit, optional, default=None
         If set, will pass along a modified hydrogen mass for OpenMM to
         use mass repartitioning.
@@ -3582,7 +3589,7 @@ class TolueneImplicit(TestSystem):
     Use the OBC2 GB model (may have non-optimal parameters)
     >>> testsystem = TolueneImplicit(implicitSolvent=app.OBC2)
     Create a dict containing a version with each available GB model:
-    >>> testsystems = { name : TolueneImplicit(implicitSolvent=getattr(simtk.openmm.app, name)) for name in ['HCT', 'OBC1', 'OBC2', 'GBn', 'GBn2'] }
+    >>> testsystems = { name : TolueneImplicit(implicitSolvent=getattr(openmm.app, name)) for name in ['HCT', 'OBC1', 'OBC2', 'GBn', 'GBn2'] }
 
     """
 
@@ -3660,7 +3667,7 @@ class HostGuestVacuum(TestSystem, _HostGuestBase):
 
     Parameters
     ----------
-    constraints : optional, default=simtk.openmm.app.HBonds
+    constraints : optional, default=openmm.app.HBonds
     hydrogenMass : unit, optional, default=None
         If set, will pass along a modified hydrogen mass for OpenMM to
         use mass repartitioning.
@@ -3708,7 +3715,7 @@ class HostGuestImplicit(TestSystem, _HostGuestBase):
 
     Parameters
     ----------
-    constraints : optional, default=simtk.openmm.app.HBonds
+    constraints : optional, default=openmm.app.HBonds
     hydrogenMass : unit, optional, default=None
         If set, will pass along a modified hydrogen mass for OpenMM to
         use mass repartitioning.
@@ -3780,17 +3787,17 @@ class HostGuestExplicit(TestSystem, _HostGuestBase):
 
     Parameters
     ----------
-    constraints : optional, default=simtk.openmm.app.HBonds
+    constraints : optional, default=openmm.app.HBonds
     rigid_water : bool, optional, default=True
     nonbondedCutoff : Quantity, optional, default=DEFAULT_CUTOFF_DISTANCE
     use_dispersion_correction : bool, optional, default=True
         If True, the long-range disperson correction will be used.
-    nonbondedMethod : simtk.openmm.app nonbonded method, optional, default=app.PME
+    nonbondedMethod : openmm.app nonbonded method, optional, default=app.PME
        Sets the nonbonded method to use for the water box (one of app.CutoffPeriodic, app.Ewald, app.PME).
     hydrogenMass : unit, optional, default=None
         If set, will pass along a modified hydrogen mass for OpenMM to
         use mass repartitioning.
-    switch_width : simtk.unit.Quantity with units compatible with angstroms, optional, default=DEFAULT_SWITCH_WIDTH
+    switch_width : openmm.unit.Quantity with units compatible with angstroms, optional, default=DEFAULT_SWITCH_WIDTH
         switching function is turned on at cutoff - switch_width
         If None, no switch will be applied (e.g. hard cutoff).
     ewaldErrorTolerance : float, optional, default=DEFAULT_EWALD_ERROR_TOLERANCE
@@ -3854,17 +3861,17 @@ class DHFRExplicit(TestSystem):
 
     Parameters
     ----------
-    constraints : optional, default=simtk.openmm.app.HBonds
+    constraints : optional, default=openmm.app.HBonds
     rigid_water : bool, optional, default=True
     nonbondedCutoff : Quantity, optional, default=DEFAULT_CUTOFF_DISTANCE
     use_dispersion_correction : bool, optional, default=True
         If True, the long-range disperson correction will be used.
-    nonbondedMethod : simtk.openmm.app nonbonded method, optional, default=app.PME
+    nonbondedMethod : openmm.app nonbonded method, optional, default=app.PME
        Sets the nonbonded method to use for the water box (one of app.CutoffPeriodic, app.Ewald, app.PME).
     hydrogenMass : unit, optional, default=None
         If set, will pass along a modified hydrogen mass for OpenMM to
         use mass repartitioning.
-    switch_width : simtk.unit.Quantity with units compatible with angstroms, optional, default=DEFAULT_SWITCH_WIDTH
+    switch_width : openmm.unit.Quantity with units compatible with angstroms, optional, default=DEFAULT_SWITCH_WIDTH
         switching function is turned on at cutoff - switch_width
         If None, no switch will be applied (e.g. hard cutoff).
     ewaldErrorTolerance : float, optional, default=DEFAULT_EWALD_ERROR_TOLERANCE
@@ -3927,17 +3934,17 @@ class DNADodecamerExplicit(TestSystem):
 
     Parameters
     ----------
-    constraints : optional, default=simtk.openmm.app.HBonds
+    constraints : optional, default=openmm.app.HBonds
     rigid_water : bool, optional, default=True
     nonbondedCutoff : Quantity, optional, default=DEFAULT_CUTOFF_DISTANCE
     use_dispersion_correction : bool, optional, default=True
         If True, the long-range disperson correction will be used.
-    nonbondedMethod : simtk.openmm.app nonbonded method, optional, default=app.PME
+    nonbondedMethod : openmm.app nonbonded method, optional, default=app.PME
        Sets the nonbonded method to use for the water box (one of app.CutoffPeriodic, app.Ewald, app.PME).
     hydrogenMass : unit, optional, default=None
         If set, will pass along a modified hydrogen mass for OpenMM to
         use mass repartitioning.
-    switch_width : simtk.unit.Quantity with units compatible with angstroms, optional, default=DEFAULT_SWITCH_WIDTH
+    switch_width : openmm.unit.Quantity with units compatible with angstroms, optional, default=DEFAULT_SWITCH_WIDTH
         switching function is turned on at cutoff - switch_width
         If None, no switch will be applied (e.g. hard cutoff).
     ewaldErrorTolerance : float, optional, default=DEFAULT_EWALD_ERROR_TOLERANCE
@@ -3993,7 +4000,7 @@ class LysozymeImplicit(TestSystem):
 
     Parameters
     ----------
-    constraints : simtk.openmm.app constraints (None, HBonds, HAngles, AllBonds)
+    constraints : openmm.app constraints (None, HBonds, HAngles, AllBonds)
        constraints to be imposed
 
     Examples
@@ -4072,7 +4079,7 @@ class SrcExplicit(TestSystem):
 
     Parameters
     ----------
-    nonbondedMethod : simtk.openmm.app nonbonded method, optional, default=app.PME
+    nonbondedMethod : openmm.app nonbonded method, optional, default=app.PME
        Sets the nonbonded method to use for the water box (CutoffPeriodic, app.Ewald, app.PME).
 
     Examples
@@ -4143,7 +4150,7 @@ class MethanolBox(TestSystem):
     ----------
     shake : string, optional, default="h-bonds"
     nonbondedCutoff : Quantity, optional, default=7.0 * unit.angstroms
-    nonbondedMethod : simtk.openmm.app nonbonded method, optional, default=app.PME
+    nonbondedMethod : openmm.app nonbonded method, optional, default=app.PME
        Sets the nonbonded method to use for the water box (one of app.CutoffPeriodic, app.Ewald, app.PME).
 
     Examples
@@ -4188,7 +4195,7 @@ class MolecularIdealGas(TestSystem):
     ----------
     shake : string, optional, default=None
     nonbondedCutoff : Quantity, optional, default=7.0 * unit.angstroms
-    nonbondedMethod : simtk.openmm.app nonbonded method, optional, default=app.PME
+    nonbondedMethod : openmm.app nonbonded method, optional, default=app.PME
        Sets the nonbonded method to use for the water box (one of app.CutoffPeriodic, app.Ewald, app.PME).
 
     Examples
@@ -4451,11 +4458,11 @@ class LennardJonesPair(TestSystem):
 
     Parameters
     ----------
-    mass : simtk.unit.Quantity with units compatible with amu, optional, default=39.9*amu
+    mass : openmm.unit.Quantity with units compatible with amu, optional, default=39.9*amu
        The mass of each particle.
-    epsilon : simtk.unit.Quantity with units compatible with kilojoules_per_mole, optional, default=1.0*kilocalories_per_mole
+    epsilon : openmm.unit.Quantity with units compatible with kilojoules_per_mole, optional, default=1.0*kilocalories_per_mole
        The effective Lennard-Jones sigma parameter.
-    sigma : simtk.unit.Quantity with units compatible with nanometers, optional, default=3.350*angstroms
+    sigma : openmm.unit.Quantity with units compatible with nanometers, optional, default=3.350*angstroms
        The effective Lennard-Jones sigma parameter.
 
     Examples

--- a/openmmtools/utils.py
+++ b/openmmtools/utils.py
@@ -31,7 +31,11 @@ import contextlib
 import zlib
 
 import numpy as np
-from simtk import openmm, unit
+try:
+    import openmm
+    from openmm import unit
+except ImportError:  # OpenMM < 7.6
+    from simtk import openmm, unit
 
 logger = logging.getLogger(__name__)
 
@@ -383,7 +387,7 @@ class TrackedQuantityView(unit.Quantity):
 
 
 
-# List of simtk.unit methods that are actually units and functions instead of base classes
+# List of openmm.unit methods that are actually units and functions instead of base classes
 # Pre-computed to reduce run-time cost
 # Get the built-in units
 _VALID_UNITS = {method: getattr(unit, method) for method in dir(unit) if type(getattr(unit, method)) is unit.Unit}
@@ -397,9 +401,9 @@ def is_quantity_close(quantity1, quantity2, rtol=1e-10, atol=0.0):
 
     Parameters
     ----------
-    quantity1 : simtk.unit.Quantity
+    quantity1 : openmm.unit.Quantity
         The first quantity to compare.
-    quantity2 : simtk.unit.Quantity
+    quantity2 : openmm.unit.Quantity
         The second quantity to compare.
     rtol : float, optional
         Relative tolerance (default is 1e-10).
@@ -431,10 +435,10 @@ def is_quantity_close(quantity1, quantity2, rtol=1e-10, atol=0.0):
 
 
 def quantity_from_string(expression):
-    """Special call to the math_eval function designed to handle simtk.unit Quantity strings
+    """Special call to the math_eval function designed to handle openmm.unit Quantity strings
 
     All the functions in the standard module math are available together with
-    most of the methods inside the simtk.unit module.
+    most of the methods inside the openmm.unit module.
 
     Parameters
     ----------
@@ -457,7 +461,7 @@ def quantity_from_string(expression):
     # Supported functions, not defined in math.
     functions = _VALID_UNIT_FUNCTIONS
 
-    # Define the units from simtk.unit as the variables
+    # Define the units from openmm.unit as the variables
     variables = _VALID_UNITS
 
     # Eliminate nested quotes and excess whitespace
@@ -540,7 +544,10 @@ def platform_supports_precision(platform, precision):
         return precision in ['mixed']
 
     if platform.getName() in ['CUDA', 'OpenCL']:
-        from simtk import openmm
+        try:
+            import openmm
+        except ImportError:  # OpenMM < 7.6
+            from simtk import openmm
         properties = { 'Precision' : precision }
         system = openmm.System()
         system.addParticle(1.0) # Cannot create Context on a system with no particles
@@ -588,7 +595,7 @@ def get_fastest_platform(minimum_precision='mixed'):
 
     Returns
     -------
-    platform : simtk.openmm.Platform
+    platform : openmm.Platform
        The fastest available platform.
 
     """


### PR DESCRIPTION
## Description
importing OpenMMTools raises warinings about importing `openmm` from `simtk`, which make OpenPathSampling's notebook tests fail (unexpected warning in the stderr output) 

This updates all imports to the new standard.

I went through  `grep -r -n "simtk" --include="*.py" -l` and updated all references to `simtk`. For the doc-tests I decided to only include the current advised method of importing openmm. For all real code, I wrapped the new method in a try/except clause that drops back to the old style imports.


## Todos
- [X] Implement feature / fix bug
- [NA] Add [tests](https://github.com/choderalab/openmmtools/tree/master/openmmtools/tests)
- [NA] Update [documentation](https://github.com/choderalab/openmmtools/tree/master/docs) as needed
- [x] Update [changelog](https://github.com/choderalab/openmmtools/blob/master/docs/releasehistory.rst)Notable points that this PR has either accomplished or will accomplish.

## Status
- [x] Ready to go
