### PR TITLE
Building path using `os` library instead of f-strings for real time analysis

### DIFF
--- a/openmmtools/multistate/multistatereporter.py
+++ b/openmmtools/multistate/multistatereporter.py
@@ -1330,7 +1330,7 @@ class MultiStateReporter(object):
         reporter_dir, reporter_filename = os.path.split(self._storage_analysis_file_path)
         # remove extension from filename
         yaml_prefix = os.path.splitext(reporter_filename)[0]
-        output_filepath = f"{reporter_dir}/{yaml_prefix}_real_time_analysis.yaml"
+        output_filepath = os.path.join(reporter_dir, f"{yaml_prefix}_real_time_analysis.yaml")
         # Remove if it is a fresh reporter session
         if self._overwrite_statistics:
             try:

--- a/openmmtools/tests/test_sampling.py
+++ b/openmmtools/tests/test_sampling.py
@@ -1577,8 +1577,8 @@ class TestMultiStateSampler(object):
             storage_dir, reporter_filename = os.path.split(sampler._reporter._storage_analysis_file_path)
             # remove extension from filename
             yaml_prefix = os.path.splitext(reporter_filename)[0]
-            output_filepath = f"{storage_dir}/{yaml_prefix}_real_time_analysis.yaml"
-            with open(f"{storage_dir}/{yaml_prefix}_real_time_analysis.yaml") as yaml_file:
+            output_filepath = os.path.join(storage_dir, f"{yaml_prefix}_real_time_analysis.yaml")
+            with open(output_filepath) as yaml_file:
                 yaml_contents = yaml.safe_load(yaml_file)
             # Make sure we get the correct number of entries
             assert len(yaml_contents) == expected_yaml_entries, \


### PR DESCRIPTION
## Description

Resolves #615 by using the `os.path.join` method instead of relying on manually introduced f-strings.

## Todos
- [x] Implement feature / fix bug
- [ ] Add [tests](https://github.com/choderalab/openmmtools/tree/master/openmmtools/tests)
- [ ] Update [changelog](https://github.com/choderalab/openmmtools/blob/master/docs/releasehistory.rst) to summarize changes in behavior, enhancements, and bugfixes implemented in this PR

## Status
- [ ] Ready to go

## Changelog 
```
Bug in generating real time analysis output when reporter is in the same working directory. Fixed by using ``os.path.join`` for creating the output path.
```