### PR TITLE
Add replica exchange attempts during equilibration phase

### DIFF
--- a/openmmtools/multistate/multistatesampler.py
+++ b/openmmtools/multistate/multistatesampler.py
@@ -643,6 +643,9 @@ class MultiStateSampler(object):
             logger.debug("Equilibration iteration {}/{}".format(iteration, n_iterations))
             timer.start('Equilibration Iteration')
 
+            # NOTE: Unlike run(), do NOT increment iteration counter.
+            # self._iteration += 1
+
             # Propagate replicas.
             self._propagate_replicas()
 

--- a/openmmtools/multistate/multistatesampler.py
+++ b/openmmtools/multistate/multistatesampler.py
@@ -642,7 +642,15 @@ class MultiStateSampler(object):
         for iteration in range(1, 1 + n_iterations):
             logger.debug("Equilibration iteration {}/{}".format(iteration, n_iterations))
             timer.start('Equilibration Iteration')
+
+            # Propagate replicas.
             self._propagate_replicas()
+
+            # Compute energies of all replicas at all states
+            self._compute_energies()
+
+            # Update thermodynamic states
+            self._mix_replicas()
 
             # Computing timing information
             iteration_time = timer.stop('Equilibration Iteration')

--- a/openmmtools/multistate/multistatesampler.py
+++ b/openmmtools/multistate/multistatesampler.py
@@ -633,12 +633,35 @@ class MultiStateSampler(object):
             raise RuntimeError('The number of MCMCMoves ({}) and ThermodynamicStates ({}) for equilibration'
                                ' must be the same.'.format(len(self._mcmc_moves), self.n_states))
 
+        timer = utils.Timer()
+        timer.start('Run Equilibration')
+
         # Temporarily set the equilibration MCMCMoves.
         production_mcmc_moves = self._mcmc_moves
         self._mcmc_moves = mcmc_moves
-        for iteration in range(n_iterations):
+        for iteration in range(1, 1 + n_iterations):
             logger.debug("Equilibration iteration {}/{}".format(iteration, n_iterations))
+            timer.start('Equilibration Iteration')
             self._propagate_replicas()
+
+            # Computing timing information
+            iteration_time = timer.stop('Equilibration Iteration')
+            partial_total_time = timer.partial('Run Equilibration')
+            time_per_iteration = partial_total_time / iteration
+            estimated_time_remaining = time_per_iteration * (n_iterations - iteration)
+            estimated_total_time = time_per_iteration * n_iterations
+            estimated_finish_time = time.time() + estimated_time_remaining
+            # TODO: Transmit timing information
+
+            # Show timing statistics if debug level is activated.
+            if logger.isEnabledFor(logging.DEBUG):
+                logger.debug("Iteration took {:.3f}s.".format(iteration_time))
+                if estimated_time_remaining != float('inf'):
+                    logger.debug("Estimated completion (of equilibration only) in {}, at {} (consuming total wall clock time {}).".format(
+                        str(datetime.timedelta(seconds=estimated_time_remaining)),
+                        time.ctime(estimated_finish_time),
+                        str(datetime.timedelta(seconds=estimated_total_time))))
+        timer.report_timing()
 
         # Restore production MCMCMoves.
         self._mcmc_moves = production_mcmc_moves

--- a/openmmtools/multistate/sams.py
+++ b/openmmtools/multistate/sams.py
@@ -426,11 +426,13 @@ class SAMSSampler(multistate.MultiStateSampler):
         logger.debug("Accepted {}/{} attempted swaps ({:.1f}%)".format(n_swaps_accepted, n_swaps_proposed,
                                                                        swap_fraction_accepted * 100.0))
 
-        # Update logZ estimates
-        self._update_logZ_estimates(replicas_log_P_k)
+        # Do not update and/or write to disk during equilibration
+        if self._iteration > 0:
+            # Update logZ estimates
+            self._update_logZ_estimates(replicas_log_P_k)
 
-        # Update log weights based on target probabilities
-        self._update_log_weights()
+            # Update log weights based on target probabilities
+            self._update_log_weights()
 
     def _local_jump(self, replicas_log_P_k):
         n_replica, n_states, locality = self.n_replicas, self.n_states, self.locality

--- a/openmmtools/tests/test_sampling.py
+++ b/openmmtools/tests/test_sampling.py
@@ -1177,8 +1177,8 @@ class TestMultiStateSampler(object):
             if len(node_replica_ids) == n_replicas:
                 reporter = self.REPORTER(storage_path, open_mode='r', checkpoint_interval=1)
                 stored_sampler_states = reporter.read_sampler_states(iteration=0)
-                for new_state, stored_state in zip(sampler._sampler_states, stored_sampler_states):
-                    assert np.allclose(new_state.positions, stored_state.positions)
+                for stored_state in stored_sampler_states:
+                    assert any([np.allclose(new_state.positions, stored_state.positions) for new_state in sampler._sampler_states])
 
             # We are still at iteration 0.
             assert sampler._iteration == 0


### PR DESCRIPTION
## Description
The equilibration protocol currently propagates replicas only; it does not perform replica exchange. As such, it is equilibrating w.r.t. an (alchemically-indexed) family of independent canonical ensembles, rather than the grand canonical ensemble. This PR makes the equilibration loop identical to the main replica exchange loop, excluding disk IO.

Failing to equilibrate w.r.t. the same ensemble can cause transient errors in the free energies of the replicas in the soft-core asymptote region, which manifests as cryptic normalization errors with pymbar, i.e. https://github.com/choderalab/yank/issues?q=W_nk

Note that in https://github.com/choderalab/yank/blob/master/Yank/reports/YANK_Health_Report_Template.ipynb, 2 out of 3 of the free energy call sites take the discard_from_start parameter, however report.generate_free_energy() uses all of the data written to the netcdf file and thus triggers the error anyway. The only way to emulate the discard_from_start parameter for this third call site is to simply not write the bad initial equilibration data to disk in the first place, i.e. to perform equilibration w.r.t. the grand canonical ensemble.

Also note that https://github.com/choderalab/pymbar/issues/419 claims that the normalization error is due to a change in the numerical solver in pymbar. While that may be part of the problem, I think the fundamental issue is feeding bad data to the solver: if you comment out report.generate_free_energy() and increase discard_from_start (to about 5-10), the norm of the weights will rapidly approach 1 until pymbar successfully runs.

Alternatively, using this PR and setting number_of_equilibration_iterations to 5-10 in Yank, you can keep discard_from_start=1 and avoid the normalization error, even when default_number_of_iterations is arbitrarily small.

## Todos
- [ ] Implement feature / fix bug
- [ ] Add [tests](https://github.com/choderalab/openmmtools/tree/master/openmmtools/tests)
- [ ] Update [documentation](https://github.com/choderalab/openmmtools/tree/master/docs) as needed
- [ ] Update [changelog](https://github.com/choderalab/openmmtools/blob/master/docs/releasehistory.rst)Notable points that this PR has either accomplished or will accomplish.

## Status
- [ ] Ready to go
