### PR TITLE
ContextCache usage cleanup

### DIFF
--- a/openmmtools/cache.py
+++ b/openmmtools/cache.py
@@ -481,6 +481,17 @@ class ContextCache(object):
             self._platform_properties = serialization["platform_properties"]
         self._lru = LRUCache(serialization['capacity'], serialization['time_to_live'])
 
+    def __eq__(self, other):
+        """Two ContextCache objects are equal if they have the same values in their public attributes."""
+        # Check types are compatible
+        if isinstance(other, ContextCache):
+            # Check all inner public attributes have the same values (excluding methods)
+            my_inner_attrs = [attr_ for attr_ in dir(self) if not attr_.startswith('_')
+                              and not callable(getattr(self, attr_))]
+            return all([getattr(self, attr) == getattr(other, attr) for attr in my_inner_attrs])
+        else:
+            return False
+
     # -------------------------------------------------------------------------
     # Internal usage
     # -------------------------------------------------------------------------

--- a/openmmtools/mcmc.py
+++ b/openmmtools/mcmc.py
@@ -148,7 +148,7 @@ class MCMCMove(SubhookedABCMeta):
     """
 
     @abc.abstractmethod
-    def apply(self, thermodynamic_state, sampler_state):
+    def apply(self, thermodynamic_state, sampler_state, context_cache):
         """Apply the MCMC move.
 
         Depending on the implementation, this can alter the thermodynamic
@@ -162,6 +162,7 @@ class MCMCMove(SubhookedABCMeta):
         sampler_state : openmmtools.states.SamplerState
            The initial sampler state before applying the move. This may
            be modified depending on the implementation.
+        context_cache : opemmtools.cache.ContextCache
 
         """
         pass
@@ -631,7 +632,7 @@ class BaseIntegratorMove(MCMCMove):
            The thermodynamic state to use to propagate dynamics.
         sampler_state : openmmtools.states.SamplerState
            The sampler state to apply the move to. This is modified.
-        context_cache : openmmtools.context.ContextCache
+        context_cache : openmmtools.cache.ContextCache
             context cache to be used during propagation with the integrator.
 
         See Also

--- a/openmmtools/mcmc.py
+++ b/openmmtools/mcmc.py
@@ -201,7 +201,7 @@ class MCMCMove(SubhookedABCMeta):
             context_cache = context_cache_input
         else:
             raise ValueError("Context cache input is not a valid ContextCache or None type.")
-        # update private attribute
+        # update private attribute - expected ONLY to be updated by this method!
         self._propagation_context_cache = context_cache
         return context_cache
 

--- a/openmmtools/mcmc.py
+++ b/openmmtools/mcmc.py
@@ -205,6 +205,20 @@ class MCMCMove(SubhookedABCMeta):
         self._propagation_context_cache = context_cache
         return context_cache
 
+    def __deepcopy__(self, memo):
+        """Overriding default deep copy behavior to avoid creating new ContextCache objects without need."""
+        if memo is None:
+            memo = {}
+
+        cls = self.__class__
+        new_state = cls.__new__(cls)
+        memo[id(self)] = new_state
+        for k, v in self.__dict__.items():
+            if k != 'context_cache':
+                new_state.__dict__[k] = copy.deepcopy(v, memo)
+        new_state.__dict__['context_cache'] = self.context_cache
+        return new_state
+
 
 # =============================================================================
 # MARKOV CHAIN MONTE CARLO SAMPLER

--- a/openmmtools/mcmc.py
+++ b/openmmtools/mcmc.py
@@ -359,7 +359,8 @@ class SequenceMove(MCMCMove):
     False
 
     """
-    def __init__(self, move_list):
+    def __init__(self, move_list, **kwargs):
+        super(SequenceMove, self).__init__(**kwargs)
         self.move_list = list(move_list)
 
     @property
@@ -445,7 +446,8 @@ class WeightedMove(MCMCMove):
     False
 
     """
-    def __init__(self, move_set):
+    def __init__(self, move_set, **kwargs):
+        super(WeightedMove, self).__init__(**kwargs)
         self.move_set = move_set
 
     @property
@@ -630,7 +632,8 @@ class BaseIntegratorMove(MCMCMove):
 
     """
 
-    def __init__(self, n_steps, reassign_velocities=False, n_restart_attempts=4):
+    def __init__(self, n_steps, reassign_velocities=False, n_restart_attempts=4, **kwargs):
+        super(BaseIntegratorMove, self).__init__(**kwargs)
         self.n_steps = n_steps
         self.reassign_velocities = reassign_velocities
         self.n_restart_attempts = n_restart_attempts
@@ -816,7 +819,8 @@ class MetropolizedMove(MCMCMove):
     1
 
     """
-    def __init__(self, atom_subset=None):
+    def __init__(self, atom_subset=None, **kwargs):
+        super(MetropolizedMove, self).__init__(**kwargs)
         self.n_accepted = 0
         self.n_proposed = 0
         self.atom_subset = atom_subset

--- a/openmmtools/mcmc.py
+++ b/openmmtools/mcmc.py
@@ -216,7 +216,9 @@ class MCMCMove(SubhookedABCMeta):
         for k, v in self.__dict__.items():
             if k != 'context_cache':
                 new_state.__dict__[k] = copy.deepcopy(v, memo)
-        new_state.__dict__['context_cache'] = self.context_cache
+        # TODO: This hacky conditional is needed when deserializing - no context_cache is serialized. Better way?
+        if hasattr(self, "context_cache"):
+            new_state.__dict__['context_cache'] = self.context_cache
         return new_state
 
 

--- a/openmmtools/mcmc.py
+++ b/openmmtools/mcmc.py
@@ -153,6 +153,8 @@ class MCMCMove(SubhookedABCMeta):
                            " apply() method as kwarg instead.")
         # hardcoding unused attribute to global context cache. For compatibility.
         self.context_cache = cache.global_context_cache
+        # private attribute for propagation context cache - useful for testing
+        self._propagation_context_cache = None
 
 
     @abc.abstractmethod
@@ -175,8 +177,7 @@ class MCMCMove(SubhookedABCMeta):
         """
         pass
 
-    @staticmethod
-    def _get_context_cache(context_cache_input):
+    def _get_context_cache(self, context_cache_input):
         """
         Method to return context to be used for move propagation.
 
@@ -200,6 +201,8 @@ class MCMCMove(SubhookedABCMeta):
             context_cache = context_cache_input
         else:
             raise ValueError("Context cache input is not a valid ContextCache or None type.")
+        # update private attribute
+        self._propagation_context_cache = context_cache
         return context_cache
 
 
@@ -421,7 +424,7 @@ class SequenceMove(MCMCMove):
         context_cache : opemmtools.cache.ContextCache, optional
 
         """
-        # Get context cache to be used and update attribute
+        # Get context cache to be used
         local_context_cache = self._get_context_cache(context_cache)
         for move in self.move_list:
             # Apply each move with the specified local context
@@ -515,7 +518,7 @@ class WeightedMove(MCMCMove):
         """
         moves, weights = zip(*self.move_set)
         move = np.random.choice(moves, p=weights)
-        # Get context cache to be used and update attribute
+        # Get context cache to be used
         local_context_cache = self._get_context_cache(context_cache)
         move.apply(thermodynamic_state, sampler_state, context_cache=local_context_cache)
 
@@ -697,7 +700,7 @@ class BaseIntegratorMove(MCMCMove):
         # Create integrator.
         integrator = self._get_integrator(thermodynamic_state)
 
-        # Get context cache and update attribute
+        # Get context cache
         local_context_cache = self._get_context_cache(context_cache)
 
         # Create context.
@@ -891,7 +894,7 @@ class MetropolizedMove(MCMCMove):
         benchmark_id = 'Applying {}'.format(self.__class__.__name__ )
         timer.start(benchmark_id)
 
-        # Get context cach and update attribute
+        # Get context cache
         local_context_cache = self._get_context_cache(context_cache)
 
         # TODO: Is this still needed now that we are specifying the context?

--- a/openmmtools/mcmc.py
+++ b/openmmtools/mcmc.py
@@ -150,8 +150,6 @@ class MCMCMove(SubhookedABCMeta):
         if context_cache is not None:
             logger.warning("Ignoring context_cache argument. The MCMCMove.context_cache field has been deprecated."
                            " The API now requires context_cache be passed to apply(). Please update your code.'")
-        # private attribute for propagation context cache - useful for testing
-        self._propagation_context_cache = None
 
     @abc.abstractmethod
     def apply(self, thermodynamic_state, sampler_state, context_cache=None):
@@ -198,14 +196,12 @@ class MCMCMove(SubhookedABCMeta):
             Context cache object to be used for propagation.
         """
         if context_cache_input is None:
-            # Default behavior, unlimited ContextCache
-            context_cache = cache.ContextCache(capacity=None, time_to_live=None)
+            # Default behavior, gobal Context Cache
+            context_cache = cache.global_context_cache
         elif isinstance(context_cache_input, cache.ContextCache):
             context_cache = context_cache_input
         else:
             raise ValueError("Context cache input is not a valid ContextCache or None type.")
-        # update private attribute - expected ONLY to be updated by this method!
-        self._propagation_context_cache = context_cache
         return context_cache
 
     def __deepcopy__(self, memo):

--- a/openmmtools/mcmc.py
+++ b/openmmtools/mcmc.py
@@ -167,7 +167,8 @@ class MCMCMove(SubhookedABCMeta):
            The initial sampler state before applying the move. This may
            be modified depending on the implementation.
         context_cache : opemmtools.cache.ContextCache
-
+            Context cache to be used in the propagation of the mcmc move. If None,
+            it will use the global context cache.
         """
         pass
 

--- a/openmmtools/mcmc.py
+++ b/openmmtools/mcmc.py
@@ -179,7 +179,8 @@ class MCMCMove(SubhookedABCMeta):
         from openmmtools import cache
         return cache.global_context_cache
 
-    def _get_context_cache(self, context_cache_input):
+    @staticmethod
+    def _get_context_cache(context_cache_input):
         """
         Method to return context to be used for move propagation.
 

--- a/openmmtools/mcmc.py
+++ b/openmmtools/mcmc.py
@@ -308,9 +308,6 @@ class SequenceMove(MCMCMove):
     ----------
     move_list : list-like of MCMCMove
         The sequence of MCMC moves to apply.
-    context_cache : openmmtools.cache.ContextCache, optional
-        If not None, the context_cache of all the moves in the sequence
-        will be set to this (default is None).
 
     Attributes
     ----------
@@ -396,9 +393,6 @@ class WeightedMove(MCMCMove):
     move_set : list of tuples (MCMCMove, float_
         Each tuple associate an MCMCMoves to its probability of being
         selected on apply().
-    context_cache : openmmtools.cache.ContextCache, optional
-        If not None, the context_cache of all the moves in the set will be
-        set to this (default is None).
 
     Attributes
     ----------
@@ -426,11 +420,8 @@ class WeightedMove(MCMCMove):
     False
 
     """
-    def __init__(self, move_set, context_cache=None):
+    def __init__(self, move_set):
         self.move_set = move_set
-        if context_cache is not None:
-            for move, weight in self.move_set:
-                move.context_cache = context_cache
 
     @property
     def statistics(self):
@@ -449,7 +440,7 @@ class WeightedMove(MCMCMove):
             if hasattr(move, 'statistics'):
                 move.statistics = value[i]
 
-    def apply(self, thermodynamic_state, sampler_state):
+    def apply(self, thermodynamic_state, sampler_state, context_cache):
         """Apply one of the MCMC moves in the set to the state.
 
         The probability that a move is picked is given by its weight.
@@ -460,11 +451,13 @@ class WeightedMove(MCMCMove):
            The thermodynamic state to use to propagate dynamics.
         sampler_state : openmmtools.states.SamplerState
            The sampler state to apply the move to.
+        context_cache : openmmtools.cache.ContextCache
+            The ContextCache to use for Context creation.
 
         """
         moves, weights = zip(*self.move_set)
         move = np.random.choice(moves, p=weights)
-        move.apply(thermodynamic_state, sampler_state)
+        move.apply(thermodynamic_state, sampler_state, context_cache)
 
     def __getstate__(self):
         serialized_moves = [utils.serialize(move) for move, _ in self.move_set]

--- a/openmmtools/mcmc.py
+++ b/openmmtools/mcmc.py
@@ -206,22 +206,6 @@ class MCMCMove(SubhookedABCMeta):
             raise ValueError("Context cache input is not a valid ContextCache or None type.")
         return context_cache
 
-    def __deepcopy__(self, memo):
-        """Overriding default deep copy behavior to avoid creating new ContextCache objects without need."""
-        if memo is None:
-            memo = {}
-
-        cls = self.__class__
-        new_state = cls.__new__(cls)
-        memo[id(self)] = new_state
-        for k, v in self.__dict__.items():
-            if k != 'context_cache':
-                new_state.__dict__[k] = copy.deepcopy(v, memo)
-        # TODO: This hacky conditional is needed when deserializing - no context_cache is serialized. Better way?
-        if hasattr(self, "context_cache"):
-            new_state.__dict__['context_cache'] = self.context_cache
-        return new_state
-
 
 # =============================================================================
 # MARKOV CHAIN MONTE CARLO SAMPLER

--- a/openmmtools/mcmc.py
+++ b/openmmtools/mcmc.py
@@ -339,11 +339,8 @@ class SequenceMove(MCMCMove):
     False
 
     """
-    def __init__(self, move_list, context_cache=None):
+    def __init__(self, move_list):
         self.move_list = list(move_list)
-        if context_cache is not None:
-            for move in self.move_list:
-                move.context_cache = context_cache
 
     @property
     def statistics(self):
@@ -362,7 +359,7 @@ class SequenceMove(MCMCMove):
             if hasattr(move, 'statistics'):
                 move.statistics = value[i]
 
-    def apply(self, thermodynamic_state, sampler_state):
+    def apply(self, thermodynamic_state, sampler_state, context_cache):
         """Apply the sequence of MCMC move in order.
 
         Parameters
@@ -374,7 +371,7 @@ class SequenceMove(MCMCMove):
 
         """
         for move in self.move_list:
-            move.apply(thermodynamic_state, sampler_state)
+            move.apply(thermodynamic_state, sampler_state, context_cache)
 
     def __str__(self):
         return str(self.move_list)

--- a/openmmtools/mcmc.py
+++ b/openmmtools/mcmc.py
@@ -148,14 +148,10 @@ class MCMCMove(SubhookedABCMeta):
     """
     def __init__(self, context_cache=None):
         if context_cache is not None:
-            logger.warning("Ignoring context_cache argument. Specifying context_cache on" 
-                           "initialization of an MCMCMove is deprecated; please pass to"
-                           " apply() method as kwarg instead.")
-        # hardcoding unused attribute to global context cache. For compatibility.
-        self.context_cache = cache.global_context_cache
+            logger.warning("Ignoring context_cache argument. The MCMCMove.context_cache field has been deprecated."
+                           " The API now requires context_cache be passed to apply(). Please update your code.'")
         # private attribute for propagation context cache - useful for testing
         self._propagation_context_cache = None
-
 
     @abc.abstractmethod
     def apply(self, thermodynamic_state, sampler_state, context_cache=None):
@@ -176,6 +172,13 @@ class MCMCMove(SubhookedABCMeta):
 
         """
         pass
+
+    @property
+    def context_cache(self):
+        logger.warning('The MCMCMove.context_cache field has been deprecated. The API now requires context_cache '
+                       'be passed to apply(). Please update your code.')
+        from openmmtools import cache
+        return cache.global_context_cache
 
     def _get_context_cache(self, context_cache_input):
         """

--- a/openmmtools/mcmc.py
+++ b/openmmtools/mcmc.py
@@ -150,7 +150,8 @@ class MCMCMove(SubhookedABCMeta):
         if context_cache is not None:
             logger.warning("Ignoring context_cache argument. Specifying context_cache on" 
                            "initialization of an MCMCMove is deprecated; please pass to"
-                           " apply() method instead")
+                           " apply() method as kwarg instead.")
+        self.context_cache = None  # hardcoding unused parameter to None. Kept for compatibility.
 
 
     @abc.abstractmethod
@@ -172,6 +173,33 @@ class MCMCMove(SubhookedABCMeta):
 
         """
         pass
+
+    @staticmethod
+    def _get_context_cache(self, context_cache_input):
+        """
+        Method to return context to be used for move propagation.
+
+        .. note:: centralized API point to deal with context cache behavior.
+
+        Parameters
+        ----------
+        context_cache_input : openmmtools.cache.ContextCache or None
+            Context cache to be used in the propagation of the mcmc move. If None,
+            it will create a new unlimited ContextCache object.
+
+        Returns
+        -------
+        context_cache : openmmtools.cache.ContextCache
+            Context cache object to be used for propagation.
+        """
+        if context_cache_input is None:
+            # Default behavior, unlimited ContextCache
+            context_cache = cache.ContextCache(capacity=None, time_to_live=None)
+        elif isinstance(context_cache_input, cache.ContextCache):
+            context_cache = context_cache_input
+        else:
+            raise ValueError("Context cache input is not a valid ContextCache or None type.")
+        return context_cache
 
 
 # =============================================================================

--- a/openmmtools/multistate/multistatesampler.py
+++ b/openmmtools/multistate/multistatesampler.py
@@ -195,8 +195,7 @@ class MultiStateSampler(object):
         self._have_displayed_citations_before = False
 
         # Initializing context cache attributes to global cache
-        self.energy_context_cache = cache.global_context_cache
-        self.sampler_context_cache = cache.global_context_cache
+        self.energy_context_cache, self.sampler_context_cache = cache.global_context_cache, cache.global_context_cache
 
         # Check convergence.
         if self.number_of_iterations == np.inf:
@@ -534,9 +533,9 @@ class MultiStateSampler(object):
         metadata : dict, optional, default=None
            Simulation metadata to be stored in the file.
         energy_context_cache : openmmtools.cache.ContextCache or None, optional, default None
-            Context cache to be used for energy computations. If None, a new fresh cache will be used.
+            Context cache to be used for energy computations. If None, global context cache will be used.
         sampler_context_cache : openmmtools.cache.ContextCache or None, optional, default None
-            Context cache to be used for move/integrator propagation. If None, a new fresh cache will be used.
+            Context cache to be used for move/integrator propagation. If None, global context cache will be used.
         """
         # Handle case in which storage is a string and not a Reporter object.
         self._reporter = self._reporter_from_storage(storage, check_exist=False)

--- a/openmmtools/multistate/multistatesampler.py
+++ b/openmmtools/multistate/multistatesampler.py
@@ -596,8 +596,8 @@ class MultiStateSampler(object):
         # The other nodes, only need the positions that they use for propagation and
         # computation of the energy matrix entries.
         minimized_positions, sampler_state_ids = mpiplus.distribute(self._minimize_replica, range(self.n_replicas),
-                                                                tolerance, max_iterations,
-                                                                send_results_to=0)
+                                                                    tolerance, max_iterations,
+                                                                    send_results_to=0)
 
         # Update all sampler states. For non-0 nodes, this will update only the
         # sampler states associated to the replicas propagated by this node.
@@ -1294,8 +1294,8 @@ class MultiStateSampler(object):
         # Use the FIRE minimizer
         integrator = FIREMinimizationIntegrator(tolerance=tolerance)
 
-        # Create context
-        context = thermodynamic_state.create_context(integrator)
+        # Get context and bound integrator from energy_context_cache
+        context, integrator = self._energy_context_cache.get_context(thermodynamic_state, integrator)
 
         # Set initial positions and box vectors.
         sampler_state.apply_to_context(context)
@@ -1329,7 +1329,7 @@ class MultiStateSampler(object):
         final_energy = thermodynamic_state.reduced_potential(sampler_state)
         logger.debug('Replica {}/{}: final energy {:8.3f}kT'.format(
             replica_id + 1, self.n_replicas, final_energy))
-	# TODO if energy > 0, use slower openmm minimizer
+        # TODO if energy > 0, use slower openmm minimizer
 
         # Clean up the integrator
         del context

--- a/openmmtools/multistate/multistatesampler.py
+++ b/openmmtools/multistate/multistatesampler.py
@@ -557,8 +557,8 @@ class MultiStateSampler(object):
                                initial_thermodynamic_states=initial_thermodynamic_states,
                                unsampled_thermodynamic_states=unsampled_thermodynamic_states,
                                metadata=metadata,
-                               energy_context_cache=None,
-                               sampler_context_cache=None)
+                               energy_context_cache=energy_context_cache,
+                               sampler_context_cache=sampler_context_cache)
 
         # Display papers to be cited.
         self._display_citations()

--- a/openmmtools/multistate/multistatesampler.py
+++ b/openmmtools/multistate/multistatesampler.py
@@ -1648,17 +1648,17 @@ class MultiStateSampler(object):
         raise RestorationError(message)
 
     @staticmethod
-    def _create_context_caches(energy_context_cache_input, propagation_context_cache_input):
+    def _create_context_caches(energy_context_cache=None, propagation_context_cache=None):
         """Handle energy and propagation context cache default behavior.
 
         .. note:: As of 01-Jan-22 default behavior is to use independent local caches.
 
         Parameters
         ----------
-        energy_context_cache_input : openmmtools.cache.ContextCache or None
+        energy_context_cache : openmmtools.cache.ContextCache or None
             Context cache to be used in energy computations. If None,
             it will create a new unlimited ContextCache object.
-        propagation_context_cache_input : openmmtools.cache.ContextCache or None
+        propagation_context_cache : openmmtools.cache.ContextCache or None
             Context cache to be used in the propagation of the mcmc moves. If None,
             it will create a new unlimited ContextCache object.
 
@@ -1670,19 +1670,19 @@ class MultiStateSampler(object):
             Context cache to be used in the propagation of the mcmc moves.
         """
         # Handling energy context cache
-        if energy_context_cache_input is None:
+        if energy_context_cache is None:
             # Default behavior, unlimited ContextCache
             energy_context_cache = cache.ContextCache(capacity=None, time_to_live=None)
-        elif isinstance(energy_context_cache_input, cache.ContextCache):
-            energy_context_cache = energy_context_cache_input
+        elif isinstance(energy_context_cache, cache.ContextCache):
+            energy_context_cache = energy_context_cache
         else:
             raise ValueError("Energy context cache input is not a valid ContextCache or None type.")
         # Handling propagation context cache
-        if propagation_context_cache_input is None:
+        if propagation_context_cache is None:
             # Default behavior, unlimited ContextCache
             propagation_context_cache = cache.ContextCache(capacity=None, time_to_live=None)
-        elif isinstance(propagation_context_cache_input, cache.ContextCache):
-            propagation_context_cache = propagation_context_cache_input
+        elif isinstance(propagation_context_cache, cache.ContextCache):
+            propagation_context_cache = propagation_context_cache
         else:
             raise ValueError("MCMC move context cache input is not a valid ContextCache or None type.")
         return energy_context_cache, propagation_context_cache

--- a/openmmtools/multistate/multistatesampler.py
+++ b/openmmtools/multistate/multistatesampler.py
@@ -1673,17 +1673,13 @@ class MultiStateSampler(object):
         if energy_context_cache is None:
             # Default behavior, unlimited ContextCache
             energy_context_cache = cache.ContextCache(capacity=None, time_to_live=None)
-        elif isinstance(energy_context_cache, cache.ContextCache):
-            energy_context_cache = energy_context_cache
-        else:
+        elif not isinstance(energy_context_cache, cache.ContextCache):
             raise ValueError("Energy context cache input is not a valid ContextCache or None type.")
         # Handling propagation context cache
         if propagation_context_cache is None:
             # Default behavior, unlimited ContextCache
             propagation_context_cache = cache.ContextCache(capacity=None, time_to_live=None)
-        elif isinstance(propagation_context_cache, cache.ContextCache):
-            propagation_context_cache = propagation_context_cache
-        else:
+        elif not isinstance(propagation_context_cache, cache.ContextCache):
             raise ValueError("MCMC move context cache input is not a valid ContextCache or None type.")
         return energy_context_cache, propagation_context_cache
 

--- a/openmmtools/multistate/sams.py
+++ b/openmmtools/multistate/sams.py
@@ -363,10 +363,8 @@ class SAMSSampler(multistate.MultiStateSampler):
         # Update log weights
         self._update_log_weights()
 
-    def _restore_sampler_from_reporter(self, reporter, energy_context_cache=None, propagation_context_cache=None):
-        super()._restore_sampler_from_reporter(reporter,
-                                               energy_context_cache=energy_context_cache,
-                                               propagation_context_cache=propagation_context_cache)
+    def _restore_sampler_from_reporter(self, reporter, **kwargs):
+        super()._restore_sampler_from_reporter(reporter, **kwargs)
         self._cached_state_histogram = self._compute_state_histogram(reporter=reporter)
         logger.debug('Restored state histogram: {}'.format(self._cached_state_histogram))
         data = reporter.read_online_analysis_data(self._iteration, 'logZ', 'stage', 't0')

--- a/openmmtools/multistate/sams.py
+++ b/openmmtools/multistate/sams.py
@@ -363,8 +363,10 @@ class SAMSSampler(multistate.MultiStateSampler):
         # Update log weights
         self._update_log_weights()
 
-    def _restore_sampler_from_reporter(self, reporter):
-        super()._restore_sampler_from_reporter(reporter)
+    def _restore_sampler_from_reporter(self, reporter, energy_context_cache=None, propagation_context_cache=None):
+        super()._restore_sampler_from_reporter(reporter,
+                                               energy_context_cache=energy_context_cache,
+                                               propagation_context_cache=propagation_context_cache)
         self._cached_state_histogram = self._compute_state_histogram(reporter=reporter)
         logger.debug('Restored state histogram: {}'.format(self._cached_state_histogram))
         data = reporter.read_online_analysis_data(self._iteration, 'logZ', 'stage', 't0')

--- a/openmmtools/tests/test_mcmc.py
+++ b/openmmtools/tests/test_mcmc.py
@@ -437,9 +437,10 @@ def test_move_restart():
     # We use a local context cache with Reference platform since on the
     # CPU platform CustomIntegrators raises an error with NaN particles.
     reference_platform = openmm.Platform.getPlatformByName('Reference')
-    move = MyMove(context_cache=cache.ContextCache(platform=reference_platform))
+    context_cache = cache.ContextCache(platform=reference_platform)
+    move = MyMove(context_cache=context_cache)
     with nose.tools.assert_raises(IntegratorMoveError) as cm:
-        move.apply(thermodynamic_state, sampler_state)
+        move.apply(thermodynamic_state, sampler_state, context_cache=context_cache)
 
     # We have counted the correct number of restart attempts.
     assert move.attempted_count == n_restart_attempts + 1

--- a/openmmtools/tests/test_mcmc.py
+++ b/openmmtools/tests/test_mcmc.py
@@ -326,6 +326,7 @@ def test_dummy_context_cache():
     assert len(cache.global_context_cache) == 0
 
 
+# TODO: This test might not be needed now that MCMCMove objs don't have context_cache attr
 def test_mcmc_move_context_cache_shallow_copy():
     """Test mcmc moves in different replicas use the same specified context_cache"""
     from openmmtools.utils import get_fastest_platform

--- a/openmmtools/tests/test_mcmc.py
+++ b/openmmtools/tests/test_mcmc.py
@@ -33,15 +33,15 @@ from openmmtools.mcmc import *
 # Test various combinations of systems and MCMC schemes
 analytical_testsystems = [
     ("HarmonicOscillator", testsystems.HarmonicOscillator(),
-        GHMCMove(timestep=10.0*unit.femtoseconds, n_steps=100)),
+     GHMCMove(timestep=10.0*unit.femtoseconds, n_steps=100)),
     ("HarmonicOscillator", testsystems.HarmonicOscillator(),
-        WeightedMove([(GHMCMove(timestep=10.0*unit.femtoseconds, n_steps=100), 0.5),
-                      (HMCMove(timestep=10*unit.femtosecond, n_steps=10), 0.5)])),
+     WeightedMove([(GHMCMove(timestep=10.0 * unit.femtoseconds, n_steps=100), 0.5),
+                   (HMCMove(timestep=10 * unit.femtosecond, n_steps=10), 0.5)])),
     ("HarmonicOscillatorArray", testsystems.HarmonicOscillatorArray(N=4),
-        LangevinDynamicsMove(timestep=10.0*unit.femtoseconds, n_steps=100)),
+     LangevinDynamicsMove(timestep=10.0*unit.femtoseconds, n_steps=100)),
     ("IdealGas", testsystems.IdealGas(nparticles=216),
-        SequenceMove([HMCMove(timestep=10*unit.femtosecond, n_steps=10),
-                      MonteCarloBarostatMove()]))
+     SequenceMove([HMCMove(timestep=10*unit.femtosecond, n_steps=10),
+                   MonteCarloBarostatMove()]))
     ]
 
 NSIGMA_CUTOFF = 6.0  # cutoff for significance testing

--- a/openmmtools/tests/test_mcmc.py
+++ b/openmmtools/tests/test_mcmc.py
@@ -215,8 +215,8 @@ def test_default_context_cache():
     # By default an independent local context cache is used
     move = SequenceMove([LangevinDynamicsMove(n_steps=5), GHMCMove(n_steps=5)])
     context_cache = move._get_context_cache(context_cache_input=None)  # get default context cache
-    # Assert the default context_cache is not the global one
-    assert context_cache is not cache.global_context_cache
+    # Assert the default context_cache is the global one
+    assert context_cache is cache.global_context_cache
 
 
 def test_default_context_cache_apply():
@@ -226,11 +226,12 @@ def test_default_context_cache_apply():
     thermodynamic_state = ThermodynamicState(testsystem.system, 300 * unit.kelvin)
 
     # By default the global context cache is used.
+    # emptying global cache - could be "dirty" from previous uses in other tests
+    global_cache = cache.global_context_cache
+    global_cache.empty()
     move = SequenceMove([LangevinDynamicsMove(n_steps=5), GHMCMove(n_steps=5)])
     # Apply move without specifying context_cache (default behavior)
     move.apply(thermodynamic_state, sampler_state)
-    # Make sure global context cache is used
-    global_cache = cache.global_context_cache
     assert len(global_cache) == 2, f"Context cache does not match dimensions."
 
 

--- a/openmmtools/tests/test_sampling.py
+++ b/openmmtools/tests/test_sampling.py
@@ -36,7 +36,6 @@ import mpiplus
 
 import openmmtools as mmtools
 from openmmtools import testsystems
-from openmmtools import cache
 from openmmtools.multistate import MultiStateReporter
 from openmmtools.multistate import MultiStateSampler, MultiStateSamplerAnalyzer
 from openmmtools.multistate import ReplicaExchangeSampler, ReplicaExchangeAnalyzer
@@ -946,23 +945,6 @@ class TestMultiStateSampler(object):
                         restored_value = restored_dict.pop(attr)
                         assert np.all(original_value == restored_value), '{}: {}\t{}'.format(
                             attr, original_value, restored_value)
-
-                # Check context caches have the same original attributes
-                for attr, original_value in list(original_dict.items()):
-                    if isinstance(original_value, cache.ContextCache):
-                        original_value = original_dict.pop(attr)
-                        restored_value = restored_dict.pop(attr)
-                        # Make sure they have the same public attributes (excluding methods)
-                        original_inner_attrs = [attr_ for attr_ in dir(original_value) if not attr_.startswith('_')
-                                                and not callable(getattr(original_value, attr_))]
-                        restored_inner_attrs = [attr_ for attr_ in dir(restored_value) if not attr_.startswith('_')
-                                                and not callable(getattr(original_value, attr_))]
-                        assert original_inner_attrs == restored_inner_attrs
-                        # Iterate over cache object attributes and check they have the same values
-                        for inner_attr in original_inner_attrs:
-                            original_inner_value = getattr(original_value, inner_attr)
-                            restored_inner_value = getattr(restored_value, inner_attr)
-                            assert original_inner_value == restored_inner_value
 
                 # Everything else should be a dict of builtins.
                 assert original_dict == restored_dict


### PR DESCRIPTION
## Description
Given that the `ContextCache` is a performance _trick_. It is better that it doesn't get serialized at all and that it is only used when the moves are applied or energies are computed. 

The `mcmc` module classes won't have a `context_cache` kwarg, instead the `apply` method for each will get fed the `context_cache` from the `multistatesampler` module objects.

This should tackle the memory issues when dealing with multiple replicas (fixes #536  ) and also work around the cycling issue (fixes #519 ). 

## Todos
- [x] Implement feature / fix bug
- [x] Add [tests](https://github.com/choderalab/openmmtools/tree/master/openmmtools/tests)
- [ ] Update [documentation](https://github.com/choderalab/openmmtools/tree/master/docs) as needed
- [ ] Update [changelog](https://github.com/choderalab/openmmtools/blob/master/docs/releasehistory.rst)Notable points that this PR has either accomplished or will accomplish.

## Status
- [x] Ready to go
