### PR TITLE
Revert to using warnings.warn

### DIFF
--- a/openmmtools/alchemy/alchemy.py
+++ b/openmmtools/alchemy/alchemy.py
@@ -328,7 +328,7 @@ class AlchemicalState(states.GlobalParameterState):
             The value of the alchemical variable.
         """
         import warnings
-        warnings.warning('AlchemicalState.get_alchemical_variable is deprecated. '
+        warnings.warn('AlchemicalState.get_alchemical_variable is deprecated. '
                       'Use AlchemicalState.get_function_variable instead.')
         return super().get_function_variable(variable_name)
 
@@ -347,7 +347,7 @@ class AlchemicalState(states.GlobalParameterState):
 
         """
         import warnings
-        warnings.warning('AlchemicalState.get_alchemical_variable is deprecated. '
+        warnings.warn('AlchemicalState.get_alchemical_variable is deprecated. '
                       'Use AlchemicalState.get_function_variable instead.')
         super().set_function_variable(variable_name, new_value)
 

--- a/openmmtools/mcmc.py
+++ b/openmmtools/mcmc.py
@@ -720,7 +720,7 @@ class BaseIntegratorMove(MCMCMove):
             except Exception as e:
                 # Catches particle positions becoming nan during integration.
                 # Return the exception message as a warning
-                warnings.warning(str(e))
+                warnings.warn(str(e))
                 restart = True
             else:
                 timer.stop("{}: step({})".format(move_name, self.n_steps))

--- a/openmmtools/multistate/multistatereporter.py
+++ b/openmmtools/multistate/multistatereporter.py
@@ -1293,7 +1293,7 @@ class MultiStateReporter(object):
                 base_warn += "\n\t{}per-iteration: {}".format(iteration_str, failure)
             for missing in collected_not_found:
                 base_warn += "\n\tMissing: {}".format(missing)
-            warnings.warning(base_warn, RuntimeWarning)
+            warnings.warn(base_warn, RuntimeWarning)
         return collected_variables
 
     def write_online_analysis_data(self, iteration: Union[int, None], **kwargs):

--- a/openmmtools/multistate/utils.py
+++ b/openmmtools/multistate/utils.py
@@ -225,7 +225,7 @@ def get_equilibration_data(timeseries_to_analyze, fast=True, max_subset=1000):
     --------
     get_equilibration_data_per_sample
     """
-    warnings.warning("This function will be removed in future versions of YANK due to redundancy, "
+    warnings.warn("This function will be removed in future versions of YANK due to redundancy, "
                   "Please use the more general `get_equilibration_data_per_sample` function instead.")
     i_t, g_i, n_effective_i = get_equilibration_data_per_sample(timeseries_to_analyze, fast=fast, max_subset=max_subset)
     n_effective_max = n_effective_i.max()

--- a/openmmtools/states.py
+++ b/openmmtools/states.py
@@ -3014,7 +3014,7 @@ class CompoundThermodynamicState(ThermodynamicState):
             import warnings
             old_signature = '_on_setattr(self, standard_system, attribute_name)'
             new_signature = old_signature[:-1] + ', old_composable_state)'
-            warnings.warning('The signature IComposableState.{} has been deprecated, '
+            warnings.warn('The signature IComposableState.{} has been deprecated, '
                           'and future versions of openmmtools will support only the '
                           'new one: {}.'.format(old_signature, new_signature))
         if change_standard_system:

--- a/openmmtools/storage/iodrivers.py
+++ b/openmmtools/storage/iodrivers.py
@@ -969,7 +969,7 @@ class NCVariableCodec(Codec):
                 raise TypeError("Storage target on NetCDF file is of type {} but this driver is designed to handle "
                                 "type {}!".format(self._bound_target.getncattr('IODriver_Type'), self.dtype_string()))
         except AttributeError:
-            warnings.warning("This Codec cannot detect storage type from on-disk variable. .write() and .append() "
+            warnings.warn("This Codec cannot detect storage type from on-disk variable. .write() and .append() "
                           "operations will not work and .read() operations may work", RuntimeWarning)
 
     def _check_storage_mode(self, expected_mode):

--- a/openmmtools/utils/utils.py
+++ b/openmmtools/utils/utils.py
@@ -680,7 +680,7 @@ def deserialize(serialization):
     except AttributeError:
         raise ValueError('Cannot deserialize class {} without a __setstate__ method'.format(class_name))
     except KeyError as e:  # Key not found in options/variables -- backward compatibility for <=0.21.4
-        warnings.warning(f"Key {e} not found in {instance.__class__.__name__}.")
+        warnings.warn(f"Key {e} not found in {instance.__class__.__name__}.")
     return instance
 
 


### PR DESCRIPTION
## Description
The warnings module doesn't have a `warnings.warning`. This was changed by mistake in #788 . My guess is that it tried to fix the `logging.warn` deprecation but it hit these undesired `warnings.warn` matches. Just something to keep in mind in the future.

Here all the instances of `warnings.warning` are reverted back to use `warnings.warn`, this should solve it.

Solves #789 

## Todos
- [x] Implement feature / fix bug
- [ ] Add [tests](https://github.com/choderalab/openmmtools/tree/master/openmmtools/tests)
- [ ] Update [documentation](https://github.com/choderalab/openmmtools/tree/master/docs) as needed
- [ ] Update [changelog](https://github.com/choderalab/openmmtools/blob/master/docs/releasehistory.rst) to summarize changes in behavior, enhancements, and bugfixes implemented in this PR

## Status
- [ ] Ready to go

## Changelog message
```
Revert to using the correct `warnings.warn` API for warning messages.
```