### PR TITLE
Enhance stability of minimization

### DIFF
--- a/openmmtools/multistate/multistatesampler.py
+++ b/openmmtools/multistate/multistatesampler.py
@@ -50,6 +50,7 @@ from openmmtools.multistate.utils import SimulationNaNError
 from openmmtools.multistate.pymbar import ParameterError
 
 from openmmtools.integrators import FIREMinimizationIntegrator, GradientDescentMinimizationIntegrator
+from openmmtools.utils import get_fastest_platform
 
 logger = logging.getLogger(__name__)
 
@@ -1366,7 +1367,12 @@ class MultiStateSampler(object):
 
         # Use Gradient Descent first for numerical stability
         integrator_grad = GradientDescentMinimizationIntegrator()
-        context_grad = thermodynamic_state.create_context(integrator_grad)
+        # platform = self.energy_context_cache.platform # This is None, causes:
+        # "ValueError: To set platform_properties, you need to also specify the platform."
+        platform = get_fastest_platform(minimum_precision='mixed')
+        if 'Precision' in platform.getPropertyNames():
+            platform.setPropertyDefaultValue('Precision', 'mixed')
+        context_grad = thermodynamic_state.create_context(integrator_grad, platform)
         # Initialize sampler_state.potential_energy using a context
         sampler_state.apply_to_context(context_grad)
         sampler_state.update_from_context(context_grad)

--- a/openmmtools/multistate/multistatesampler.py
+++ b/openmmtools/multistate/multistatesampler.py
@@ -1366,7 +1366,11 @@ class MultiStateSampler(object):
         thermodynamic_state.pressure = None
 
         # Use Gradient Descent first for numerical stability
-        integrator_grad = GradientDescentMinimizationIntegrator()
+        # This initial step size is 10 times smaller than the default, but
+        # 1. the goal here is stability, not convergence rate and
+        # 2. the step size is adaptive, so it should quickly increase anyway.
+        initial_step_size = 0.001 * unit.angstroms
+        integrator_grad = GradientDescentMinimizationIntegrator(initial_step_size)
         # platform = self.energy_context_cache.platform # This is None, causes:
         # "ValueError: To set platform_properties, you need to also specify the platform."
         platform = get_fastest_platform(minimum_precision='mixed')

--- a/openmmtools/multistate/multistatesampler.py
+++ b/openmmtools/multistate/multistatesampler.py
@@ -49,7 +49,7 @@ import mpiplus
 from openmmtools.multistate.utils import SimulationNaNError
 from openmmtools.multistate.pymbar import ParameterError
 
-from openmmtools.integrators import FIREMinimizationIntegrator
+from openmmtools.integrators import FIREMinimizationIntegrator, GradientDescentMinimizationIntegrator
 
 logger = logging.getLogger(__name__)
 
@@ -1354,12 +1354,46 @@ class MultiStateSampler(object):
         thermodynamic_state_id = self._replica_thermodynamic_states[replica_id]
         thermodynamic_state = self._thermodynamic_states[thermodynamic_state_id]
         sampler_state = self._sampler_states[replica_id]
+        # NOTE: At this point, sampler_state.potential_energy is None. Initialize below.
+
+        logger.debug('Sampler state {}/{}:'.format(replica_id + 1, self.n_replicas))
 
         # Temporarily disable the barostat during minimization by setting the
         # pressure to None. (Otherwise, the minimizer will modify the box
         # vectors and may cause instabilities which are very difficult to debug.)
         pressure = thermodynamic_state.pressure
         thermodynamic_state.pressure = None
+
+        # Use Gradient Descent first for numerical stability
+        integrator_grad = GradientDescentMinimizationIntegrator()
+        context_grad = thermodynamic_state.create_context(integrator_grad)
+        # Initialize sampler_state.potential_energy using a context
+        sampler_state.apply_to_context(context_grad)
+        sampler_state.update_from_context(context_grad)
+
+        # Compute the energy of the system for logging.
+        energy = thermodynamic_state.reduced_potential(sampler_state)
+        volume = sampler_state.volume.value_in_unit(unit.nanometer**3)
+        bv = sampler_state.box_vectors
+        [bxx, byy, bzz] = [v.value_in_unit(unit.nanometer) for v in [bv[0][0], bv[1][1], bv[2][2]]]
+        logger.debug('energy {:8.3f}kT box_volume {:6.4f}nm**3 bxx {:2.4f}nm  byy {:2.4f}nm  bzz {:2.4f}nm'.format(
+            energy, volume, bxx, byy, bzz))
+
+        # If pressure is not None, use one timestep less than the barostat
+        # frequency so we absolutely do not apply any barostat moves.
+        bar_freq = thermodynamic_state.barostat.getFrequency() - 1 if thermodynamic_state.pressure is not None else 25 - 1
+        logger.debug('Using Gradient Descent: num_iterations {}'.format(bar_freq))
+        integrator_grad.step(bar_freq)
+        sampler_state.update_from_context(context_grad)
+        del context_grad
+
+        # Compute the energy of the system for logging.
+        energy = thermodynamic_state.reduced_potential(sampler_state)
+        volume = sampler_state.volume.value_in_unit(unit.nanometer**3)
+        bv = sampler_state.box_vectors
+        [bxx, byy, bzz] = [v.value_in_unit(unit.nanometer) for v in [bv[0][0], bv[1][1], bv[2][2]]]
+        logger.debug('energy {:8.3f}kT box_volume {:6.4f}nm**3 bxx {:2.4f}nm  byy {:2.4f}nm  bzz {:2.4f}nm'.format(
+            energy, volume, bxx, byy, bzz))
 
         # Use the FIRE minimizer
         integrator = FIREMinimizationIntegrator(tolerance=tolerance)
@@ -1371,11 +1405,6 @@ class MultiStateSampler(object):
 
         # Set initial positions and box vectors.
         sampler_state.apply_to_context(context)
-
-        # Compute the initial energy of the system for logging.
-        initial_energy = thermodynamic_state.reduced_potential(context)
-        logger.debug('Replica {}/{}: initial energy {:8.3f}kT'.format(
-            replica_id + 1, self.n_replicas, initial_energy))
 
         # Minimize energy.
         try:
@@ -1400,10 +1429,13 @@ class MultiStateSampler(object):
         # Get the minimized positions.
         sampler_state.update_from_context(context)
 
-        # Compute the final energy of the system for logging.
-        final_energy = thermodynamic_state.reduced_potential(sampler_state)
-        logger.debug('Replica {}/{}: final energy {:8.3f}kT'.format(
-            replica_id + 1, self.n_replicas, final_energy))
+        # Compute the energy of the system for logging.
+        energy = thermodynamic_state.reduced_potential(sampler_state)
+        volume = sampler_state.volume.value_in_unit(unit.nanometer**3)
+        bv = sampler_state.box_vectors
+        [bxx, byy, bzz] = [v.value_in_unit(unit.nanometer) for v in [bv[0][0], bv[1][1], bv[2][2]]]
+        logger.debug('energy {:8.3f}kT box_volume {:6.4f}nm**3 bxx {:2.4f}nm  byy {:2.4f}nm  bzz {:2.4f}nm'.format(
+            energy, volume, bxx, byy, bzz))
         # TODO if energy > 0, use slower openmm minimizer
 
         # Clean up the integrator


### PR DESCRIPTION
## Description
I have been experiencing some instabilities which, after much difficulty, I was able to track down to the minimizer. The observed behavior is that the minimizer will finish 'successfully', but some time later, during equilibration and/or propagating replicas, the simulation may or may not randomly crash with NaNs or even throw CUDA_ERROR_ILLEGAL_ADDRESS (700).

Nearly identical behavior can be found here https://github.com/openmm/openmm/issues/3414. In that ticket, the issue was that the box vectors were not being updated correctly. For stability, during minimization the box vectors should not be allowed to change at all. Subsequent equilibration at NPT should be used to adjust the box vectors.

In my case(s), the box vectors were changing only at the fourth significant figure, and yet that was sufficient to (usually) crash the simulations. Inserting Gradient Descent before FIRE seems to greatly ameliorate but not completely eliminate the instabilities. Replacing FIRE with L-BFGS (with or without Gradient Descent) also seems to fix the instabilities.

This PR adds three changes to improve the stability of minimization:

1. First and foremost, it temporarily disables the barostat during minimization to keep the box vectors fixed. This is probably the only change that is absolutely necessary to fix the instabilities.
2. It inserts a very short (24 timestep) Gradient Descent minimization before the main FIRE minimization. Gradient Descent is not asymptotically fast, but it is excellent for preconditioning a 'better' minimizer.
3. I have replaced FIRE with L-BFGS. Unlike FIRE, L-BFGS does not modify the box vectors (even when the pressure is not None) and it's a fine minimizer anyway.

## Todos
- [ ] Implement feature / fix bug
- [ ] Add [tests](https://github.com/choderalab/openmmtools/tree/master/openmmtools/tests)
- [ ] Update [documentation](https://github.com/choderalab/openmmtools/tree/master/docs) as needed
- [ ] Update [changelog](https://github.com/choderalab/openmmtools/blob/master/docs/releasehistory.rst)Notable points that this PR has either accomplished or will accomplish.

## Status
- [ ] Ready to go
