### PR TITLE
Avoid expecting a fixed index/order in forces -- Fix windows tests

### DIFF
--- a/openmmtools/tests/test_integrators.py
+++ b/openmmtools/tests/test_integrators.py
@@ -520,7 +520,13 @@ class TestExternalPerturbationLangevinIntegrator(TestCase):
             omm_force.setParticleParameters(2, charge=0.417, sigma=0, epsilon=1)
             omm_force.updateParametersInContext(omm_context)
 
-        force = wbox.system.getForce(2)  # Non-bonded force.
+        # Get Nonbonded force from system -- Note: order may vary by platform. Don't expect a specific index.
+        for force in wbox.system.getForces():
+            if isinstance(force, openmm.NonbondedForce):
+                nonbonded_force = force
+                break
+        else:
+            raise ValueError("No nonbonded force found in the system.")
 
         # Number of NCMC steps
         nsteps = 20
@@ -533,14 +539,14 @@ class TestExternalPerturbationLangevinIntegrator(TestCase):
             for step in range(nsteps):
                 fraction = float(step + 1) / float(nsteps)
                 initial_energy = context.getState(getEnergy=True).getPotentialEnergy()
-                switchoff(force, context, frac=fraction)
+                switchoff(nonbonded_force, context, frac=fraction)
                 final_energy = context.getState(getEnergy=True).getPotentialEnergy()
                 external_protocol_work += (final_energy - initial_energy) / kT
                 integrator.step(1)
             integrator_protocol_work = integrator.get_protocol_work(dimensionless=True)
             assert abs(external_protocol_work - integrator_protocol_work) < 1.E-5
             # Return to unperturbed state
-            switchon(force, context)
+            switchon(nonbonded_force, context)
 
 
     def test_protocol_work_accumulation_harmonic_oscillator(self):

--- a/openmmtools/tests/test_integrators.py
+++ b/openmmtools/tests/test_integrators.py
@@ -508,17 +508,17 @@ class TestExternalPerturbationLangevinIntegrator(TestCase):
         context.setPositions(wbox.positions)
         context.setVelocitiesToTemperature(temperature)
 
-        def switchoff(force, context, frac=0.9):
-            force.setParticleParameters(0, charge=-0.834 * frac, sigma=0.3150752406575124*frac, epsilon=0.635968 * frac)
-            force.setParticleParameters(1, charge=0.417 * frac, sigma=0, epsilon=1 * frac)
-            force.setParticleParameters(2, charge=0.417 * frac, sigma=0, epsilon=1 * frac)
-            force.updateParametersInContext(context)
+        def switchoff(omm_force, omm_context, frac=0.9):
+            omm_force.setParticleParameters(0, charge=-0.834 * frac, sigma=0.3150752406575124 * frac, epsilon=0.635968 * frac)
+            omm_force.setParticleParameters(1, charge=0.417 * frac, sigma=0, epsilon=1 * frac)
+            omm_force.setParticleParameters(2, charge=0.417 * frac, sigma=0, epsilon=1 * frac)
+            omm_force.updateParametersInContext(omm_context)
 
-        def switchon(force, context):
-            force.setParticleParameters(0, charge=-0.834, sigma=0.3150752406575124, epsilon=0.635968)
-            force.setParticleParameters(1, charge=0.417, sigma=0, epsilon=1)
-            force.setParticleParameters(2, charge=0.417, sigma=0, epsilon=1)
-            force.updateParametersInContext(context)
+        def switchon(omm_force, omm_context):
+            omm_force.setParticleParameters(0, charge=-0.834, sigma=0.3150752406575124, epsilon=0.635968)
+            omm_force.setParticleParameters(1, charge=0.417, sigma=0, epsilon=1)
+            omm_force.setParticleParameters(2, charge=0.417, sigma=0, epsilon=1)
+            omm_force.updateParametersInContext(omm_context)
 
         force = wbox.system.getForce(2)  # Non-bonded force.
 


### PR DESCRIPTION
## Description
These changes avoid shadowing the variable names from the outer scope and hopefully will be fixing the failing CI workflow for windows with Openmm8, for example in https://github.com/choderalab/openmmtools/actions/runs/4409361691/jobs/7725555141#step:7:3200

## Todos
- [x] Implement feature / fix bug
- [ ] Add [tests](https://github.com/choderalab/openmmtools/tree/master/openmmtools/tests)
- [ ] Update [documentation](https://github.com/choderalab/openmmtools/tree/master/docs) as needed
- [ ] Update [changelog](https://github.com/choderalab/openmmtools/blob/master/docs/releasehistory.rst) to summarize changes in behavior, enhancements, and bugfixes implemented in this PR

## Status
- [ ] Ready to go
