### PR TITLE
Fix 2 more tests that fail sometimes in CI

### DIFF
--- a/openmmtools/tests/test_sampling.py
+++ b/openmmtools/tests/test_sampling.py
@@ -306,6 +306,7 @@ class TestHarmonicOscillatorsMultiStateSampler:
         # Clean up.
         del simulation
 
+    @pytest.mark.flaky(reruns=3)
     def test_with_unsampled_states(self):
         """Test multistate sampler on a harmonic oscillator with unsampled endstates"""
         self.run(include_unsampled_states=True)
@@ -313,6 +314,7 @@ class TestHarmonicOscillatorsMultiStateSampler:
     # on windows we get a ZeroDivisionError: float division by zero
     # when measuring the timing data
     @pytest.mark.skipif(sys.platform.startswith("win"), reason="Test fails on windows")
+    @pytest.mark.flaky(reruns=3)
     def test_without_unsampled_states(self):
         """Test multistate sampler on a harmonic oscillator without unsampled endstates"""
         self.run(include_unsampled_states=False)


### PR DESCRIPTION
These two tests sometimes fail on CI but re-running them tends to fix it. This automates the re-running.