### PR TITLE
Appending real time stats

### DIFF
--- a/docs/releasehistory.rst
+++ b/docs/releasehistory.rst
@@ -1,6 +1,22 @@
 Release History
 ***************
 
+0.22.0 - pymbar 4 support and gentle equilibration
+==================================================
+
+Enhancements
+------------
+- Openmmtools now supports both Pymbar 3 and 4 versions. (PR `#659 <https://github.com/choderalab/openmmtools/pull/659>`_)
+- Gentle equilibration protocol utility function available in ``openmmtools.utils.gentle_equilibration`` (PR `#669 <https://github.com/choderalab/openmmtools/pull/669>`_).
+- Timing information for multiple state sampler is now reported by default (PRs `#679 <https://github.com/choderalab/openmmtools/pull/679>`_ and `#671 <https://github.com/choderalab/openmmtools/issues/671>`_).
+
+Bugfixes
+--------
+- Users were not able to distinguish the exceptions caught during dynamics. Warnings are now raised when an exception is being caught (Issue `#643 <https://github.com/choderalab/openmmtools/issues/643>`_ PR `#658 <https://github.com/choderalab/openmmtools/pull/658>`_).
+- Deserializing MCMC moves objects from versions <=0.21.4 resulted in error finding the key. Fixed by catching the exception and raising a warning when key is not found (Issue `#618 <https://github.com/choderalab/openmmtools/issues/618>`_ PR `#675 <https://github.com/choderalab/openmmtools/pull/675>`_).
+- Different improvements in documentation strings and readthedocs documentation generation (Issues `#620 <https://github.com/choderalab/openmmtools/issues/620>`_ `#641 <https://github.com/choderalab/openmmtools/issues/641>`_ `#548 <https://github.com/choderalab/openmmtools/issues/548>`_. PR `#676 <https://github.com/choderalab/openmmtools/pull/676>`_)
+- Support for newer NetCDF versions (1.6 branch) by not using zlib compression for varying length variables. (PR `#654 <https://github.com/choderalab/openmmtools/pull/654>`_).
+
 0.21.5 - Bugfix release
 ======================
 

--- a/openmmtools/multistate/multistatereporter.py
+++ b/openmmtools/multistate/multistatereporter.py
@@ -137,8 +137,9 @@ class MultiStateReporter(object):
         self._analysis_particle_indices = tuple(analysis_particle_indices)
         if open_mode is not None:
             self.open(open_mode)
-        # Flag to check whether to overwrite real time statistics file
-        self._overwrite_statistics = True
+        # TODO: Maybe we want to expose this flag to control ovrwriting/appending
+        # Flag to check whether to overwrite real time statistics file -- Defaults to append
+        self._overwrite_statistics = False
 
     @property
     def filepath(self):
@@ -266,6 +267,7 @@ class MultiStateReporter(object):
         self.close()
 
         # Create directory if we want to write.
+        # TODO: We probably want to check here specifically for w when we want to write
         if mode != 'r':
             for storage_path in self._storage_paths:
                 # normpath() transform '' to '.' for makedirs().

--- a/openmmtools/multistate/multistatesampler.py
+++ b/openmmtools/multistate/multistatesampler.py
@@ -589,6 +589,12 @@ class MultiStateSampler(object):
             raise RuntimeError('Storage file {} already exists; cowardly '
                                'refusing to overwrite.'.format(self._reporter.filepath))
 
+        # Make sure online analysis interval is a multiples of the reporter's checkpoint interval
+        # this avoids having redundant iteration information in the real time yaml files
+        if self.online_analysis_interval % self._reporter.checkpoint_interval != 0:
+            raise ValueError(f"Online analysis interval: {self.online_analysis_interval}, must be a "
+                             f"multiple of the checkpoint interval: {self._reporter.checkpoint_interval}")
+
         # Make sure sampler_states is an iterable of SamplerStates.
         if isinstance(sampler_states, states.SamplerState):
             sampler_states = [sampler_states]

--- a/openmmtools/tests/test_mcmc.py
+++ b/openmmtools/tests/test_mcmc.py
@@ -364,7 +364,7 @@ def test_mcmc_move_context_cache_shallow_copy():
     )
     # Create temporary reporter storage file
     with tempfile.NamedTemporaryFile() as storage:
-        reporter = multistate.MultiStateReporter(storage.name, checkpoint_interval=999999)
+        reporter = multistate.MultiStateReporter(storage.name, checkpoint_interval=200)
     simulation.create(
         thermodynamic_states=thermodynamic_states,
         sampler_states=SamplerState(

--- a/openmmtools/tests/test_sampling.py
+++ b/openmmtools/tests/test_sampling.py
@@ -141,7 +141,8 @@ class TestHarmonicOscillatorsMultiStateSampler(object):
     def run(self, include_unsampled_states=False):
         # Create and configure simulation object
         move = mmtools.mcmc.MCDisplacementMove(displacement_sigma=1.0*unit.angstroms)
-        simulation = self.SAMPLER(mcmc_moves=move, number_of_iterations=self.N_ITERATIONS)
+        simulation = self.SAMPLER(mcmc_moves=move, number_of_iterations=self.N_ITERATIONS,
+                                  online_analysis_interval=self.N_ITERATIONS)
 
         # Define file for temporary storage.
         with temporary_directory() as tmp_dir:
@@ -587,6 +588,7 @@ class TestBaseMultistateSampler(object):
 
     N_SAMPLERS = 3
     N_STATES = 5
+    # TODO: Once we migrate to pytest SAMPLER and REPORTER should be fixtures!
     SAMPLER = MultiStateSampler
     REPORTER = MultiStateReporter
 
@@ -999,7 +1001,7 @@ class TestMultiStateSampler(TestBaseMultistateSampler):
         thermodynamic_states, sampler_states, unsampled_states = copy.deepcopy(self.alanine_test)
 
         with self.temporary_storage_path() as storage_path:
-            sampler = self.SAMPLER(number_of_iterations=5)
+            sampler = self.SAMPLER(number_of_iterations=5, online_analysis_interval=1)
             reporter = self.REPORTER(storage_path, checkpoint_interval=1)
             self.call_sampler_create(sampler, reporter,
                                      thermodynamic_states, sampler_states,
@@ -1451,7 +1453,8 @@ class TestMultiStateSampler(TestBaseMultistateSampler):
             sampler = self.SAMPLER(mcmc_moves=move, number_of_iterations=n_iterations,
                                    online_analysis_interval=online_interval,
                                    online_analysis_minimum_iterations=3)
-            self.call_sampler_create(sampler, storage_path,
+            reporter = self.REPORTER(storage_path, checkpoint_interval=online_interval)
+            self.call_sampler_create(sampler, reporter,
                                      thermodynamic_states, sampler_states,
                                      unsampled_states)
             # Run
@@ -1510,7 +1513,8 @@ class TestMultiStateSampler(TestBaseMultistateSampler):
                                    online_analysis_interval=online_interval,
                                    online_analysis_minimum_iterations=0,
                                    online_analysis_target_error=np.inf)  # use infinite error to stop right away
-            self.call_sampler_create(sampler, storage_path,
+            reporter = self.REPORTER(storage_path, checkpoint_interval=online_interval)
+            self.call_sampler_create(sampler, reporter,
                                      thermodynamic_states, sampler_states,
                                      unsampled_states)
             # Run
@@ -1570,7 +1574,8 @@ class TestMultiStateSampler(TestBaseMultistateSampler):
             move = mmtools.mcmc.IntegratorMove(openmm.VerletIntegrator(1.0 * unit.femtosecond), n_steps=1)
             sampler = self.SAMPLER(mcmc_moves=move, number_of_iterations=n_iterations,
                                    online_analysis_interval=online_interval)
-            self.call_sampler_create(sampler, storage_path,
+            reporter = self.REPORTER(storage_path, checkpoint_interval=online_interval)
+            self.call_sampler_create(sampler, reporter,
                                      thermodynamic_states, sampler_states,
                                      unsampled_states)
             # Run


### PR DESCRIPTION
## Description
Changing the default behavior of the multistate reporter to append in the YAML real time statistics file instead of overwriting.

We already had the machinery for this, we probably want to discuss if we want to expose this option to the user.

I tested this resuming a run, but we probably want to write a proper test for this behavior. WIP.

Resolves #691 

## Todos
- [x] Implement feature / fix bug
- [ ] Add [tests](https://github.com/choderalab/openmmtools/tree/master/openmmtools/tests)
- [ ] Update [documentation](https://github.com/choderalab/openmmtools/tree/master/docs) as needed
- [ ] Update [changelog](https://github.com/choderalab/openmmtools/blob/master/docs/releasehistory.rst) to summarize changes in behavior, enhancements, and bugfixes implemented in this PR

## Status
- [x] Ready to go

## Changelog message
```
Real time statistics in YAML file are now appended when resuming simulations, instead of being overwritten.
```