### PR TITLE
Pymbar4 entropy enthalpy

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -76,7 +76,7 @@ jobs:
 
       - name: Run tests
         run: |
-          pytest -n logical -v --cov=openmmtools --cov-report=xml --cov-report=term --color=yes openmmtools/tests/
+          pytest -n logical -v --cov=openmmtools --cov-report=xml --cov-report=term --color=yes --durations=10 openmmtools/tests/
 
       - name: CodeCov
         uses: codecov/codecov-action@v4

--- a/openmmtools/multistate/multistateanalyzer.py
+++ b/openmmtools/multistate/multistateanalyzer.py
@@ -1975,9 +1975,13 @@ class MultiStateSamplerAnalyzer(PhaseAnalyzer):
 
     def _compute_enthalpy_and_entropy(self):
         """Function to compute the cached values of enthalpy and entropy"""
-        (f_k, df_k, H_k, dH_k, S_k, dS_k) = self.mbar.computeEntropyAndEnthalpy()
-        enthalpy = {'value': H_k, 'error': dH_k}
-        entropy = {'value': S_k, 'error': dS_k}
+        try:
+            results = self.mbar.computeEntropyAndEnthalpy(return_dict=True)
+        except AttributeError:
+            results = self.mbar.compute_entropy_and_enthalpy()
+
+        enthalpy = {'value': results['Delta_u'], 'error': results['dDelta_u']}
+        entropy = {'value': results['Delta_s'], 'error': results['dDelta_s']}
         self._computed_observables['enthalpy'] = enthalpy
         self._computed_observables['entropy'] = entropy
 

--- a/openmmtools/tests/test_sampling.py
+++ b/openmmtools/tests/test_sampling.py
@@ -30,6 +30,7 @@ import yaml
 
 import pytest
 import requests
+from coverage.data import debug_data_file
 
 try:
     import openmm
@@ -401,22 +402,20 @@ class TestHarmonicOscillatorsMultiStateSampler:
         nsigma[indices] = error[indices] / delta_s_ij_stderr[indices]
         MAX_SIGMA = 6.0  # maximum allowed number of standard errors
         if np.any(nsigma > MAX_SIGMA):
-            np.set_printoptions(precision=3)
-            print("delta_s_ij")
-            print(delta_s_ij)
-            print("delta_s_ij_analytical")
-            print(-delta_f_ij_analytical)
-            print("error")
-            print(error)
-            print("stderr")
-            print(delta_s_ij_stderr)
-            print("nsigma")
-            print(nsigma)
-            raise Exception(
-                "Dimensionless (reduced) entropy exceeds MAX_SIGMA of %.1f"
-                % MAX_SIGMA
-            )
+            np.set_printoptions(precision=3, supress=True)
+            debug_data = {
+                "delta_s_ij": delta_s_ij,
+                "delta_s_ij_analytical": delta_f_ij_analytical,
+                "error": error,
+                "stderr": delta_s_ij_stderr,
+                "nsigma": nsigma,
+            }
+            print("\n[DEBUG] Entropy test failed. Details:")
+            for key, value in debug_data.items():
+                print(f"{key}: {value}")
+            assert False, f"Dimensionless (reduced) entropy exceeds MAX_SIGMA of {MAX_SIGMA:.1f}"
 
+        # Check enthalpy
         delta_u_ij, delta_u_ij_stderr = analyzer.get_enthalpy()
 
         if include_unsampled_states:
@@ -436,21 +435,19 @@ class TestHarmonicOscillatorsMultiStateSampler:
         nsigma[indices] = error[indices] / delta_u_ij_stderr[indices]
         MAX_SIGMA = 6.0  # maximum allowed number of standard errors
         if np.any(nsigma > MAX_SIGMA):
-            np.set_printoptions(precision=3)
-            print("delta_u_ij")
-            print(delta_u_ij)
-            print("delta_u_ij_analytical")
-            print(0)
-            print("error")
-            print(error)
-            print("stderr")
-            print(delta_u_ij_stderr)
-            print("nsigma")
-            print(nsigma)
-            raise Exception(
-                "Dimensionless (reduced) potential (enthalpy) difference exceeds MAX_SIGMA of %.1f"
-                % MAX_SIGMA
-            )
+            np.set_printoptions(precision=3, supress=True)
+            debug_data = {
+                "delta_u_ij": delta_u_ij,
+                "delta_u_ij_analytical": 0,
+                "error": error,
+                "stderr": delta_u_ij_stderr,
+                "nsigma": nsigma,
+            }
+            print("\n[DEBUG] Enthalpy test failed. Details:")
+            for key, value in debug_data.items():
+                print(f"{key}:{value}")
+            assert False, f"Dimensionless (reduced) potential (enthalpy) difference exceeds MAX_SIGMA of {MAX_SIGMA:.1f}"
+
 
 
 class TestHarmonicOscillatorsReplicaExchangeSampler(

--- a/openmmtools/tests/test_sampling.py
+++ b/openmmtools/tests/test_sampling.py
@@ -352,7 +352,7 @@ class TestHarmonicOscillatorsMultiStateSampler:
         move = mmtools.mcmc.MCDisplacementMove(displacement_sigma=1.0 * unit.angstroms)
         simulation = self.SAMPLER(
             mcmc_moves=move,
-            number_of_iterations=self.N_ITERATIONS,
+            number_of_iterations=2*self.N_ITERATIONS,
             online_analysis_interval=self.N_ITERATIONS,
         )
         storage = os.path.join(tmp_path, "test_storage.nc")

--- a/openmmtools/tests/test_sampling.py
+++ b/openmmtools/tests/test_sampling.py
@@ -347,17 +347,18 @@ class TestHarmonicOscillatorsMultiStateSampler:
         the appropriate submatrix of the analytical free energy matrix depending on whether
         unsampled boundary states are included.
         """
+        n_iterations = int(2.5*self.N_ITERATIONS)  # We want more iterations for entropy test
         # TODO: These can probably be fixtures, we use them in different tests
         # Create and configure simulation object
         move = mmtools.mcmc.MCDisplacementMove(displacement_sigma=1.0 * unit.angstroms)
         simulation = self.SAMPLER(
             mcmc_moves=move,
-            number_of_iterations=self.N_ITERATIONS,
-            online_analysis_interval=self.N_ITERATIONS,
+            number_of_iterations=n_iterations,
+            online_analysis_interval=n_iterations,
         )
         storage = os.path.join(tmp_path, "test_storage.nc")
         reporter = MultiStateReporter(
-            storage, checkpoint_interval=self.N_ITERATIONS
+            storage, checkpoint_interval=n_iterations
         )
 
         if include_unsampled_states:

--- a/openmmtools/tests/test_sampling.py
+++ b/openmmtools/tests/test_sampling.py
@@ -305,80 +305,6 @@ class TestHarmonicOscillatorsMultiStateSampler:
                     % MAX_SIGMA
                 )
 
-            # Check if entropy and enthalpy can be calculated and are within tolerance
-            delta_s_ij, delta_s_ij_stderr = analyzer.get_entropy()
-
-            nstates, _ = delta_s_ij.shape
-
-            if include_unsampled_states:
-                nstates_expected = (
-                    self.N_STATES + 2
-                )  # We expect N_STATES plus two additional states
-            else:
-                nstates_expected = self.N_STATES  # We expect only N_STATES
-
-            assert (
-                nstates == nstates_expected
-            ), f"analyzer.get_entropy() returned {delta_s_ij.shape} but expected {nstates_expected,nstates_expected}"
-
-            error = np.abs(delta_s_ij + delta_f_ij_analytical) # We expect dS = -dF
-            indices = np.where(delta_s_ij_stderr > 0.0)
-            nsigma = np.zeros([nstates, nstates], np.float32)
-            nsigma[indices] = error[indices] / delta_s_ij_stderr[indices]
-            MAX_SIGMA = 6.0  # maximum allowed number of standard errors
-            if np.any(nsigma > MAX_SIGMA):
-                np.set_printoptions(precision=3)
-                print("delta_s_ij")
-                print(delta_s_ij)
-                print("delta_s_ij_analytical")
-                print(-delta_f_ij_analytical)
-                print("error")
-                print(error)
-                print("stderr")
-                print(delta_s_ij_stderr)
-                print("nsigma")
-                print(nsigma)
-                raise Exception(
-                    "Dimensionless (reduced) entropy exceeds MAX_SIGMA of %.1f"
-                    % MAX_SIGMA
-                )
-
-            delta_u_ij, delta_u_ij_stderr = analyzer.get_enthalpy()
-
-            if include_unsampled_states:
-                nstates_expected = (
-                    self.N_STATES + 2
-                )  # We expect N_STATES plus two additional states
-            else:
-                nstates_expected = self.N_STATES  # We expect only N_STATES
-
-            assert (
-                nstates == nstates_expected
-            ), f"analyzer.get_entropy() returned {delta_u_ij.shape} but expected {nstates_expected,nstates_expected}"
-
-            error = np.abs(delta_u_ij) # We expect du = 0
-            indices = np.where(delta_u_ij_stderr > 0.0)
-            nsigma = np.zeros([nstates, nstates], np.float32)
-            nsigma[indices] = error[indices] / delta_u_ij_stderr[indices]
-            MAX_SIGMA = 6.0  # maximum allowed number of standard errors
-            if np.any(nsigma > MAX_SIGMA):
-                np.set_printoptions(precision=3)
-                print("delta_u_ij")
-                print(delta_u_ij)
-                print("delta_u_ij_analytical")
-                print(0)
-                print("error")
-                print(error)
-                print("stderr")
-                print(delta_u_ij_stderr)
-                print("nsigma")
-                print(nsigma)
-                raise Exception(
-                    "Dimensionless (reduced) potential (enthalpy) difference exceeds MAX_SIGMA of %.1f"
-                    % MAX_SIGMA
-                )
-
-
         # Clean up.
         del simulation
 
@@ -393,6 +319,138 @@ class TestHarmonicOscillatorsMultiStateSampler:
     def test_without_unsampled_states(self):
         """Test multistate sampler on a harmonic oscillator without unsampled endstates"""
         self.run(include_unsampled_states=False)
+
+    @pytest.mark.parametrize("include_unsampled_states", [False, True])
+    def test_entropy_enthalpy(self, include_unsampled_states, tmp_path):
+        """
+        Test that the entropy and enthalpy matrices computed by the analyzer match analytical expectations.
+
+        This function initializes a MultiStateReporter, constructs an analyzer from stored simulation data,
+        and compares computed entropy (ΔS_ij) and enthalpy (ΔU_ij) matrices to analytical expectations.
+
+        Entropy is expected to satisfy ΔS_ij ≈ -ΔF_ij_analytical (assuming ΔU ≈ 0), and enthalpy is expected to be ≈ 0.
+        Deviations are tested against a threshold of 6 standard errors (σ). Any entry exceeding this threshold
+        raises an exception.
+
+        Parameters
+        ----------
+        include_unsampled_states : bool
+            Whether to include unsampled boundary states in the analysis. If True, additional
+            boundary states are expected in the computed matrices.
+        tmp_path : Path or str
+            Temporary path for creating the NetCDF storage file.
+
+        Notes
+        -----
+        This test assumes ΔU ≈ 0 for all states and checks that ΔS ≈ -ΔF. It dynamically selects
+        the appropriate submatrix of the analytical free energy matrix depending on whether
+        unsampled boundary states are included.
+        """
+        # TODO: These can probably be fixtures, we use them in different tests
+        # Create and configure simulation object
+        move = mmtools.mcmc.MCDisplacementMove(displacement_sigma=1.0 * unit.angstroms)
+        simulation = self.SAMPLER(
+            mcmc_moves=move,
+            number_of_iterations=self.N_ITERATIONS,
+            online_analysis_interval=self.N_ITERATIONS,
+        )
+        storage = os.path.join(tmp_path, "test_storage.nc")
+        reporter = MultiStateReporter(
+            storage, checkpoint_interval=self.N_ITERATIONS
+        )
+
+        if include_unsampled_states:
+            nstates_expected = (
+                    self.N_STATES + 2
+            )  # We expect N_STATES plus two additional states
+            delta_f_ij_analytical = (
+                self.delta_f_ij_analytical
+            )  # Use the whole matrix
+            simulation.create(
+                self.thermodynamic_states,
+                self.sampler_states,
+                reporter,
+                unsampled_thermodynamic_states=self.unsampled_states,
+            )
+        else:
+            nstates_expected = self.N_STATES  # We expect only N_STATES
+            delta_f_ij_analytical = self.delta_f_ij_analytical[
+                                    1:-1, 1:-1
+                                    ]  # Use only the intermediate, sampled states
+            simulation.create(
+                self.thermodynamic_states, self.sampler_states, reporter
+            )
+
+        # Run simulation to generate/populate data
+        simulation.run()
+
+        analyzer = self.ANALYZER(reporter)
+
+        # Check if entropy and enthalpy can be calculated and are within tolerance
+        delta_s_ij, delta_s_ij_stderr = analyzer.get_entropy()
+
+        nstates, _ = delta_s_ij.shape
+
+        assert (
+                nstates == nstates_expected
+        ), f"analyzer.get_entropy() returned {delta_s_ij.shape} but expected {nstates_expected, nstates_expected}"
+
+        error = np.abs(delta_s_ij + delta_f_ij_analytical)  # We expect dS = -dF
+        indices = np.where(delta_s_ij_stderr > 0.0)
+        nsigma = np.zeros([nstates, nstates], np.float32)
+        nsigma[indices] = error[indices] / delta_s_ij_stderr[indices]
+        MAX_SIGMA = 6.0  # maximum allowed number of standard errors
+        if np.any(nsigma > MAX_SIGMA):
+            np.set_printoptions(precision=3)
+            print("delta_s_ij")
+            print(delta_s_ij)
+            print("delta_s_ij_analytical")
+            print(-delta_f_ij_analytical)
+            print("error")
+            print(error)
+            print("stderr")
+            print(delta_s_ij_stderr)
+            print("nsigma")
+            print(nsigma)
+            raise Exception(
+                "Dimensionless (reduced) entropy exceeds MAX_SIGMA of %.1f"
+                % MAX_SIGMA
+            )
+
+        delta_u_ij, delta_u_ij_stderr = analyzer.get_enthalpy()
+
+        if include_unsampled_states:
+            nstates_expected = (
+                    self.N_STATES + 2
+            )  # We expect N_STATES plus two additional states
+        else:
+            nstates_expected = self.N_STATES  # We expect only N_STATES
+
+        assert (
+                nstates == nstates_expected
+        ), f"analyzer.get_entropy() returned {delta_u_ij.shape} but expected {nstates_expected, nstates_expected}"
+
+        error = np.abs(delta_u_ij)  # We expect du = 0
+        indices = np.where(delta_u_ij_stderr > 0.0)
+        nsigma = np.zeros([nstates, nstates], np.float32)
+        nsigma[indices] = error[indices] / delta_u_ij_stderr[indices]
+        MAX_SIGMA = 6.0  # maximum allowed number of standard errors
+        if np.any(nsigma > MAX_SIGMA):
+            np.set_printoptions(precision=3)
+            print("delta_u_ij")
+            print(delta_u_ij)
+            print("delta_u_ij_analytical")
+            print(0)
+            print("error")
+            print(error)
+            print("stderr")
+            print(delta_u_ij_stderr)
+            print("nsigma")
+            print(nsigma)
+            raise Exception(
+                "Dimensionless (reduced) potential (enthalpy) difference exceeds MAX_SIGMA of %.1f"
+                % MAX_SIGMA
+            )
 
 
 class TestHarmonicOscillatorsReplicaExchangeSampler(

--- a/openmmtools/tests/test_sampling.py
+++ b/openmmtools/tests/test_sampling.py
@@ -352,7 +352,7 @@ class TestHarmonicOscillatorsMultiStateSampler:
         move = mmtools.mcmc.MCDisplacementMove(displacement_sigma=1.0 * unit.angstroms)
         simulation = self.SAMPLER(
             mcmc_moves=move,
-            number_of_iterations=2*self.N_ITERATIONS,
+            number_of_iterations=self.N_ITERATIONS,
             online_analysis_interval=self.N_ITERATIONS,
         )
         storage = os.path.join(tmp_path, "test_storage.nc")

--- a/openmmtools/tests/test_sampling.py
+++ b/openmmtools/tests/test_sampling.py
@@ -366,7 +366,7 @@ class TestHarmonicOscillatorsMultiStateSampler:
                 print("delta_u_ij")
                 print(delta_u_ij)
                 print("delta_u_ij_analytical")
-                print(-delta_f_ij_analytical)
+                print(0)
                 print("error")
                 print(error)
                 print("stderr")

--- a/openmmtools/tests/test_sampling.py
+++ b/openmmtools/tests/test_sampling.py
@@ -402,7 +402,7 @@ class TestHarmonicOscillatorsMultiStateSampler:
         nsigma[indices] = error[indices] / delta_s_ij_stderr[indices]
         MAX_SIGMA = 6.0  # maximum allowed number of standard errors
         if np.any(nsigma > MAX_SIGMA):
-            np.set_printoptions(precision=3, supress=True)
+            np.set_printoptions(precision=3)
             debug_data = {
                 "delta_s_ij": delta_s_ij,
                 "delta_s_ij_analytical": delta_f_ij_analytical,
@@ -435,7 +435,7 @@ class TestHarmonicOscillatorsMultiStateSampler:
         nsigma[indices] = error[indices] / delta_u_ij_stderr[indices]
         MAX_SIGMA = 6.0  # maximum allowed number of standard errors
         if np.any(nsigma > MAX_SIGMA):
-            np.set_printoptions(precision=3, supress=True)
+            np.set_printoptions(precision=3)
             debug_data = {
                 "delta_u_ij": delta_u_ij,
                 "delta_u_ij_analytical": 0,


### PR DESCRIPTION
## Description
This supersedes #758 
Fixes #757 

This just make the entropy and enthalpy test a separate more granular test that we can check independently.

## Todos
- [x] Implement feature / fix bug
- [x] Add [tests](https://github.com/choderalab/openmmtools/tree/master/openmmtools/tests)
- [ ] Update [documentation](https://github.com/choderalab/openmmtools/tree/master/docs) as needed
- [ ] Update [changelog](https://github.com/choderalab/openmmtools/blob/master/docs/releasehistory.rst) to summarize changes in behavior, enhancements, and bugfixes implemented in this PR

## Status
- [ ] Ready to go

## Changelog message
```
Add support for entropy and enthalpy calculations with pymbar4
```