### PR TITLE
Add support for receptor dimers

### DIFF
--- a/openmmtools/tests/test_forcefactories.py
+++ b/openmmtools/tests/test_forcefactories.py
@@ -151,7 +151,7 @@ def test_restrain_atoms():
     restrain_atoms(thermodynamic_state, sampler_state, restrained_atoms)
 
     # Compute host center_of_geometry.
-    centroid = np.mean(sampler_state.positions[:126], axis=0)
+    centroid = np.mean(sampler_state.positions[restrained_atoms], axis=0)
     assert np.allclose(centroid, np.zeros(3))
 
 def test_replace_reaction_field():


### PR DESCRIPTION
## Description
Provide a brief description of the PR's purpose here.

I'm performing a simulation using Yank of a system in which the receptor is a dimer. This causes the following error to be thrown from openmmtools https://github.com/choderalab/openmmtools/blob/master/openmmtools/forcefactories.py#L152

The call site in Yank https://github.com/choderalab/yank/blob/master/Yank/experiment.py#L2504 passes in ALL of the carbon alpha and/or carbon atoms, i.e. from both chains. However, in openmmtools, the chains are treated separately and rejected.

The original justification for not supporting more than one chain is that, at the time, it caused issues with the Barostat: https://github.com/openmm/openmm/issues/1854 

It appears that the issue was fixed by https://github.com/choderalab/openmmtools/issues/310 

It also appears that removing support for more than one chain was only a temporary workaround, and that the workaround was simply never removed. Issue #1854 was created on 7/5/2017 and issue #310 was resolved on 11/24/2017. In between, the workaround was added to version 0.13.1 on 9/20/2017 and the fix was added to version 0.13.4 on 11/27/2017. It appears that the justification for the workaround got lost between these two separate tickets, and someone added the fix while thinking about issue #310 and didn’t think to remove the workaround due to issue #1854.

The fact that this feature could cause problems with Yank was identified in https://github.com/choderalab/openmmtools/pull/290. (In that issue, the two molecules were incorrectly identified as the ligand and a receptor monomer, but the failure of the single molecule check still remains for a receptor dimer.)

In light of #310, I suggest the single molecule check be removed.

## Todos
- [x] Implement feature / fix bug
- [x] Add [tests](https://github.com/choderalab/openmmtools/tree/master/openmmtools/tests)
- [x] Update [documentation](https://github.com/choderalab/openmmtools/tree/master/docs) as needed
- [ ] Update [changelog](https://github.com/choderalab/openmmtools/blob/master/docs/releasehistory.rst)Notable points that this PR has either accomplished or will accomplish.

## Status
- [x] Ready to go
