### PR TITLE
Disable the barostat during FIRE minimization

### DIFF
--- a/openmmtools/integrators.py
+++ b/openmmtools/integrators.py
@@ -2371,7 +2371,7 @@ class FIREMinimizationIntegrator(mm.CustomIntegrator):
         self.addGlobalVariable("delta_t", timestep.value_in_unit_system(unit.md_unit_system))
 
         # Update context state.
-        self.addUpdateContextState()
+        #self.addUpdateContextState()
 
         # Assess convergence
         # TODO: Can we more closely match the OpenMM criterion here?

--- a/openmmtools/multistate/multistatesampler.py
+++ b/openmmtools/multistate/multistatesampler.py
@@ -1360,6 +1360,13 @@ class MultiStateSampler(object):
         # Retrieve thermodynamic and sampler states.
         thermodynamic_state_id = self._replica_thermodynamic_states[replica_id]
         thermodynamic_state = self._thermodynamic_states[thermodynamic_state_id]
+
+        # Temporarily disable the barostat during minimization.
+        # Otherwise, the minimizer will modify the box
+        # vectors and may cause instabilities.
+        barostat_freq = thermodynamic_state.barostat.getFrequency()
+        print(barostat_freq)
+        thermodynamic_state.barostat.setFrequency(0)
         sampler_state = self._sampler_states[replica_id]
 
         # Use the FIRE minimizer
@@ -1397,6 +1404,9 @@ class MultiStateSampler(object):
 
         # Get the minimized positions.
         sampler_state.update_from_context(context)
+        
+        # Restore the barostate frequency
+        thermodynamic_state.barostat.setFrequency(barostat_freq)
 
         # Compute the final energy of the system for logging.
         final_energy = thermodynamic_state.reduced_potential(sampler_state)

--- a/openmmtools/multistate/multistatesampler.py
+++ b/openmmtools/multistate/multistatesampler.py
@@ -1364,9 +1364,8 @@ class MultiStateSampler(object):
         # Temporarily disable the barostat during minimization.
         # Otherwise, the minimizer will modify the box
         # vectors and may cause instabilities.
-        barostat_freq = thermodynamic_state.barostat.getFrequency()
-        print(barostat_freq)
-        thermodynamic_state.barostat.setFrequency(0)
+        pressure = thermodynamic_state.pressure
+        thermodynamic_state.pressure = None
         sampler_state = self._sampler_states[replica_id]
 
         # Use the FIRE minimizer
@@ -1405,8 +1404,8 @@ class MultiStateSampler(object):
         # Get the minimized positions.
         sampler_state.update_from_context(context)
         
-        # Restore the barostate frequency
-        thermodynamic_state.barostat.setFrequency(barostat_freq)
+        # Restore the barostat
+        thermodynamic_state.pressure = pressure
 
         # Compute the final energy of the system for logging.
         final_energy = thermodynamic_state.reduced_potential(sampler_state)


### PR DESCRIPTION
## Description
As has been described here (https://github.com/choderalab/openmmtools/pull/557), box vectors can change during energy minimization using the FIRE minimizer, leading to instabilities. This PR temporarily disables the barostat for the minimization.

## Changelog message
```

```