### PR TITLE
Returning and broadcasting _replica_thermodynamic_states

### DIFF
--- a/openmmtools/multistate/multistatesampler.py
+++ b/openmmtools/multistate/multistatesampler.py
@@ -760,7 +760,7 @@ class MultiStateSampler(object):
             timer.start('Iteration')
 
             # Update thermodynamic states
-            self._mix_replicas()
+            self._replica_thermodynamic_states = self._mix_replicas()
 
             # Propagate replicas.
             self._propagate_replicas()

--- a/openmmtools/multistate/replicaexchange.py
+++ b/openmmtools/multistate/replicaexchange.py
@@ -290,6 +290,7 @@ class ReplicaExchangeSampler(multistate.MultiStateSampler):
             swap_fraction_accepted = float(n_swaps_accepted) / n_swaps_proposed
         logger.debug("Accepted {}/{} attempted swaps ({:.1f}%)".format(n_swaps_accepted, n_swaps_proposed,
                                                                        swap_fraction_accepted * 100.0))
+        return self._replica_thermodynamic_states
 
     @staticmethod
     @njit


### PR DESCRIPTION
## Description
Fixes #449 by ensuring that `_mix_replicas` returns the `_replica_thermodynamic_states`. Also broadcasting it to the MPI context, according to [mpiplus broadcasting](https://github.com/choderalab/mpiplus/blob/216f1328d40f71e6554d909d470b6fe3104fde68/mpiplus/mpiplus.py#L226)

## Todos
- [ ] Implement feature / fix bug
- [ ] Add [tests](https://github.com/choderalab/openmmtools/tree/master/openmmtools/tests)
- [ ] Update [documentation](https://github.com/choderalab/openmmtools/tree/master/docs) as needed
- [ ] Update [changelog](https://github.com/choderalab/openmmtools/blob/master/docs/releasehistory.rst)Notable points that this PR has either accomplished or will accomplish.

## Status
- [x] Ready to go
