### PR TITLE
Numpy 2.3 fix (tostring -> tobytes)

### DIFF
--- a/openmmtools/multistate/multistatereporter.py
+++ b/openmmtools/multistate/multistatereporter.py
@@ -1091,7 +1091,7 @@ class MultiStateReporter(object):
             if nc_element.dtype == 'S1':
                 # Handle variables stored in fixed_dimensions
                 data_chars = nc_element[:]
-                data_str = data_chars.tostring().decode()
+                data_str = data_chars.tobytes().decode()
             else:
                 data_str = str(nc_element[0])
             data = yaml.load(data_str, Loader=_DictYamlLoader)

--- a/openmmtools/tests/test_sampling.py
+++ b/openmmtools/tests/test_sampling.py
@@ -584,7 +584,7 @@ class TestReporter:
                 if variable.dtype == "S1":
                     # Handle variables stored in fixed_dimensions
                     data_chars = variable[:]
-                    data_str = data_chars.tostring().decode()
+                    data_str = data_chars.tobytes().decode()
                 else:
                     data_str = str(variable[0])
                 return data_str


### PR DESCRIPTION
## Description

I *think* this is all we need to do, the old numpy test case was:

```
    def test_tostring_matches_tobytes(self):
        arr = np.array(list(b"test\xFF"), dtype=np.uint8)
        b = arr.tobytes()
        with assert_warns(DeprecationWarning):
            s = arr.tostring()
        assert s == b
```


## Todos
- [x] Implement feature / fix bug
- [ ] Add [tests](https://github.com/choderalab/openmmtools/tree/master/openmmtools/tests)
- [ ] Update [documentation](https://github.com/choderalab/openmmtools/tree/master/docs) as needed
- [ ] Update [changelog](https://github.com/choderalab/openmmtools/blob/master/docs/releasehistory.rst) to summarize changes in behavior, enhancements, and bugfixes implemented in this PR

## Status
- [x] Ready to go

## Changelog message
```
Switch deprecated `tostring` numpy calls to `tobytes`.
```