### PR TITLE
Force statistical inefficiency computation to use self.max_n_iterations 

### DIFF
--- a/docs/releasehistory.rst
+++ b/docs/releasehistory.rst
@@ -1,6 +1,14 @@
 Release History
 ***************
 
+0.21.4 - Bugfix release
+=======================
+
+Bugfixes
+--------
+- Bug in statistical inefficiency computation -- where self.max_n_iterations wasn't being used -- was fixed (`#577 <https://github.com/choderalab/openmmtools/pull/577>`_).
+
+
 0.21.3 - Bugfix release
 =======================
 

--- a/openmmtools/multistate/multistateanalyzer.py
+++ b/openmmtools/multistate/multistateanalyzer.py
@@ -1262,7 +1262,7 @@ class MultiStateSamplerAnalyzer(PhaseAnalyzer):
         # Compute state index statistical inefficiency of stationary data.
         # states[n][k] is the state index of replica k at iteration n, but
         # the functions wants a list of timeseries states[k][n].
-        states_kn = np.transpose(states[number_equilibrated:])
+        states_kn = np.transpose(states[number_equilibrated:self.max_n_iterations - 1])
         g = timeseries.statisticalInefficiencyMultiple(states_kn)
 
         return self._MixingStatistics(transition_matrix=t_ij, eigenvalues=mu,

--- a/openmmtools/multistate/multistateanalyzer.py
+++ b/openmmtools/multistate/multistateanalyzer.py
@@ -1262,7 +1262,7 @@ class MultiStateSamplerAnalyzer(PhaseAnalyzer):
         # Compute state index statistical inefficiency of stationary data.
         # states[n][k] is the state index of replica k at iteration n, but
         # the functions wants a list of timeseries states[k][n].
-        states_kn = np.transpose(states[number_equilibrated:self.max_n_iterations - 1])
+        states_kn = np.transpose(states[number_equilibrated:self.max_n_iterations,])
         g = timeseries.statisticalInefficiencyMultiple(states_kn)
 
         return self._MixingStatistics(transition_matrix=t_ij, eigenvalues=mu,


### PR DESCRIPTION
## Description
I noticed that in `MultiStateAnalyzer.generate_mixing_statistics()`, `self.max_n_iterations` is used to generate the transition matrix and compute the perron eigenvalue, but it's not used to compute the statistical inefficiency. This PR supplies `self.max_n_iterations` to the statistical inefficiency computation, so that the whole function is consistent (in terms of iterations used) in the mixing statistics it outputs.

## Todos
- [x] Implement feature / fix bug
- [ ] Add [tests](https://github.com/choderalab/openmmtools/tree/master/openmmtools/tests)
- [ ] Update [documentation](https://github.com/choderalab/openmmtools/tree/master/docs) as needed
- [ ] Update [changelog](https://github.com/choderalab/openmmtools/blob/master/docs/releasehistory.rst)Notable points that this PR has either accomplished or will accomplish.

## Status
- [ ] Ready to go
