### PR TITLE
More streamlined context caches usage

### DIFF
--- a/docs/releasehistory.rst
+++ b/docs/releasehistory.rst
@@ -1,8 +1,13 @@
 Release History
 ***************
 
-0.2Y.Z - XXXXXX release
+0.21.1 - Bugfix release
 =======================
+
+Bugfixes
+--------
+- More streamlined context cache usage using instance attributes (`#547 <https://github.com/choderalab/openmmtools/pull/547>`_).
+- Improved docstring and examples for ``MultiStateSampler`` object.
 
 0.21.0 - Bugfix release
 =======================

--- a/openmmtools/multistate/multistatesampler.py
+++ b/openmmtools/multistate/multistatesampler.py
@@ -194,8 +194,8 @@ class MultiStateSampler(object):
 
         self._have_displayed_citations_before = False
 
-        # Initializing context cache attributes to global cache
-        self.energy_context_cache, self.sampler_context_cache = cache.global_context_cache, cache.global_context_cache
+        # Initializing context cache attributes
+        self._initialize_context_caches()
 
         # Check convergence.
         if self.number_of_iterations == np.inf:
@@ -207,7 +207,7 @@ class MultiStateSampler(object):
                                "specified maximum number of iterations!")
 
     @classmethod
-    def from_storage(cls, storage, energy_context_cache=None, propagation_context_cache=None):
+    def from_storage(cls, storage):
         """Constructor from an existing storage file.
 
         Parameters
@@ -216,12 +216,6 @@ class MultiStateSampler(object):
             If str: The path to the storage file.
             If :class:`Reporter`: uses the :class:`Reporter` options
             In the future this will be able to take a Storage class as well.
-
-        energy_context_cache : openmmtools.cache.ContextCache or None, optional, default None
-            Context cache to be used for energy computations. If None, a new fresh cache will be used.
-
-        propagation_context_cache : openmmtools.cache.ContextCache or None, optional, default None
-            Context cache to be used for move/integrator propagation. If None, a new fresh cache will be used.
 
         Returns
         -------
@@ -237,9 +231,7 @@ class MultiStateSampler(object):
             # Open the reporter to read the data.
             reporter.open(mode='r')
             sampler = cls._instantiate_sampler_from_reporter(reporter)
-            sampler._restore_sampler_from_reporter(reporter,
-                                                   energy_context_cache=energy_context_cache,
-                                                   propagation_context_cache=propagation_context_cache)
+            sampler._restore_sampler_from_reporter(reporter)
         finally:
             # Close reporter in reading mode.
             reporter.close()
@@ -247,7 +239,7 @@ class MultiStateSampler(object):
         # We open the reporter only in node 0 in append mode ready for use
         sampler._reporter = reporter
         mpiplus.run_single_node(0, sampler._reporter.open, mode='a',
-                            broadcast_result=False, sync_nodes=False)
+                                broadcast_result=False, sync_nodes=False)
         # Don't write the new last iteration, we have not technically
         # written anything yet, so there is no "junk".
         return sampler
@@ -491,7 +483,7 @@ class MultiStateSampler(object):
 
     def create(self, thermodynamic_states: list, sampler_states, storage,
                initial_thermodynamic_states=None, unsampled_thermodynamic_states=None,
-               metadata=None, energy_context_cache=None, sampler_context_cache=None):
+               metadata=None):
         """Create new multistate sampler simulation.
 
         Parameters
@@ -532,10 +524,6 @@ class MultiStateSampler(object):
             is None).
         metadata : dict, optional, default=None
            Simulation metadata to be stored in the file.
-        energy_context_cache : openmmtools.cache.ContextCache or None, optional, default None
-            Context cache to be used for energy computations. If None, global context cache will be used.
-        sampler_context_cache : openmmtools.cache.ContextCache or None, optional, default None
-            Context cache to be used for move/integrator propagation. If None, global context cache will be used.
         """
         # Handle case in which storage is a string and not a Reporter object.
         self._reporter = self._reporter_from_storage(storage, check_exist=False)
@@ -556,9 +544,7 @@ class MultiStateSampler(object):
         self._pre_write_create(thermodynamic_states, sampler_states, storage,
                                initial_thermodynamic_states=initial_thermodynamic_states,
                                unsampled_thermodynamic_states=unsampled_thermodynamic_states,
-                               metadata=metadata,
-                               energy_context_cache=energy_context_cache,
-                               sampler_context_cache=sampler_context_cache)
+                               metadata=metadata)
 
         # Display papers to be cited.
         self._display_citations()
@@ -769,9 +755,7 @@ class MultiStateSampler(object):
                           storage,
                           initial_thermodynamic_states=None,
                           unsampled_thermodynamic_states=None,
-                          metadata=None,
-                          energy_context_cache=None,
-                          sampler_context_cache=None):
+                          metadata=None,):
         """
         Internal function which allocates and sets up ALL variables prior to actually using them.
         This is helpful to ensure subclasses have all variables created prior to writing them out with
@@ -807,13 +791,6 @@ class MultiStateSampler(object):
         elif 'title' not in metadata:
             metadata['title'] = default_title
         self._metadata = metadata
-
-        # Handling context cache parameters and attributes
-        # update context caches attributes handling inputs
-        self.energy_context_cache, self.sampler_context_cache = self._initialize_context_caches(
-            energy_context_cache,
-            sampler_context_cache
-        )
 
         # Save thermodynamic states. This sets n_replicas.
         self._thermodynamic_states = copy.deepcopy(thermodynamic_states)
@@ -892,7 +869,7 @@ class MultiStateSampler(object):
         sampler._display_citations()
         return sampler
 
-    def _restore_sampler_from_reporter(self, reporter, energy_context_cache=None, propagation_context_cache=None):
+    def _restore_sampler_from_reporter(self, reporter):
         """
         (Re-)initialize the instanced sampler from the reporter. Intended to be called as the second half of a
         :func:`from_storage` method after the :class:`MultiStateSampler` has been instanced from disk.
@@ -978,12 +955,8 @@ class MultiStateSampler(object):
         self._last_mbar_f_k = last_mbar_f_k
         self._last_err_free_energy = last_err_free_energy
 
-        # Handle with context caches as specified
-        # update context caches attributes handling inputs
-        self.energy_context_cache, self.sampler_context_cache = self._initialize_context_caches(
-            energy_context_cache,
-            propagation_context_cache
-        )
+        # Initialize context caches
+        self._initialize_context_caches()
 
     def _check_nan_energy(self):
         """Checks that energies are finite and abort otherwise.
@@ -1652,41 +1625,16 @@ class MultiStateSampler(object):
 
         raise RestorationError(message)
 
-    @staticmethod
-    def _initialize_context_caches(energy_context_cache=None, propagation_context_cache=None):
+    def _initialize_context_caches(self):
         """Handle energy and propagation context cache default behavior.
 
+        Centralized API point where to initialize the context cache instance attributes.
+
         .. note:: As of 03-Feb-22 default behavior is to use the global cache.
-
-        Parameters
-        ----------
-        energy_context_cache : openmmtools.cache.ContextCache or None
-            Context cache to be used in energy computations. If None,
-            it will use the global context cache.
-        propagation_context_cache : openmmtools.cache.ContextCache or None
-            Context cache to be used in the propagation of the mcmc moves. If None,
-            it will use the global context cache.
-
-        Returns
-        -------
-        energy_context_cache : openmmtools.cache.ContextCache
-            Context cache to be used in energy computations.
-        propagation_context_cache : openmmtools.cache.ContextCache
-            Context cache to be used in the propagation of the mcmc moves.
         """
-        # Handling energy context cache
-        if energy_context_cache is None:
-            # Default behavior, global context cache
-            energy_context_cache = cache.global_context_cache
-        elif not isinstance(energy_context_cache, cache.ContextCache):
-            raise ValueError("Energy context cache input is not a valid ContextCache or None type.")
-        # Handling propagation context cache
-        if propagation_context_cache is None:
-            # Default behavior, global context cache
-            propagation_context_cache = cache.global_context_cache
-        elif not isinstance(propagation_context_cache, cache.ContextCache):
-            raise ValueError("MCMC move context cache input is not a valid ContextCache or None type.")
-        return energy_context_cache, propagation_context_cache
+        # Default is using global context cache
+        self.energy_context_cache = cache.global_context_cache
+        self.sampler_context_cache = cache.global_context_cache
 
     # -------------------------------------------------------------------------
     # Internal-usage: Test globals

--- a/openmmtools/multistate/paralleltempering.py
+++ b/openmmtools/multistate/paralleltempering.py
@@ -197,7 +197,7 @@ class ParallelTemperingSampler(ReplicaExchangeSampler):
         reference_thermodynamic_state = self._thermodynamic_states[0]
 
         # Get the context, any Integrator works.
-        context, integrator = cache.global_context_cache.get_context(reference_thermodynamic_state)
+        context, integrator = self.energy_context_cache.get_context(reference_thermodynamic_state)
 
         # Update positions and box vectors.
         sampler_state.apply_to_context(context)

--- a/openmmtools/tests/test_sampling.py
+++ b/openmmtools/tests/test_sampling.py
@@ -35,6 +35,7 @@ except ImportError:  # OpenMM < 7.6
 import mpiplus
 
 import openmmtools as mmtools
+from openmmtools import cache
 from openmmtools import testsystems
 from openmmtools.multistate import MultiStateReporter
 from openmmtools.multistate import MultiStateSampler, MultiStateSamplerAnalyzer
@@ -1441,6 +1442,58 @@ class TestMultiStateSampler(object):
             sampler.run()
             assert sampler._iteration < n_iterations
             assert sampler.is_completed
+
+    def test_context_cache_default(self):
+        """Test default behavior of context cache attributes."""
+        sampler = self.SAMPLER()
+        global_context_cache = cache.global_context_cache
+        # Default is to use global context cache for both context cache attributes
+        assert sampler.sampler_context_cache is global_context_cache
+        assert sampler.energy_context_cache is global_context_cache
+
+    def test_context_cache_energy_propagation(self):
+        """Test specifying different context caches for energy and propagation in a short simulation."""
+        thermodynamic_states, sampler_states, unsampled_states = copy.deepcopy(self.alanine_test)
+        n_replicas = len(sampler_states)
+        if n_replicas == 1:
+            # This test is intended for use with more than one replica
+            return
+
+        with self.temporary_storage_path() as storage_path:
+            # For this test to work, positions should be the same but
+            # translated, so that minimized positions should satisfy
+            # the same condition.
+            original_diffs = [np.average(sampler_states[i].positions - sampler_states[i + 1].positions)
+                              for i in range(n_replicas - 1)]
+            assert not np.allclose(original_diffs,
+                                   [0 for _ in range(n_replicas - 1)]), "sampler %s failed" % self.SAMPLER
+
+            # Create a replica exchange that propagates only 1 femtosecond
+            # per iteration so that positions won't change much.
+            move = mmtools.mcmc.IntegratorMove(openmm.VerletIntegrator(1.0 * unit.femtosecond), n_steps=1)
+            sampler = self.SAMPLER(mcmc_moves=move)
+            reporter = self.REPORTER(storage_path)
+            self.call_sampler_create(sampler, reporter,
+                                     thermodynamic_states, sampler_states,
+                                     unsampled_states)
+            # Set context cache attributes
+            sampler.energy_context_cache = cache.ContextCache(capacity=None, time_to_live=None)
+            sampler.sampler_context_cache = cache.ContextCache(capacity=None, time_to_live=None)
+            # Compute energies
+            sampler._compute_energies()
+            # Check only energy context cache has been accessed
+            assert sampler.energy_context_cache._lru._n_access == sampler.n_replicas
+            assert sampler.sampler_context_cache._lru._n_access == 0
+
+            # Propagate replicas
+            sampler._propagate_replicas()
+            # Check only propagation context cache has been accessed
+            assert sampler.energy_context_cache._lru._n_access == sampler.n_replicas
+            assert sampler.sampler_context_cache._lru._n_access == sampler.n_states
+
+            # Check that global context cache was never accessed/used
+            assert cache.global_context_cache._lru._n_access == 0
+
 
 
 #############


### PR DESCRIPTION
## Description
Context caches for propagation and energy computations are expected to be handled only via `MultiStateSampler` instance attributes. Default behavior is to use global cache. If users want to avoid cycling they are expected to specify different context caches via the instance attributes.

Since we are not serializing context cache information, resuming simulations requires users to specify context cache attributes upon resuming.

Resolves #546 

## Todos
- [x] Implement feature / fix bug
- [x] Add [tests](https://github.com/choderalab/openmmtools/tree/master/openmmtools/tests)
- [x] Update [documentation](https://github.com/choderalab/openmmtools/tree/master/docs) as needed
- [x] Update [changelog](https://github.com/choderalab/openmmtools/blob/master/docs/releasehistory.rst)Notable points that this PR has either accomplished or will accomplish.

## Status
- [x] Ready to go
