### PR TITLE
Dropping macos-13 (legacy) tests in CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -30,7 +30,7 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12"]
         openmm: ["8.1.2", "8.2.0"]
-        os: [macOS-latest, ubuntu-latest, macOS-13]
+        os: [macOS-latest, ubuntu-latest]
         pymbar-version: ["4"]
         include:
           # Test newest python, openmm, and pymbar we support on windows


### PR DESCRIPTION
## Description
This changes our current CI workflow in order to not run it on legacy macos-13 (intel). This is in order to reduce the load of our CI workflows by running less jobs, streamlining the PR changes a little bit. 

