### PR TITLE
Try closing reporter in test for windows fix

### DIFF
--- a/openmmtools/tests/test_sampling.py
+++ b/openmmtools/tests/test_sampling.py
@@ -756,6 +756,9 @@ class TestMultiStateSampler(object):
             else:
                 assert not sampler._reporter.is_open()
 
+            # Ensure reporter is closed. Windows based system testing seems to get upset about this.
+            reporter.close()
+
             # Open reporter to read stored data.
             reporter = self.REPORTER(storage_path, open_mode='r', checkpoint_interval=1)
 


### PR DESCRIPTION
## Description

This PR attempts to fix the issue raised in #527. From what I can tell,
the tests where this is thrown always fails exactly at the same point.
This PR closes the reporter file formally before the failing line
occurs, so hopefully this will correctly allow Window's memory to
release the file.

## Todos
- [x] Implement feature / fix bug
- [x] Add [tests](https://github.com/choderalab/openmmtools/tree/master/openmmtools/tests)
- [x] Update [documentation](https://github.com/choderalab/openmmtools/tree/master/docs) as needed
- [ ] Update [changelog](https://github.com/choderalab/openmmtools/blob/master/docs/releasehistory.rst)Notable points that this PR has either accomplished or will accomplish.

## Status
- [x] Ready to go
