### PR TITLE
Remove restriction on online_analysis_interval and checkpoint_interval

### DIFF
--- a/docs/releasehistory.rst
+++ b/docs/releasehistory.rst
@@ -1,6 +1,16 @@
 Release History
 ***************
 
+0.24.3
+======
+
+Enhancements
+------------
+
+- Remove the requirement that the ``online_analysis_interval`` is a multiple of ``checkpoint_interval``
+  - Issue a logger warning rather than raise a ``ValueError``
+  - Note that the real time analysis output file may contain redundant information after restoring from checkpoints that would result in the repeated calculation of a specific iteration index
+
 0.24.2 - Numpy 2 support and FIRE minimization improvements
 ===========================================================
 

--- a/openmmtools/multistate/multistatesampler.py
+++ b/openmmtools/multistate/multistatesampler.py
@@ -590,13 +590,9 @@ class MultiStateSampler(object):
             raise RuntimeError('Storage file {} already exists; cowardly '
                                'refusing to overwrite.'.format(self._reporter.filepath))
 
-        # Make sure online analysis interval is a multiples of the reporter's checkpoint interval
-        # this avoids having redundant iteration information in the real time yaml files
-        # only check if self.online_analysis_interval is set
         if self.online_analysis_interval:
             if self.online_analysis_interval % self._reporter.checkpoint_interval != 0:
-                raise ValueError(f"Online analysis interval: {self.online_analysis_interval}, must be a "
-                                 f"multiple of the checkpoint interval: {self._reporter.checkpoint_interval}")
+                logger.warning("An online_analysis_interval that is not a multiple of the checkpoint_interval can lead to redundant information in the real time yaml file.")
 
         # Make sure sampler_states is an iterable of SamplerStates.
         if isinstance(sampler_states, states.SamplerState):

--- a/openmmtools/multistate/multistatesampler.py
+++ b/openmmtools/multistate/multistatesampler.py
@@ -592,7 +592,7 @@ class MultiStateSampler(object):
 
         if self.online_analysis_interval:
             if self.online_analysis_interval % self._reporter.checkpoint_interval != 0:
-                logger.warning("An online_analysis_interval that is not a multiple of the checkpoint_interval can lead to redundant information in the real time yaml file.")
+                logger.warning("An online_analysis_interval that is not a multiple of the checkpoint_interval can lead to redundant information in the real time yaml file after recovering from checkpoints.")
 
         # Make sure sampler_states is an iterable of SamplerStates.
         if isinstance(sampler_states, states.SamplerState):


### PR DESCRIPTION
## Description

This PR removes the requirement that the `online_analysis_interval` is a multiple of the `checkpoint_interval`.

closes #770

## Todos
- [x] Implement feature / fix bug
- [x] Add [tests](https://github.com/choderalab/openmmtools/tree/master/openmmtools/tests)
- [x] Update [documentation](https://github.com/choderalab/openmmtools/tree/master/docs) as needed
- [x] Update [changelog](https://github.com/choderalab/openmmtools/blob/master/docs/releasehistory.rst) to summarize changes in behavior, enhancements, and bugfixes implemented in this PR

## Status
- [x] Ready to go

## Changelog message
```
```