### PR TITLE
Improve docstring for `analysis_particle_indices` in `MultiStateReporter`

### DIFF
--- a/openmmtools/multistate/multistatereporter.py
+++ b/openmmtools/multistate/multistatereporter.py
@@ -97,8 +97,8 @@ class MultiStateReporter(object):
         The reporter internally tracks what data goes into which file, so its transparent to all other classes
         In the future, this will be able to take Storage classes as well
     analysis_particle_indices : tuple of ints, Optional. Default: () (empty tuple)
-        Indices of particles which should be treated as special when manipulating read and write functions.
-        If this is an empty tuple, then no particles are treated as special
+        If specified, it will serialize positions and velocities for the specified particles, at every iteration, in the
+        reporter storage (.nc) file. If empty, no positions or velocities will be stored in this file for any atoms.
 
     Attributes
     ----------

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,15 +1,13 @@
-conda:
-  file: devtools/conda-envs/test_env.yaml
+version: 2
 
-# The default for requirements_file is null, but for some reason we get an error with this message if it's not set:
-# "Problem parsing YAML configuration. Invalid "requirements_file": path docs/requirements.txt does not exist"
-requirements_file: null
+conda:
+  environment: devtools/conda-envs/test_env.yaml
 
 build:
-  image: latest
+  os: ubuntu-22.04
   tools:
     python: mambaforge-4.10
 
-python:
-  version: 3.6
-  setup_py_install: true
+sphinx:
+   configuration: docs/conf.py
+   fail_on_warning: true

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -10,4 +10,4 @@ build:
 
 sphinx:
    configuration: docs/conf.py
-   fail_on_warning: true
+   fail_on_warning: false


### PR DESCRIPTION
## Description
This improve the documentation of the `analysis_particle_indices` parameter in `MultiStateReporter`.

Resolves #641 
Resolves #638 

It also makes changes for using an up to date version of the sphinx/RTD infrastructure.

## Todos
- [x] Implement feature / fix bug
- [ ] Add [tests](https://github.com/choderalab/openmmtools/tree/master/openmmtools/tests)
- [ ] Update [documentation](https://github.com/choderalab/openmmtools/tree/master/docs) as needed
- [ ] Update [changelog](https://github.com/choderalab/openmmtools/blob/master/docs/releasehistory.rst) to summarize changes in behavior, enhancements, and bugfixes implemented in this PR

## Status
- [ ] Ready to go

## Changelog message
```
Improved documentation for ``analysis_particle_indices`` parameter in ``MultiStateReporter``.
```