### PR TITLE
Add basic available gpu information in debug log.

### DIFF
--- a/openmmtools/multistate/multistatesampler.py
+++ b/openmmtools/multistate/multistatesampler.py
@@ -1754,7 +1754,7 @@ class MultiStateSampler(object):
 
     @staticmethod
     def _display_cuda_devices():
-        """Query system nvidia-smi to get avaliable GPUs indices and names in debug log."""
+        """Query system nvidia-smi to get available GPUs indices and names in debug log."""
         # Read nvidia-smi query, should return empty strip if no GPU is found.
         cuda_query_output = os.popen("nvidia-smi --query-gpu=index,gpu_name --format=csv,noheader").read().strip()
         # Split by line jump and comma

--- a/openmmtools/multistate/multistatesampler.py
+++ b/openmmtools/multistate/multistatesampler.py
@@ -190,6 +190,9 @@ class MultiStateSampler(object):
         # Warn that API is experimental
         logger.warn('Warning: The openmmtools.multistate API is experimental and may change in future releases')
 
+        # Display cuda device in debug log
+        self._display_cuda_devices()
+
         # These will be set on initialization. See function
         # create() for explanation of single variables.
         self._thermodynamic_states = None
@@ -1748,6 +1751,15 @@ class MultiStateSampler(object):
             current_simulated_time = 0.0 * unit.nanosecond  # Hardcoding to 0 ns
         performance = current_simulated_time.in_units_of(unit.nanosecond) / (partial_total_time / 86400)
         self._timing_data["ns_per_day"] = performance.value_in_unit(unit.nanosecond)
+
+    @staticmethod
+    def _display_cuda_devices():
+        """Query system nvidia-smi to get avaliable GPUs indices and names in debug log."""
+        # Read nvidia-smi query, should return empty strip if no GPU is found.
+        cuda_query_output = os.popen("nvidia-smi --query-gpu=index,gpu_name --format=csv,noheader").read().strip()
+        # Split by line jump and comma
+        cuda_devices_list = [entry.split(',') for entry in cuda_query_output.split('\n')]
+        logger.debug(f"CUDA devices available: {*cuda_devices_list,}")
 
     # -------------------------------------------------------------------------
     # Internal-usage: Test globals


### PR DESCRIPTION
## Description
Adds available GPUs information to debug log by querying nvidia-smi.

Resolves #563 

## Todos
- [x] Implement feature / fix bug
- [NA] Add [tests](https://github.com/choderalab/openmmtools/tree/master/openmmtools/tests)
- [NA] Update [documentation](https://github.com/choderalab/openmmtools/tree/master/docs) as needed
- [ ] Update [changelog](https://github.com/choderalab/openmmtools/blob/master/docs/releasehistory.rst)Notable points that this PR has either accomplished or will accomplish.

## Status
- [ ] Ready to go
