### PR TITLE
Not using zlib for varying length variables when storing in NetCDF

### DIFF
--- a/openmmtools/multistate/multistatereporter.py
+++ b/openmmtools/multistate/multistatereporter.py
@@ -1810,7 +1810,7 @@ class MultiStateReporter(object):
                 dimension_name = 'scalar'
             # Create variable.
             nc_variable = storage_nc.createVariable(path, variable_type,
-                                                    dimension_name, zlib=True)
+                                                    dimension_name, zlib=False)
 
         # Assign the value to the variable.
         if fixed_dimension:


### PR DESCRIPTION
## Description

With newer NetCDF versions there is a problem with using `zlib=True` when storing variables with varying length. More info at https://github.com/Unidata/netcdf4-python/issues/1175

## Todos
- [x] Implement feature / fix bug
- [ ] Add [tests](https://github.com/choderalab/openmmtools/tree/master/openmmtools/tests)
- [ ] Update [documentation](https://github.com/choderalab/openmmtools/tree/master/docs) as needed
- [ ] Update [changelog](https://github.com/choderalab/openmmtools/blob/master/docs/releasehistory.rst) to summarize changes in behavior, enhancements, and bugfixes implemented in this PR

## Status
- [x] Ready to go

## Changelog message
```
Support for newer NetCDF versions (>1.5.8) by not using zlib compression for varying length variables.
```