### PR TITLE
Allow override t0 and g_t when computing free energy

### DIFF
--- a/openmmtools/multistate/multistateanalyzer.py
+++ b/openmmtools/multistate/multistateanalyzer.py
@@ -1442,11 +1442,18 @@ class MultiStateSamplerAnalyzer(PhaseAnalyzer):
         logger.debug("Done.")
         return u_n
 
-    def _compute_mbar_decorrelated_energies(self):
+    def _compute_mbar_decorrelated_energies(self, t0=None, subsample_rate=None):
         """Return an MBAR-ready decorrelated energy matrix.
 
         The data is returned after discarding equilibration and truncating
         the iterations to self.max_n_iterations.
+        
+        Parameters
+        ---------- 
+        t0 : int, optional
+            the number of equilibrated iterations to override number_equilibrated
+        subsample_rate : int, optional
+            the subsample rate to override g_t
 
         Returns
         -------
@@ -1464,6 +1471,8 @@ class MultiStateSamplerAnalyzer(PhaseAnalyzer):
         # Use the cached information to generate the equilibration data.
         sampled_energy_matrix, unsampled_energy_matrix, neighborhoods, replicas_state_indices = energy_data
         number_equilibrated, g_t, Neff_max = self._get_equilibration_data(sampled_energy_matrix, neighborhoods, replicas_state_indices)
+        number_equilibrated = t0 if t0 is not None else number_equilibrated
+        g_t = subsample_rate if subsample_rate is not None else g_t
 
         logger.debug("Assembling uncorrelated energies...")
 


### PR DESCRIPTION
## Description
The `MultiStateAnalyzer` automatically determines t0 and g_t [here](https://github.com/choderalab/openmmtools/blob/0771ddc36f9a7d4cb183cafe3b95bbd1988fd048/openmmtools/multistate/multistateanalyzer.py#L1466). 

I have discovered that for my barnase:barstar repex simulations, t0 is always 1, which is too small. I'd like to be able to manually feed in t0 (and g_t) before retrieving the free energy.

This PR allows overriding t0 and g_t in the following way:
```python
# Given a reporter, create an analyzer
analyzer = MultiStateSamplerAnalyzer(reporter, max_n_iterations=max_n_iterations)

# Override t0 and g_t
t0 = 1000
subsample_rate = 10
decorrelated_u_ln, decorrelated_N_l = analyzer._compute_mbar_decorrelated_energies(t0=t0, subsample_rate=subsample_rate)

# Compute free energy
f_ij, df_ij = analyzer.get_free_energy()
```

## Todos
- [ ] Implement feature / fix bug
- [ ] Add [tests](https://github.com/choderalab/openmmtools/tree/master/openmmtools/tests)
- [ ] Update [documentation](https://github.com/choderalab/openmmtools/tree/master/docs) as needed
- [ ] Update [changelog](https://github.com/choderalab/openmmtools/blob/master/docs/releasehistory.rst)Notable points that this PR has either accomplished or will accomplish.

## Status
- [ ] Ready to go
