### PR TITLE
DOC - Adding example when resuming simulation in docstring

### DIFF
--- a/openmmtools/multistate/multistatesampler.py
+++ b/openmmtools/multistate/multistatesampler.py
@@ -184,6 +184,7 @@ class MultiStateSampler(object):
     >>> simulation = HybridRepexSampler.from_storage(reporter)
     >>> simulation.energy_context_cache = cache.ContextCache(capacity=None, time_to_live=None, platform=platform)
     >>> simulation.sampler_context_cache = cache.ContextCache(capacity=None, time_to_live=None, platform=platform)
+    >>> simulation.extend(n_iterations=1)
     """
 
     # -------------------------------------------------------------------------

--- a/openmmtools/multistate/multistatesampler.py
+++ b/openmmtools/multistate/multistatesampler.py
@@ -176,6 +176,14 @@ class MultiStateSampler(object):
 
     Run the simulation
     >>> simulation.run()
+
+    Note that to avoid the repex cycling problem upon resuming a simulation, make sure to specify do the optional
+    energy and sampler context caches.
+
+    >>> reporter = MultiStateReporter(reporter_file, checkpoint_interval=10)
+    >>> simulation = HybridRepexSampler.from_storage(reporter)
+    >>> simulation.energy_context_cache = cache.ContextCache(capacity=None, time_to_live=None, platform=platform)
+    >>> simulation.sampler_context_cache = cache.ContextCache(capacity=None, time_to_live=None, platform=platform)
     """
 
     # -------------------------------------------------------------------------


### PR DESCRIPTION
## Description
Adds an example in the docstring when resuming the simulation.

## Todos
- [NA] Implement feature / fix bug
- [NA] Add [tests](https://github.com/choderalab/openmmtools/tree/master/openmmtools/tests)
- [x] Update [documentation](https://github.com/choderalab/openmmtools/tree/master/docs) as needed
- [NA] Update [changelog](https://github.com/choderalab/openmmtools/blob/master/docs/releasehistory.rst)Notable points that this PR has either accomplished or will accomplish.

## Status
- [x] Ready to go
