### PR TITLE
Handling unsampled states in offline/realtime analysis.

### DIFF
--- a/docs/releasehistory.rst
+++ b/docs/releasehistory.rst
@@ -8,6 +8,7 @@ Bugfixes
 --------
 - Bug in statistical inefficiency computation -- where self.max_n_iterations wasn't being used -- was fixed (`#577 <https://github.com/choderalab/openmmtools/pull/577>`_).
 - Bug in estimated performance in realtime yaml file -- fixed by iterating through all MCMC moves (`#578 <https://github.com/choderalab/openmmtools/pull/578>`_)
+- Bug in handling unsampled states in realtime/offline analysis -- fixed by using ``MultiStateSampler._unsampled_states`` to build the mbar estimate array. Issue `#592 <https://github.com/choderalab/openmmtools/issues/592>`_ (`#593 <https://github.com/choderalab/openmmtools/pull/593>`_)
 
 
 0.21.3 - Bugfix release


### PR DESCRIPTION
## Description
This aims to refactor `MultiStateSampler._offline_analysis` to handle unsampled states when doing the mbar estimate.

In this case the `_offline_analysis` method was decoupled from the `_online_analisis` one (which is still experimental). So that it initializes the first time with zeros as guess and subsequent results are updated  using the previous calculation.

For this I had to make a new private attribute `_last_mbar_f_k_offline` which gets also written to the nc file independently of the attributes used in the `_online_analysis` method.

Resolves #592 

## Todos
- [x] Implement feature / fix bug
- [n/a] Add [tests](https://github.com/choderalab/openmmtools/tree/master/openmmtools/tests)
- [ ] Update [documentation](https://github.com/choderalab/openmmtools/tree/master/docs) as needed
- [x] Update [changelog](https://github.com/choderalab/openmmtools/blob/master/docs/releasehistory.rst)Notable points that this PR has either accomplished or will accomplish.

## Status
- [ ] Ready to go
