### PR TITLE
Real time analysis dynamic naming from reporter

### DIFF
--- a/openmmtools/multistate/multistateanalyzer.py
+++ b/openmmtools/multistate/multistateanalyzer.py
@@ -1035,9 +1035,9 @@ class PhaseAnalyzer(ABC):
         Parameters
         ----------
         energy_matrix : array of numpy.float64, optional, default=None
-           Reduced potential energies of the replicas; if None, will be extracted from the ncfile
+           Reduced potential energies of the replicas.
         samples_per_state : array of ints, optional, default=None
-           Number of samples drawn from each kth state; if None, will be extracted from the ncfile
+           Number of samples drawn from each kth state.
 
         """
         # Initialize MBAR (computing free energy estimates, which may take a while)
@@ -2131,6 +2131,10 @@ class MultiStateSamplerAnalyzer(PhaseAnalyzer):
 
     @mbar.default
     def mbar(self, instance):
+        # u_ln[l,n] is the reduced potential for concatenated decorrelated snapshot n evaluated at thermodynamic state l
+        # Shape is (n_states + n_unsampled_states, n_samples)
+        # N_l[l] is the number of decorrelated samples sampled from thermodynamic state l, some can be 0.
+        # Shape is (n_states + n_unsampled_states, )
         return instance._create_mbar(instance._unbiased_decorrelated_u_ln,
                                      instance._unbiased_decorrelated_N_l)
 

--- a/openmmtools/multistate/multistatereporter.py
+++ b/openmmtools/multistate/multistatereporter.py
@@ -1323,8 +1323,10 @@ class MultiStateReporter(object):
         data: dict
             Dictionary with the key, value pairs to store in YAML format.
         """
-        reporter_dir, _ = os.path.split(self._storage_analysis_file_path)
-        output_filepath = f"{reporter_dir}/real_time_analysis.yaml"
+        reporter_dir, reporter_filename = os.path.split(self._storage_analysis_file_path)
+        # remove extension from filename
+        yaml_prefix = os.path.splitext(reporter_filename)[0]
+        output_filepath = f"{reporter_dir}/{yaml_prefix}_real_time_analysis.yaml"
         # Remove if it is a fresh reporter session
         if self._overwrite_statistics:
             try:

--- a/openmmtools/tests/test_sampling.py
+++ b/openmmtools/tests/test_sampling.py
@@ -1506,8 +1506,11 @@ class TestMultiStateSampler(object):
             # Run
             sampler.run()
             # load file and check number of iterations
-            storage_dir, _ = os.path.split(sampler._reporter._storage_analysis_file_path)
-            with open(f"{storage_dir}/real_time_analysis.yaml") as yaml_file:
+            storage_dir, reporter_filename = os.path.split(sampler._reporter._storage_analysis_file_path)
+            # remove extension from filename
+            yaml_prefix = os.path.splitext(reporter_filename)[0]
+            output_filepath = f"{storage_dir}/{yaml_prefix}_real_time_analysis.yaml"
+            with open(f"{storage_dir}/{yaml_prefix}_real_time_analysis.yaml") as yaml_file:
                 yaml_contents = yaml.safe_load(yaml_file)
             # Make sure we get the correct number of entries
             assert len(yaml_contents) == expected_yaml_entries, \


### PR DESCRIPTION
## Description
Fixes naming convention for new real time analysis yaml file. It uses the reporter filename as a prefix, dynamically. Solves #564 

## Todos
- [x] Implement feature / fix bug

## Status
- [ ] Ready to go
