### PR TITLE
Fix NaN-catching text in MultiStateSampler

### DIFF
--- a/openmmtools/multistate/multistatesampler.py
+++ b/openmmtools/multistate/multistatesampler.py
@@ -1379,7 +1379,7 @@ class MultiStateSampler(object):
                 logger.debug('Using FIRE: tolerance {} max_iterations {}'.format(tolerance, max_iterations))
                 integrator.step(max_iterations)
         except Exception as e:
-            if str(e) == 'Particle coordinate is nan':
+            if 'particle coordinate is nan' in str(e).lower():
                 logger.debug('NaN encountered in FIRE minimizer; falling back to L-BFGS after resetting positions')
                 sampler_state.apply_to_context(context)
                 openmm.LocalEnergyMinimizer.minimize(context, tolerance, max_iterations)


### PR DESCRIPTION
## Description

We're getting errors in OpenFE during minimization of the multistate sampler. This appears to be because a handler for NaN in the FIRE minimizer was not updated to match OpenMM's changed error message. (I note that other lines seem to have updated). See https://github.com/OpenFreeEnergy/openfe/issues/253#issuecomment-1513172023 and following.

## Todos
- [x] Implement feature / fix bug
- [ ] Add [tests](https://github.com/choderalab/openmmtools/tree/master/openmmtools/tests)
- [ ] Update [documentation](https://github.com/choderalab/openmmtools/tree/master/docs) as needed
- [ ] Update [changelog](https://github.com/choderalab/openmmtools/blob/master/docs/releasehistory.rst) to summarize changes in behavior, enhancements, and bugfixes implemented in this PR

## Status
- [ ] Ready to go

## Changelog message
```
Fix NaN-catching text in MultiStateSampler
```