### PR TITLE
Add changelog entry spot to checklist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,7 +5,12 @@ Provide a brief description of the PR's purpose here.
 - [ ] Implement feature / fix bug
 - [ ] Add [tests](https://github.com/choderalab/openmmtools/tree/master/openmmtools/tests)
 - [ ] Update [documentation](https://github.com/choderalab/openmmtools/tree/master/docs) as needed
-- [ ] Update [changelog](https://github.com/choderalab/openmmtools/blob/master/docs/releasehistory.rst)Notable points that this PR has either accomplished or will accomplish.
 
 ## Status
 - [ ] Ready to go
+
+## Changelog entry
+See [changelog](https://github.com/choderalab/openmmtools/blob/master/docs/releasehistory.rst) for examples
+```
+
+```


### PR DESCRIPTION
I think adding (and making sure we are happy with) the changelog entry as part of the template will:
1) Improve the quality of the change log entry, since that can be reviewed at commit time between the person who submitted the PR and the reviewers
1) Prevent annoying [changelog](https://github.com/choderalab/openmmtools/blob/master/docs/releasehistory.rst) that happen when PRs all try and edit the same line in the change log.

Then at release time (we should make a release PR template) the person doing the release can copy and paste everything into the changelog on github as well as the changelog we ship with the code.

Does this sound good @jchodera ? 